### PR TITLE
Fix terminal scrolling and terminalNotify

### DIFF
--- a/public/themes/pterodactyl/js/frontend/console.js
+++ b/public/themes/pterodactyl/js/frontend/console.js
@@ -116,7 +116,7 @@ $(document).ready(function () {
 });
 
 $terminal.on('scroll', function () {
-    if ($(this).scrollTop() + $(this).innerHeight() < $(this)[0].scrollHeight) {
+    if ($(this).scrollTop() + $(this).innerHeight() + 50 < $(this)[0].scrollHeight) {
         $scrollNotify.removeClass('hidden');
     } else {
         $scrollNotify.addClass('hidden');


### PR DESCRIPTION
The original statement seems to be a bit too precise regarding the height. Any tiny lag or one pixel movement leads to the console not being scrolled to the bottom anymore. Same applies for manually scrolling down which does not hide the `terminalNotify` properly. 

A bit larger "buffer" fixes this.