### PR TITLE
Refactor to use more laravel logic and improve compatibility with older PHP versions

### DIFF
--- a/app/Http/Controllers/API/LocationController.php
+++ b/app/Http/Controllers/API/LocationController.php
@@ -49,15 +49,11 @@ class LocationController extends BaseController
      */
     public function lists(Request $request)
     {
-        $locations = Location::select('locations.*', DB::raw('GROUP_CONCAT(nodes.id) as nodes'))
+        return Location::select('locations.*', DB::raw('GROUP_CONCAT(nodes.id) as nodes'))
             ->join('nodes', 'locations.id', '=', 'nodes.location')
             ->groupBy('locations.id')
-            ->get();
-
-        foreach ($locations as &$location) {
-            $location->nodes = explode(',', $location->nodes);
-        }
-
-        return $locations->toArray();
+            ->get()->each(function ($location) {
+                $location->nodes = explode(',', $location->nodes);
+            })->all();
     }
 }

--- a/app/Http/Controllers/API/LocationController.php
+++ b/app/Http/Controllers/API/LocationController.php
@@ -47,7 +47,7 @@ class LocationController extends BaseController
      * @Versions({"v1"})
      * @Response(200)
      */
-    public function list(Request $request)
+    public function lists(Request $request)
     {
         $locations = Location::select('locations.*', DB::raw('GROUP_CONCAT(nodes.id) as nodes'))
             ->join('nodes', 'locations.id', '=', 'nodes.location')

--- a/app/Http/Controllers/API/NodeController.php
+++ b/app/Http/Controllers/API/NodeController.php
@@ -56,7 +56,7 @@ class NodeController extends BaseController
      * })
      * @Response(200)
      */
-    public function list(Request $request)
+    public function lists(Request $request)
     {
         return Models\Node::all()->toArray();
     }

--- a/app/Http/Controllers/API/ServerController.php
+++ b/app/Http/Controllers/API/ServerController.php
@@ -57,7 +57,7 @@ class ServerController extends BaseController
      * })
      * @Response(200)
      */
-    public function list(Request $request)
+    public function lists(Request $request)
     {
         return Models\Server::all()->toArray();
     }

--- a/app/Http/Controllers/API/ServiceController.php
+++ b/app/Http/Controllers/API/ServiceController.php
@@ -38,7 +38,7 @@ class ServiceController extends BaseController
         //
     }
 
-    public function list(Request $request)
+    public function lists(Request $request)
     {
         return Models\Service::all()->toArray();
     }

--- a/app/Http/Controllers/API/ServiceController.php
+++ b/app/Http/Controllers/API/ServiceController.php
@@ -50,14 +50,12 @@ class ServiceController extends BaseController
             throw new NotFoundHttpException('No service by that ID was found.');
         }
 
-        $options = Models\ServiceOptions::select('id', 'name', 'description', 'tag', 'docker_image')->where('parent_service', $service->id)->get();
-        foreach ($options as &$opt) {
-            $opt->variables = Models\ServiceVariables::where('option_id', $opt->id)->get();
-        }
-
         return [
             'service' => $service,
-            'options' => $options,
+            'options' => Models\ServiceOptions::select('id', 'name', 'description', 'tag', 'docker_image')
+                ->where('parent_service', $service->id)
+                ->with('variables')
+                ->get(),
         ];
     }
 }

--- a/app/Http/Controllers/API/User/InfoController.php
+++ b/app/Http/Controllers/API/User/InfoController.php
@@ -36,7 +36,7 @@ class InfoController extends BaseController
         $response = [];
 
         foreach ($servers as &$server) {
-            $response = array_merge($response, [[
+            $response[] = [
                 'id' => $server->uuidShort,
                 'uuid' => $server->uuid,
                 'name' => $server->name,
@@ -48,7 +48,7 @@ class InfoController extends BaseController
                 'port' => $server->port,
                 'service' => $server->a_serviceName,
                 'option' => $server->a_serviceOptionName,
-            ]]);
+            ];
         }
 
         return $response;

--- a/app/Http/Controllers/API/User/InfoController.php
+++ b/app/Http/Controllers/API/User/InfoController.php
@@ -32,11 +32,8 @@ class InfoController extends BaseController
 {
     public function me(Request $request)
     {
-        $servers = Models\Server::getUserServers();
-        $response = [];
-
-        foreach ($servers as &$server) {
-            $response[] = [
+        return Models\Server::getUserServers()->map(function ($server) {
+            return [
                 'id' => $server->uuidShort,
                 'uuid' => $server->uuid,
                 'name' => $server->name,
@@ -49,8 +46,6 @@ class InfoController extends BaseController
                 'service' => $server->a_serviceName,
                 'option' => $server->a_serviceOptionName,
             ];
-        }
-
-        return $response;
+        })->all();
     }
 }

--- a/app/Http/Controllers/API/User/ServerController.php
+++ b/app/Http/Controllers/API/User/ServerController.php
@@ -92,7 +92,6 @@ class ServerController extends BaseController
     public function power(Request $request, $uuid)
     {
         $server = Models\Server::getByUUID($uuid);
-        $node = Models\Node::getByID($server->node);
         $client = Models\Node::guzzleRequest($server->node);
 
         Auth::user()->can('power-' . $request->input('action'), $server);

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -55,7 +55,7 @@ class UserController extends BaseController
      * })
      * @Response(200)
      */
-    public function list(Request $request)
+    public function lists(Request $request)
     {
         return Models\User::all()->toArray();
     }

--- a/app/Http/Controllers/Base/APIController.php
+++ b/app/Http/Controllers/Base/APIController.php
@@ -48,7 +48,7 @@ class APIController extends Controller
         ]);
     }
 
-    public function new(Request $request)
+    public function create(Request $request)
     {
         return view('base.api.new');
     }
@@ -57,7 +57,7 @@ class APIController extends Controller
     {
         try {
             $repo = new APIRepository($request->user());
-            $secret = $repo->new($request->except(['_token']));
+            $secret = $repo->create($request->except(['_token']));
             Alert::success('An API Keypair has successfully been generated. The API secret for this public key is shown below and will not be shown again.<br /><br /><code>' . $secret . '</code>')->flash();
 
             return redirect()->route('account.api');

--- a/app/Http/Routes/APIRoutes.php
+++ b/app/Http/Routes/APIRoutes.php
@@ -55,7 +55,7 @@ class APIRoutes
              */
             $api->get('users', [
                 'as' => 'api.admin.users.list',
-                'uses' => 'Pterodactyl\Http\Controllers\API\UserController@list',
+                'uses' => 'Pterodactyl\Http\Controllers\API\UserController@lists',
             ]);
 
             $api->post('users', [
@@ -83,7 +83,7 @@ class APIRoutes
              */
             $api->get('servers', [
                 'as' => 'api.admin.servers.list',
-                'uses' => 'Pterodactyl\Http\Controllers\API\ServerController@list',
+                'uses' => 'Pterodactyl\Http\Controllers\API\ServerController@lists',
             ]);
 
             $api->post('servers', [
@@ -126,7 +126,7 @@ class APIRoutes
              */
             $api->get('nodes', [
                 'as' => 'api.admin.nodes.list',
-                'uses' => 'Pterodactyl\Http\Controllers\API\NodeController@list',
+                'uses' => 'Pterodactyl\Http\Controllers\API\NodeController@lists',
             ]);
 
             $api->post('nodes', [
@@ -164,7 +164,7 @@ class APIRoutes
              */
             $api->get('locations', [
                 'as' => 'api.admin.locations.list',
-                'uses' => 'Pterodactyl\Http\Controllers\API\LocationController@list',
+                'uses' => 'Pterodactyl\Http\Controllers\API\LocationController@lists',
             ]);
 
             /*
@@ -172,7 +172,7 @@ class APIRoutes
              */
             $api->get('services', [
                 'as' => 'api.admin.services.list',
-                'uses' => 'Pterodactyl\Http\Controllers\API\ServiceController@list',
+                'uses' => 'Pterodactyl\Http\Controllers\API\ServiceController@lists',
             ]);
 
             $api->get('services/{id}', [

--- a/app/Http/Routes/BaseRoutes.php
+++ b/app/Http/Routes/BaseRoutes.php
@@ -85,7 +85,7 @@ class BaseRoutes
             ]);
             $router->get('/new', [
                 'as' => 'account.api.new',
-                'uses' => 'Base\APIController@new',
+                'uses' => 'Base\APIController@create',
             ]);
             $router->post('/new', [
                 'uses' => 'Base\APIController@save',

--- a/app/Models/ServiceOptions.php
+++ b/app/Models/ServiceOptions.php
@@ -51,11 +51,11 @@ class ServiceOptions extends Model
          'parent_service' => 'integer',
      ];
 
-    /**
-     * Gets all variables associated with this service.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
-     */
+     /**
+      * Gets all variables associated with this service.
+      *
+      * @return \Illuminate\Database\Eloquent\Relations\HasMany
+      */
      public function variables()
      {
          return $this->hasMany(ServiceVariables::class, 'option_id');

--- a/app/Models/ServiceOptions.php
+++ b/app/Models/ServiceOptions.php
@@ -50,4 +50,14 @@ class ServiceOptions extends Model
      protected $casts = [
          'parent_service' => 'integer',
      ];
+
+    /**
+     * Gets all variables associated with this service.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+     public function variables()
+     {
+         return $this->hasMany(ServiceVariables::class, 'option_id');
+     }
 }

--- a/app/Models/Subuser.php
+++ b/app/Models/Subuser.php
@@ -81,6 +81,7 @@ class Subuser extends Model
     public static function accessServers()
     {
         $union = self::select('server_id')->where('user_id', self::$user->id);
+
         return Server::select('id')->where('owner', self::$user->id)->union($union)->pluck('id');
     }
 }

--- a/app/Models/Subuser.php
+++ b/app/Models/Subuser.php
@@ -80,15 +80,7 @@ class Subuser extends Model
      */
     public static function accessServers()
     {
-        $access = [];
-
         $union = self::select('server_id')->where('user_id', self::$user->id);
-        $select = Server::select('id')->where('owner', self::$user->id)->union($union)->get();
-
-        foreach ($select as &$select) {
-            $access = array_merge($access, [$select->id]);
-        }
-
-        return $access;
+        return Server::select('id')->where('owner', self::$user->id)->union($union)->pluck('id');
     }
 }

--- a/app/Policies/ServerPolicy.php
+++ b/app/Policies/ServerPolicy.php
@@ -74,11 +74,7 @@ class ServerPolicy
      */
     public function power(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('power')->exists();
+        return $this->checkPermission($user, $server, 'power');
     }
 
     /**
@@ -90,11 +86,7 @@ class ServerPolicy
      */
     public function powerStart(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('power-start')->exists();
+        return $this->heckPermission($user, $server, 'power-start');
     }
 
     /**
@@ -106,11 +98,7 @@ class ServerPolicy
      */
     public function powerStop(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('power-stop')->exists();
+        return $this->checkPermission($user, $server, 'power-stop');
     }
 
     /**
@@ -122,11 +110,7 @@ class ServerPolicy
      */
     public function powerRestart(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('power-restart')->exists();
+        return $this->checkPermission($user, $server, 'power-restart');
     }
 
     /**
@@ -138,11 +122,7 @@ class ServerPolicy
      */
     public function powerKill(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('power-kill')->exists();
+        return $this->checkPermission($user, $server, 'power-kill');
     }
 
     /**
@@ -154,11 +134,7 @@ class ServerPolicy
      */
     public function sendCommand(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('send-command')->exists();
+        return $this->checkPermission($user, $server, 'send-command');
     }
 
     /**
@@ -170,11 +146,7 @@ class ServerPolicy
      */
     public function listFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('list-files')->exists();
+        return $this->checkPermission($user, $server, 'list-files');
     }
 
     /**
@@ -186,11 +158,7 @@ class ServerPolicy
      */
     public function editFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('edit-files')->exists();
+        return $this->checkPermission($user, $server, 'edit-files');
     }
 
     /**
@@ -202,11 +170,7 @@ class ServerPolicy
      */
     public function saveFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('save-files')->exists();
+        return $this->checkPermission($user, $server, 'save-files');
     }
 
     /**
@@ -218,11 +182,7 @@ class ServerPolicy
      */
     public function moveFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('move-files')->exists();
+        return $this->checkPermission($user, $server, 'move-files');
     }
 
     /**
@@ -234,11 +194,7 @@ class ServerPolicy
      */
     public function copyFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('copy-files')->exists();
+        return $this->checkPermission($user, $server, 'copy-files');
     }
 
     /**
@@ -250,11 +206,7 @@ class ServerPolicy
      */
     public function compressFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('compress-files')->exists();
+        return $this->checkPermission($user, $server, 'compress-files');
     }
 
     /**
@@ -266,11 +218,7 @@ class ServerPolicy
      */
     public function decompressFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('decompress-files')->exists();
+        return $this->checkPermission($user, $server, 'decompress-files');
     }
 
     /**
@@ -282,11 +230,7 @@ class ServerPolicy
      */
     public function addFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('add-files')->exists();
+        return $this->checkPermission($user, $server, 'add-files');
     }
 
     /**
@@ -299,11 +243,7 @@ class ServerPolicy
      */
     public function uploadFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('upload-files')->exists();
+        return $this->checkPermission($user, $server, 'upload-files');
     }
 
     /**
@@ -315,11 +255,7 @@ class ServerPolicy
      */
     public function downloadFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('download-files')->exists();
+        return $this->checkPermission($user, $server, 'download-files');
     }
 
     /**
@@ -331,11 +267,7 @@ class ServerPolicy
      */
     public function deleteFiles(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('delete-files')->exists();
+        return $this->checkPermission($user, $server, 'delete-files');
     }
 
     /**
@@ -347,11 +279,7 @@ class ServerPolicy
      */
     public function listSubusers(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('list-subusers')->exists();
+        return $this->checkPermission($user, $server, 'list-subusers');
     }
 
     /**
@@ -363,11 +291,7 @@ class ServerPolicy
      */
     public function viewSubuser(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('view-subuser')->exists();
+        return $this->checkPermission($user, $server, 'view-subuser');
     }
 
     /**
@@ -379,11 +303,7 @@ class ServerPolicy
      */
     public function editSubuser(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('edit-subuser')->exists();
+        return $this->checkPermission($user, $server, 'edit-subuser');
     }
 
     /**
@@ -395,11 +315,7 @@ class ServerPolicy
      */
     public function deleteSubuser(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('delete-subuser')->exists();
+        return $this->checkPermission($user, $server, 'delete-subuser');
     }
 
     /**
@@ -411,11 +327,7 @@ class ServerPolicy
      */
     public function createSubuser(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('create-subuser')->exists();
+        return $this->checkPermission($user, $server, 'create-subuser');
     }
 
     /**
@@ -427,11 +339,7 @@ class ServerPolicy
      */
     public function setConnection(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('set-connection')->exists();
+        return $this->checkPermission($user, $server, 'set-connection');
     }
 
     /**
@@ -443,11 +351,7 @@ class ServerPolicy
      */
     public function viewStartup(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('view-startup')->exists();
+        return $this->checkPermission($user, $server, 'view-startup');
     }
 
     /**
@@ -459,11 +363,7 @@ class ServerPolicy
      */
     public function editStartup(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('edit-startup')->exists();
+        return $this->checkPermission($user, $server, 'edit-startup');
     }
 
     /**
@@ -475,11 +375,7 @@ class ServerPolicy
      */
     public function viewSftp(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('view-sftp')->exists();
+        return $this->checkPermission($user, $server, 'view-sftp');
     }
 
     /**
@@ -491,11 +387,7 @@ class ServerPolicy
      */
     public function resetSftp(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('reset-sftp')->exists();
+        return $this->checkPermission($user, $server, 'reset-sftp');
     }
 
     /**
@@ -507,11 +399,7 @@ class ServerPolicy
      */
     public function viewSftpPassword(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('view-sftp-password')->exists();
+        return $this->checkPermission($user, $server, 'view-sftp-password');
     }
 
     /**
@@ -523,11 +411,7 @@ class ServerPolicy
      */
     public function viewDatabases(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('view-databases')->exists();
+        return $this->checkPermission($user, $server, 'view-databases');
     }
 
     /**
@@ -539,11 +423,7 @@ class ServerPolicy
      */
     public function resetDbPassword(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('reset-db-password')->exists();
+        return $this->checkPermission($user, $server, 'reset-db-password');
     }
 
     /**
@@ -555,11 +435,7 @@ class ServerPolicy
      */
     public function listTasks(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('list-tasks')->exists();
+        return $this->checkPermission($user, $server, 'list-tasks');
     }
 
     /**
@@ -571,11 +447,7 @@ class ServerPolicy
      */
     public function viewTask(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('view-task')->exists();
+        return $this->checkPermission($user, $server, 'view-task');
     }
 
     /**
@@ -587,11 +459,7 @@ class ServerPolicy
      */
     public function toggleTask(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('toggle-task')->exists();
+        return $this->checkPermission($user, $server, 'toggle-task');
     }
 
     /**
@@ -603,11 +471,7 @@ class ServerPolicy
      */
     public function queueTask(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('queue-task')->exists();
+        return $this->checkPermission($user, $server, 'queue-task');
     }
 
     /**
@@ -619,11 +483,7 @@ class ServerPolicy
      */
     public function deleteTask(User $user, Server $server)
     {
-        if ($this->isOwner($user, $server)) {
-            return true;
-        }
-
-        return $user->permissions()->server($server)->permission('delete-task')->exists();
+        return $this->checkPermission($user, $server, 'delete-task');
     }
 
     /**
@@ -635,10 +495,23 @@ class ServerPolicy
      */
     public function createTask(User $user, Server $server)
     {
+        return $this->checkPermission($user, $server, 'create-task');
+    }
+
+    /**
+     * Checks if the user has the given permission on/for the server.
+     *
+     * @param \Pterodactyl\Models\User   $user
+     * @param \Pterodactyl\Models\Server $server
+     * @param $permission
+     * @return bool
+     */
+    private function checkPermission(User $user, Server $server, $permission)
+    {
         if ($this->isOwner($user, $server)) {
             return true;
         }
 
-        return $user->permissions()->server($server)->permission('create-task')->exists();
+        return $user->permissions()->server($server)->permission($permission)->exists();
     }
 }

--- a/app/Policies/ServerPolicy.php
+++ b/app/Policies/ServerPolicy.php
@@ -42,8 +42,8 @@ class ServerPolicy
     /**
      * Determine if current user is the owner of a server.
      *
-     * @param  Pterodactyl\Models\User    $user
-     * @param  Pterodactyl\Models\Server  $server
+     * @param  \Pterodactyl\Models\User    $user
+     * @param  \Pterodactyl\Models\Server  $server
      * @return bool
      */
     protected function isOwner(User $user, Server $server)
@@ -54,7 +54,7 @@ class ServerPolicy
     /**
      * Runs before any of the functions are called. Used to determine if user is root admin, if so, ignore permissions.
      *
-     * @param  Pterodactyl\Models\User $user
+     * @param  \Pterodactyl\Models\User $user
      * @param  string $ability
      * @return bool
      */
@@ -68,8 +68,8 @@ class ServerPolicy
     /**
      * Check if user has permission to control power for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function power(User $user, Server $server)
@@ -84,8 +84,8 @@ class ServerPolicy
     /**
      * Check if user has permission to start a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function powerStart(User $user, Server $server)
@@ -100,8 +100,8 @@ class ServerPolicy
     /**
      * Check if user has permission to stop a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function powerStop(User $user, Server $server)
@@ -116,8 +116,8 @@ class ServerPolicy
     /**
      * Check if user has permission to restart a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function powerRestart(User $user, Server $server)
@@ -132,8 +132,8 @@ class ServerPolicy
     /**
      * Check if user has permission to kill a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function powerKill(User $user, Server $server)
@@ -148,8 +148,8 @@ class ServerPolicy
     /**
      * Check if user has permission to run a command on a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function sendCommand(User $user, Server $server)
@@ -164,8 +164,8 @@ class ServerPolicy
     /**
      * Check if user has permission to list files on a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function listFiles(User $user, Server $server)
@@ -180,8 +180,8 @@ class ServerPolicy
     /**
      * Check if user has permission to edit files on a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function editFiles(User $user, Server $server)
@@ -196,8 +196,8 @@ class ServerPolicy
     /**
      * Check if user has permission to save files on a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function saveFiles(User $user, Server $server)
@@ -212,8 +212,8 @@ class ServerPolicy
     /**
      * Check if user has permission to move and rename files and folders on a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function moveFiles(User $user, Server $server)
@@ -228,8 +228,8 @@ class ServerPolicy
     /**
      * Check if user has permission to copy folders and files on a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function copyFiles(User $user, Server $server)
@@ -244,8 +244,8 @@ class ServerPolicy
     /**
      * Check if user has permission to compress files and folders on a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function compressFiles(User $user, Server $server)
@@ -260,8 +260,8 @@ class ServerPolicy
     /**
      * Check if user has permission to decompress files on a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function decompressFiles(User $user, Server $server)
@@ -276,8 +276,8 @@ class ServerPolicy
     /**
      * Check if user has permission to add files to a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function addFiles(User $user, Server $server)
@@ -293,8 +293,8 @@ class ServerPolicy
      * Check if user has permission to upload files to a server.
      * This permission relies on the user having the 'add-files' permission as well due to page authorization.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function uploadFiles(User $user, Server $server)
@@ -309,8 +309,8 @@ class ServerPolicy
     /**
      * Check if user has permission to download files from a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function downloadFiles(User $user, Server $server)
@@ -325,8 +325,8 @@ class ServerPolicy
     /**
      * Check if user has permission to delete files from a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function deleteFiles(User $user, Server $server)
@@ -341,8 +341,8 @@ class ServerPolicy
     /**
      * Check if user has permission to view subusers for the server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function listSubusers(User $user, Server $server)
@@ -357,8 +357,8 @@ class ServerPolicy
     /**
      * Check if user has permission to view specific subuser permissions.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function viewSubuser(User $user, Server $server)
@@ -373,8 +373,8 @@ class ServerPolicy
     /**
      * Check if user has permission to edit a subuser.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function editSubuser(User $user, Server $server)
@@ -389,8 +389,8 @@ class ServerPolicy
     /**
      * Check if user has permission to delete a subuser.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function deleteSubuser(User $user, Server $server)
@@ -405,8 +405,8 @@ class ServerPolicy
     /**
      * Check if user has permission to edit a subuser.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function createSubuser(User $user, Server $server)
@@ -421,8 +421,8 @@ class ServerPolicy
     /**
      * Check if user has permission to set the default connection for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function setConnection(User $user, Server $server)
@@ -437,8 +437,8 @@ class ServerPolicy
     /**
      * Check if user has permission to view the startup command used for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function viewStartup(User $user, Server $server)
@@ -453,8 +453,8 @@ class ServerPolicy
     /**
      * Check if user has permission to edit the startup command used for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function editStartup(User $user, Server $server)
@@ -469,8 +469,8 @@ class ServerPolicy
     /**
      * Check if user has permission to view the SFTP information for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function viewSftp(User $user, Server $server)
@@ -485,8 +485,8 @@ class ServerPolicy
     /**
      * Check if user has permission to reset the SFTP password for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function resetSftp(User $user, Server $server)
@@ -501,8 +501,8 @@ class ServerPolicy
     /**
      * Check if user has permission to view the SFTP password for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function viewSftpPassword(User $user, Server $server)
@@ -517,8 +517,8 @@ class ServerPolicy
     /**
      * Check if user has permission to view databases for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function viewDatabases(User $user, Server $server)
@@ -533,8 +533,8 @@ class ServerPolicy
     /**
      * Check if user has permission to reset database passwords.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function resetDbPassword(User $user, Server $server)
@@ -549,8 +549,8 @@ class ServerPolicy
     /**
      * Check if user has permission to view all tasks for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function listTasks(User $user, Server $server)
@@ -565,8 +565,8 @@ class ServerPolicy
     /**
      * Check if user has permission to view a specific task for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function viewTask(User $user, Server $server)
@@ -581,8 +581,8 @@ class ServerPolicy
     /**
      * Check if user has permission to view a toggle a task for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function toggleTask(User $user, Server $server)
@@ -597,8 +597,8 @@ class ServerPolicy
     /**
      * Check if user has permission to queue a task for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function queueTask(User $user, Server $server)
@@ -613,8 +613,8 @@ class ServerPolicy
     /**
      * Check if user has permission to delete a specific task for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function deleteTask(User $user, Server $server)
@@ -629,8 +629,8 @@ class ServerPolicy
     /**
      * Check if user has permission to create a task for a server.
      *
-     * @param  Pterodactyl\Models\User   $user
-     * @param  Pterodactyl\Models\Server $server
+     * @param  \Pterodactyl\Models\User   $user
+     * @param  \Pterodactyl\Models\Server $server
      * @return bool
      */
     public function createTask(User $user, Server $server)

--- a/app/Policies/ServerPolicy.php
+++ b/app/Policies/ServerPolicy.php
@@ -86,7 +86,7 @@ class ServerPolicy
      */
     public function powerStart(User $user, Server $server)
     {
-        return $this->heckPermission($user, $server, 'power-start');
+        return $this->checkPermission($user, $server, 'power-start');
     }
 
     /**

--- a/app/Repositories/APIRepository.php
+++ b/app/Repositories/APIRepository.php
@@ -219,7 +219,7 @@ class APIRepository
      *
      * @return void
      */
-    public function revoke(string $key)
+    public function revoke($key)
     {
         DB::beginTransaction();
 

--- a/app/Repositories/APIRepository.php
+++ b/app/Repositories/APIRepository.php
@@ -116,7 +116,7 @@ class APIRepository
      *
      * @return string Returns the generated secret token.
      */
-    public function new(array $data)
+    public function create(array $data)
     {
         $validator = Validator::make($data, [
             'memo' => 'string|max:500',

--- a/app/Repositories/APIRepository.php
+++ b/app/Repositories/APIRepository.php
@@ -225,7 +225,7 @@ class APIRepository
 
         try {
             $model = Models\APIKey::where('public', $key)->where('user', $this->user->id)->firstOrFail();
-            $permissions = Models\APIPermission::where('key_id', $model->id)->delete();
+            Models\APIPermission::where('key_id', $model->id)->delete();
             $model->delete();
 
             DB::commit();

--- a/app/Repositories/Daemon/FileRepository.php
+++ b/app/Repositories/Daemon/FileRepository.php
@@ -181,24 +181,23 @@ class FileRepository
         $folders = [];
         foreach ($json as &$value) {
             if ($value->directory === true) {
-
                 // @TODO Handle Symlinks
-                $folders = array_merge($folders, [[
+                $folders[] = [
                     'entry' => $value->name,
                     'directory' => trim($directory, '/'),
                     'size' => null,
                     'date' => strtotime($value->modified),
                     'mime' => $value->mime,
-                ]]);
+                ];
             } elseif ($value->file === true) {
-                $files = array_merge($files, [[
+                $files[] = [
                     'entry' => $value->name,
                     'directory' => trim($directory, '/'),
                     'extension' => pathinfo($value->name, PATHINFO_EXTENSION),
                     'size' => HelperRepository::bytesToHuman($value->size),
                     'date' => strtotime($value->modified),
                     'mime' => $value->mime,
-                ]]);
+                ];
             }
         }
 

--- a/app/Repositories/ServerRepository.php
+++ b/app/Repositories/ServerRepository.php
@@ -261,7 +261,7 @@ class ServerRepository
 
             // Add Variables
             $environmentVariables = [
-                'STARTUP' => $data['startup']
+                'STARTUP' => $data['startup'],
             ];
 
             foreach ($variableList as $item) {
@@ -717,7 +717,7 @@ class ServerRepository
 
             // Add Variables
             $environmentVariables = [
-                'STARTUP' => $server->startup
+                'STARTUP' => $server->startup,
             ];
             foreach ($variableList as $item) {
                 $environmentVariables[$item['env']] = $item['val'];

--- a/app/Repositories/ServerRepository.php
+++ b/app/Repositories/ServerRepository.php
@@ -170,11 +170,11 @@ class ServerRepository
                     if ($variable->required === 1) {
                         throw new DisplayException('A required service option variable field (env_' . $variable->env_variable . ') was missing from the request.');
                     }
-                    $variableList = array_merge($variableList, [[
+                    $variableList[] = [
                         'id' => $variable->id,
                         'env' => $variable->env_variable,
                         'val' => $variable->default_value,
-                    ]]);
+                    ];
                     continue;
                 }
 
@@ -183,11 +183,11 @@ class ServerRepository
                     throw new DisplayException('Failed to validate service option variable field (env_' . $variable->env_variable . ') aganist regex (' . $variable->regex . ').');
                 }
 
-                $variableList = array_merge($variableList, [[
+                $variableList[] = [
                     'id' => $variable->id,
                     'env' => $variable->env_variable,
                     'val' => $data['env_' . $variable->env_variable],
-                ]]);
+                ];
                 continue;
             }
         }
@@ -260,14 +260,13 @@ class ServerRepository
             $allocation->save();
 
             // Add Variables
-            $environmentVariables = [];
-            $environmentVariables = array_merge($environmentVariables, [
-                'STARTUP' => $data['startup'],
-            ]);
+            $environmentVariables = [
+                'STARTUP' => $data['startup']
+            ];
+
             foreach ($variableList as $item) {
-                $environmentVariables = array_merge($environmentVariables, [
-                    $item['env'] => $item['val'],
-                ]);
+                $environmentVariables[$item['env']] = $item['val'];
+
                 Models\ServerVariables::create([
                     'server_id' => $server->id,
                     'variable_id' => $item['id'],
@@ -672,21 +671,21 @@ class ServerRepository
                 foreach ($variables as &$variable) {
                     // Move on if the new data wasn't even sent
                     if (! isset($data[$variable->env_variable])) {
-                        $variableList = array_merge($variableList, [[
+                        $variableList[] = [
                             'id' => $variable->id,
                             'env' => $variable->env_variable,
                             'val' => $variable->a_currentValue,
-                        ]]);
+                        ];
                         continue;
                     }
 
                     // Update Empty but skip validation
                     if (empty($data[$variable->env_variable])) {
-                        $variableList = array_merge($variableList, [[
+                        $variableList[] = [
                             'id' => $variable->id,
                             'env' => $variable->env_variable,
                             'val' => null,
-                        ]]);
+                        ];
                         continue;
                     }
 
@@ -708,23 +707,20 @@ class ServerRepository
                         throw new DisplayException('Failed to validate service option variable field (' . $variable->env_variable . ') aganist regex (' . $variable->regex . ').');
                     }
 
-                    $variableList = array_merge($variableList, [[
+                    $variableList[] = [
                         'id' => $variable->id,
                         'env' => $variable->env_variable,
                         'val' => $data[$variable->env_variable],
-                    ]]);
+                    ];
                 }
             }
 
             // Add Variables
-            $environmentVariables = [];
-            $environmentVariables = array_merge($environmentVariables, [
-                'STARTUP' => $server->startup,
-            ]);
+            $environmentVariables = [
+                'STARTUP' => $server->startup
+            ];
             foreach ($variableList as $item) {
-                $environmentVariables = array_merge($environmentVariables, [
-                    $item['env'] => $item['val'],
-                ]);
+                $environmentVariables[$item['env']] = $item['val'];
 
                 // Update model or make a new record if it doesn't exist.
                 $model = Models\ServerVariables::firstOrNew([

--- a/app/Repositories/ServiceRepository/Option.php
+++ b/app/Repositories/ServiceRepository/Option.php
@@ -118,6 +118,7 @@ class Option
         }
 
         $option->fill($data);
-        $option->save();
+
+        return $option->save();
     }
 }

--- a/app/Repositories/ServiceRepository/Service.php
+++ b/app/Repositories/ServiceRepository/Service.php
@@ -82,7 +82,8 @@ class Service
         }
 
         $service->fill($data);
-        $service->save();
+
+        return $service->save();
     }
 
     public function delete($id)

--- a/app/Repositories/ServiceRepository/Variable.php
+++ b/app/Repositories/ServiceRepository/Variable.php
@@ -71,7 +71,8 @@ class Variable
         $variable = new Models\ServiceVariables;
         $variable->option_id = $option->id;
         $variable->fill($data);
-        $variable->save();
+
+        return $variable->save();
     }
 
     public function delete($id)
@@ -125,6 +126,7 @@ class Variable
         $data['required'] = (isset($data['required']) && in_array((int) $data['required'], [0, 1])) ? $data['required'] : $variable->required;
 
         $variable->fill($data);
-        $variable->save();
+
+        return $variable->save();
     }
 }

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -144,7 +144,8 @@ class UserRepository
         }
 
         $user->fill($data);
-        $user->save();
+
+        return $user->save();
     }
 
     /**

--- a/resources/views/admin/databases/index.blade.php
+++ b/resources/views/admin/databases/index.blade.php
@@ -36,7 +36,7 @@
         <li><a href="{{ route('admin.databases.new') }}"><i class="fa fa-plus"></i></a></li>
     </ul>
     <div class="tab-content">
-        <div class="tab-pane active" id="tab_databases">
+        <div class="tab-pane {{ Request::input('tab') == 'tab_dbservers' ? '' : 'active' }}" id="tab_databases">
             <div class="panel panel-default">
                 <div class="panel-heading"></div>
                 <div class="panel-body">
@@ -65,12 +65,12 @@
                         </tbody>
                     </table>
                     <div class="col-md-12 text-center">
-                        {{ $databases->render() }}
+                        {{ $databases->appends('tab', 'tab_databases')->render() }}
                     </div>
                 </div>
             </div>
         </div>
-        <div class="tab-pane" id="tab_dbservers">
+        <div class="tab-pane {{ Request::input('tab') == 'tab_dbservers' ? 'active' : '' }}" id="tab_dbservers">
             <div class="panel panel-default">
                 <div class="panel-heading"></div>
                 <div class="panel-body">
@@ -99,7 +99,7 @@
                         </tbody>
                     </table>
                     <div class="col-md-12 text-center">
-                        {{ $dbh->render() }}
+                        {{ $dbh->appends('tab', 'tab_dbservers')->render() }}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
As discussed in the discord, here is a PR refactoring a few bits and pieces to streamline a few methods (mostly the API) with the help of the integrated laravel helper methods and classes.

While going through the code on my PHP 5.6 development machine, I noticed a few issues regarding the usage of reserved keywords as method names. Those should be fixed, so servers without fancy PHP 7 can now run the panel just fine.