### PR TITLE
Add styling rules to limit size of the FQDN column.

### DIFF
--- a/resources/views/base/index.blade.php
+++ b/resources/views/base/index.blade.php
@@ -59,7 +59,7 @@
                         @endif
                         <td><a href="/server/{{ $server->uuidShort }}">{{ $server->name }}</a></td>
                         <td>{{ $server->nodeName }}</td>
-                        <td><code>@if(!is_null($server->ip_alias)){{ $server->ip_alias }}@else{{ $server->ip }}@endif:{{ $server->port }}</code></td>
+                        <td style="max-width:290px;word-wrap:break-word;"><code>@if(!is_null($server->ip_alias)){{ $server->ip_alias }}@else{{ $server->ip }}@endif:{{ $server->port }}</code></td>
                         <td class="text-center" data-action="players">--</td>
                         <td class="text-center hidden-sm hidden-xs"><span data-action="memory">--</span> / {{ $server->memory === 0 ? '&infin;' : $server->memory }} MB</td>
                         <td class="text-center hidden-sm hidden-xs"><span data-action="cpu" data-cpumax="{{ $server->cpu }}">--</span> %</td>


### PR DESCRIPTION
Add styling rules to limit size of the FQDN column. Break words for very long FQDNs.

References #221.