### PR TITLE
Set drop-down menu option to be same as help text below

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -4,7 +4,7 @@ return [
 
     'env' => env('APP_ENV', 'production'),
 
-    'version' => env('APP_VERSION', 'canary'),
+    'version' => env('APP_VERSION', '0.6.0-beta.2'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -4,7 +4,7 @@ return [
 
     'env' => env('APP_ENV', 'production'),
 
-    'version' => env('APP_VERSION', '0.6.0-beta.2'),
+    'version' => env('APP_VERSION', 'canary'),
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/lang/en/server.php
+++ b/resources/lang/en/server.php
@@ -12,7 +12,7 @@ return [
         'current' => 'Current Scheduled Tasks',
         'actions' => [
             'command' => 'Send Command',
-            'power' => 'Send Power Toggle',
+            'power' => 'Send Power Option',
         ],
         'new_task' => 'Add New Task',
         'toggle' => 'Toggle Status',


### PR DESCRIPTION
The drop down menu option was previously "Send Power Toggle" where the help text below it was referring to it as "Send Power Option"
This could probably be changed either way, however I think "option" makes more sense than toggle.