### PR TITLE
Fix #872 - Logo cutoff when cascaded

### DIFF
--- a/public/themes/pterodactyl/css/pterodactyl.css
+++ b/public/themes/pterodactyl/css/pterodactyl.css
@@ -456,3 +456,11 @@ label.control-label > span.field-optional:before {
 .pagination > li > a, .pagination > li > span {
     padding: 3px 10px !important;
 }
+
+body.sidebar-collapse .main-header .logo {
+    overflow: hidden;
+    text-indent: 100%;
+    background-image: url('/favicons/favicon-32x32.png');
+    background-repeat: no-repeat;
+    background-position: center;
+}


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/1296882/34921023-5098b5ac-f94a-11e7-90aa-4974a48aebd7.png)

After: 
![image](https://user-images.githubusercontent.com/1296882/34921025-54d10b9c-f94a-11e7-8f23-fefd26d6d5a9.png)

Non-cascaded: https://user-images.githubusercontent.com/1296882/34921027-5b9e41c4-f94a-11e7-8c04-c0832f1dcd4c.png

