### PR TITLE
add link on server navigation to get to the admin page

### DIFF
--- a/resources/lang/en/navigation.php
+++ b/resources/lang/en/navigation.php
@@ -25,5 +25,6 @@ return [
         'startup_parameters' => 'Startup Parameters',
         'databases' => 'Databases',
         'edit_file' => 'Edit File',
+        'admin' => 'Manage',
     ],
 ];

--- a/resources/themes/pterodactyl/layouts/master.blade.php
+++ b/resources/themes/pterodactyl/layouts/master.blade.php
@@ -184,6 +184,13 @@
                                     </ul>
                                 </li>
                             @endif
+                            @if(Auth::user()->root_admin)
+                                <li>
+                                    <a href="{{ route('admin.servers.view', $server->id) }}">
+                                        <i class="fa fa-cog"></i> <span>@lang('navigation.server.admin')</span>
+                                    </a>
+                                </li>
+                            @endif
                         @endif
                     </ul>
                 </section>


### PR DESCRIPTION
This adds a link to the admin page of the current server to the navigation on the left.
It's currently labeled "Manage".

This is untested but should work (The daemon let me down)

resolves #696 