### PR TITLE
Repair user creation functionality

### DIFF
--- a/app/Console/Commands/MakeUser.php
+++ b/app/Console/Commands/MakeUser.php
@@ -35,6 +35,9 @@ class MakeUser extends Command
      * @var string
      */
     protected $signature = 'pterodactyl:user
+                            {--firstname= : First name to use for this account.}
+                            {--lastname= : Last name to use for this account.}
+                            {--username= : Username to use for this account.}
                             {--email= : Email address to use for this account.}
                             {--password= : Password to assign to the user.}
                             {--admin= :  Boolean flag for if user should be an admin.}';
@@ -63,19 +66,22 @@ class MakeUser extends Command
      */
     public function handle()
     {
-        $email = is_null($this->option('email')) ? $this->ask('Email') : $this->option('email');
-        $password = is_null($this->option('password')) ? $this->secret('Password') : $this->option('password');
+        $data['name_first'] = is_null($this->option('firstname')) ? $this->ask('First Name') : $this->option('firstname');
+        $data['name_last'] = is_null($this->option('lastname')) ? $this->ask('Last Name') : $this->option('lastname');
+        $data['username'] = is_null($this->option('username')) ? $this->ask('Username') : $this->option('username');
+        $data['email'] = is_null($this->option('email')) ? $this->ask('Email') : $this->option('email');
+        $data['password'] = is_null($this->option('password')) ? $this->secret('Password') : $this->option('password');
         $password_confirmation = is_null($this->option('password')) ? $this->secret('Confirm Password') : $this->option('password');
 
-        if ($password !== $password_confirmation) {
+        if ($data['password'] !== $password_confirmation) {
             return $this->error('The passwords provided did not match!');
         }
 
-        $admin = is_null($this->option('admin')) ? $this->confirm('Is this user a root administrator?') : $this->option('admin');
+        $data['root_admin'] = is_null($this->option('admin')) ? $this->confirm('Is this user a root administrator?') : $this->option('admin');
 
         try {
             $user = new UserRepository;
-            $user->create($email, $password, $admin);
+            $user->create($data);
 
             return $this->info('User successfully created.');
         } catch (\Exception $ex) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -67,7 +67,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      *
      * @var [type]
      */
-    protected $fillable = ['username', 'email', 'name_first', 'name_last', 'password', 'language', 'use_totp', 'totp_secret', 'gravatar'];
+    protected $fillable = ['username', 'email', 'name_first', 'name_last', 'password', 'language', 'use_totp', 'totp_secret', 'gravatar', 'root_admin'];
 
      /**
       * Cast values to correct type.

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -90,7 +90,7 @@ class UserRepository
                 'username' => $data['username'],
                 'name_first' => $data['name_first'],
                 'name_last' => $data['name_last'],
-                'password' => Hash::make((empty($data['password'])) ? str_random(30) : $password),
+                'password' => Hash::make((empty($data['password'])) ? str_random(30) : $data['password']),
                 'root_admin' => $data['root_admin'],
                 'language' => Settings::get('default_language', 'en'),
             ]);


### PR DESCRIPTION
Repair functionality of the make user console command (pterodactyl:user)
Fix up the user repository, was using the old $password instead of the changed format $data['password']
Change User model to allow root_admin to be a fillable item.