### PR TITLE
show users’ subuser servers on user detail view

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -30,6 +30,7 @@ use Alert;
 use Illuminate\Http\Request;
 use Pterodactyl\Models\User;
 use Pterodactyl\Models\Server;
+use Pterodactyl\Models\Subuser;
 use Pterodactyl\Exceptions\DisplayException;
 use Pterodactyl\Http\Controllers\Controller;
 use Pterodactyl\Repositories\UserRepository;
@@ -86,10 +87,9 @@ class UserController extends Controller
     {
         return view('admin.users.view', [
             'user' => User::findOrFail($id),
-            'servers' => Server::select('servers.*', 'nodes.name as nodeName', 'locations.long as location')
-                ->join('nodes', 'servers.node', '=', 'nodes.id')
-                ->join('locations', 'nodes.location', '=', 'locations.id')
-                ->where('owner', $id)
+            'servers' => Server::select('servers.*')
+                ->whereIn('servers.id', Subuser::select('server_id')->where('user_id', $id)->get())
+                ->orWhere('owner', $id)
                 ->get(),
         ]);
     }

--- a/resources/lang/en/strings.php
+++ b/resources/lang/en/strings.php
@@ -60,4 +60,6 @@ return [
     'no' => 'No',
     'delete' => 'Delete',
     '2fa' => '2FA',
+    'owner' => 'Owner',
+    'subuser' => 'Subuser'
 ];

--- a/resources/themes/pterodactyl/server/users/index.blade.php
+++ b/resources/themes/pterodactyl/server/users/index.blade.php
@@ -54,7 +54,13 @@
                         @foreach($subusers as $user)
                             <tr>
                                 <td class="text-center middle"><img class="img-circle" src="https://www.gravatar.com/avatar/{{ md5($user->email) }}?s=128" style="height:20px;" alt="User Image"></td>
-                                <td class="middle">{{ $user->username }}
+                                <td class="middle">
+                                    @if(Auth::user()->isRootAdmin())
+                                        <a href="{{ route('admin.users.view', $user->user_id) }}">{{ $user->username }}</a>
+                                    @else
+                                        {{ $user->username }}
+                                    @endif
+                                </td>
                                 <td class="middle"><code>{{ $user->email }}</code></td>
                                 <td class="middle text-center">
                                     @if($user->use_totp)

--- a/resources/views/admin/users/view.blade.php
+++ b/resources/views/admin/users/view.blade.php
@@ -104,10 +104,9 @@
                     <thead>
                         <tr>
                             <th style="width:2%;"></th>
+                            <th>Name</th>
                             <th>Identifier</th>
-                            <th>Server Name</th>
-                            <th>Node</th>
-                            <th>Username</th>
+                            <th>Access</th>
                             <th style="width:10%;"></th>
                         </tr>
                     </thead>
@@ -115,10 +114,9 @@
                             @foreach($servers as $server)
                                 <tr>
                                     <td><a href="/server/{{ $server->uuidShort }}/"><i class="fa fa-tachometer"></i></a></td>
-                                    <td><code>{{ $server->uuidShort }}</code></td>
                                     <td><a href="/admin/servers/view/{{ $server->id }}">{{ $server->name }}</a></td>
-                                    <td>{{ $server->nodeName }}</td>
-                                    <td><code>{{ $server->username }}</code></td>
+                                    <td><code>{{ $server->uuidShort }}</code></td>
+                                    <td>{{ $server->owner == $user->id ? trans('strings.owner') : trans('strings.subuser') }}</td>
                                     <td class="centered">@if($server->suspended === 0)<span class="label muted muted-hover label-success">Active</span>@else<span class="label label-warning">Suspended</span>@endif</td>
                                 </td>
                             @endforeach


### PR DESCRIPTION
Shows servers a user is assigned to as subuser in the user detail view.
Removed some useless information (Server user and Server node) and optimized query.

![image](https://cloud.githubusercontent.com/assets/1710904/22400706/f4d93774-e5bc-11e6-8f18-0a5fc60658d4.png)

Also adds a links from the subusers table of the server to the admin user detail view (if the logged in user is an admin).

Fixes #209 