### PR TITLE
Temporary routes fix because these controllers don't exist anymore…

### DIFF
--- a/routes/api-admin.php
+++ b/routes/api-admin.php
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-Route::get('/', 'CoreController@index');
+Route::get('/', '\Pterodactyl\Http\Controllers\API\User\CoreController@index');
 
 /*
 |--------------------------------------------------------------------------

--- a/routes/server.php
+++ b/routes/server.php
@@ -96,7 +96,7 @@ Route::group(['prefix' => 'schedules'], function () {
     Route::post('/new', 'Tasks\TaskManagementController@store');
 
     Route::patch('/view/{schedule}', 'Tasks\TaskManagementController@update')->middleware('schedule');
-    Route::patch('/view/{schedule}/toggle', 'Tasks\TaskToggleController@index')->middleware('schedule')->name('server.schedules.toggle');
+    // Route::patch('/view/{schedule}/toggle', 'Tasks\TaskToggleController@index')->middleware('schedule')->name('server.schedules.toggle');
 
     Route::delete('/view/{schedule}/delete', 'Tasks\TaskManagementController@delete')->middleware('schedule')->name('server.schedules.delete');
 });


### PR DESCRIPTION
…apparently ¯\_(ツ)_/¯

This allows you to run artisan route:list and artisan route:cache