### PR TITLE
Use universal sign out icons because power buttons are already used

### DIFF
--- a/resources/themes/pterodactyl/layouts/admin.blade.php
+++ b/resources/themes/pterodactyl/layouts/admin.blade.php
@@ -79,7 +79,7 @@
                                 <li><a href="{{ route('index') }}" data-toggle="tooltip" data-placement="bottom" title="Exit Admin Control"><i class="fa fa-server"></i></a></li>
                             </li>
                             <li>
-                                <li><a href="{{ route('auth.logout') }}" id="logoutButton" data-toggle="tooltip" data-placement="bottom" title="Logout"><i class="fa fa-power-off"></i></a></li>
+                                <li><a href="{{ route('auth.logout') }}" id="logoutButton" data-toggle="tooltip" data-placement="bottom" title="Logout"><i class="fa fa-sign-out"></i></a></li>
                             </li>
                         </ul>
                     </div>

--- a/resources/themes/pterodactyl/layouts/master.blade.php
+++ b/resources/themes/pterodactyl/layouts/master.blade.php
@@ -83,7 +83,7 @@
                                 </li>
                             @endif
                             <li>
-                                <li><a href="{{ route('auth.logout') }}" id="logoutButton" data-toggle="tooltip" data-placement="bottom" title="{{ @trans('strings.logout') }}"><i class="fa fa-power-off"></i></a></li>
+                                <li><a href="{{ route('auth.logout') }}" id="logoutButton" data-toggle="tooltip" data-placement="bottom" title="{{ @trans('strings.logout') }}"><i class="fa fa-sign-out"></i></a></li>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
Use universal sign out icons because power buttons are already used in the themes\pterodactyl\admin\nodes\view\settings.blade.php