### PR TITLE
show Suspended server in overview fixes #386

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project follows [Semantic Versioning](http://semver.org) guidelines.
 
 ## v0.6.0-beta.3 (Courageous Carniadactylus)
 ### Fixed
+* `[beta.2]` — Suspended servers now show as suspended.
 * `[beta.2]` — Fixes filemanager 404 when editing a file within a directory.
 
 ## v0.6.0-beta.2 (Courageous Carniadactylus)

--- a/resources/themes/pterodactyl/base/index.blade.php
+++ b/resources/themes/pterodactyl/base/index.blade.php
@@ -62,7 +62,7 @@
                             <th class="text-center">@lang('strings.status')</th>
                         </tr>
                         @foreach($servers as $server)
-                            <tr class=" {{$server->suspended === 1 ?: 'dynamic-update' }}" data-server="{{ $server->uuidShort }}">
+                            <tr class=" {{$server->suspended ?: 'dynamic-update' }}" data-server="{{ $server->uuidShort }}">
                                 <td @if(! empty($server->description)) rowspan="2" @endif><code>{{ $server->uuidShort }}</code></td>
                                 <td><a href="{{ route('server.index', $server->uuidShort) }}">{{ $server->name }}</a></td>
                                 <td>{{ $server->node->name }}</td>
@@ -79,7 +79,7 @@
                                     @endif
                                 </td>
                                 <td class="text-center" data-action="status">
-                                    @if($server->suspended === 1)
+                                    @if($server->suspended)
                                         <span class="label label-warning">@lang('strings.suspended')</span>
                                     @else
                                         <span class="label label-default"><i class="fa fa-refresh fa-fw fa-spin"></i></span>

--- a/resources/themes/pterodactyl/base/index.blade.php
+++ b/resources/themes/pterodactyl/base/index.blade.php
@@ -62,7 +62,7 @@
                             <th class="text-center">@lang('strings.status')</th>
                         </tr>
                         @foreach($servers as $server)
-                            <tr class="dynamic-update" data-server="{{ $server->uuidShort }}">
+                            <tr class=" {{$server->suspended === 1 ?: 'dynamic-update' }}" data-server="{{ $server->uuidShort }}">
                                 <td @if(! empty($server->description)) rowspan="2" @endif><code>{{ $server->uuidShort }}</code></td>
                                 <td><a href="{{ route('server.index', $server->uuidShort) }}">{{ $server->name }}</a></td>
                                 <td>{{ $server->node->name }}</td>


### PR DESCRIPTION
Another solution to this would be to change it in the javascript - I wasn't sure which you prefered so i just removed the class for dynamic update so it doesn't call the ajax status (which is hidden behind the checkServer middleware) 