### PR TITLE
TEXT/BLOB defaults not widely supported. Use STRING/VARCHAR instead.

### DIFF
--- a/database/migrations/2017_04_20_171943_AddScriptsToServiceOptions.php
+++ b/database/migrations/2017_04_20_171943_AddScriptsToServiceOptions.php
@@ -16,8 +16,8 @@ class AddScriptsToServiceOptions extends Migration
         Schema::table('service_options', function (Blueprint $table) {
             $table->text('script_install')->after('startup')->nullable();
             $table->boolean('script_is_privileged')->default(true)->after('startup');
-            $table->text('script_entry')->default('ash')->after('startup');
-            $table->text('script_container')->default('alpine:3.4')->after('startup');
+            $table->string('script_entry')->default('ash')->after('startup');
+            $table->string('script_container')->default('alpine:3.4')->after('startup');
         });
     }
 


### PR DESCRIPTION
Currently mysql does not support defaults for text and blobs without disabling strict mode in 5.7. https://dev.mysql.com/doc/refman/5.7/en/blob.html

Mariadb (a drop in replacement for mysql made by the same team of devs as mysql) also doesnt support defaults for text and blobs until 10.2.1 (there is no stable release, 10.2.5 is a release candidate) which isnt available on non-bleeding edge distro's. No one is going to install an unstable release of mariadb on production servers. https://mariadb.com/kb/en/mariadb/text/
Latest release for ubuntu xenial is 10.0.29-MariaDB

So for now we change text to string for values that have defaults until defaults are more widely supported for TEXT and BLOB mysql values.