### PR TITLE
Added 2 Vars and commonly mounted games

### DIFF
--- a/database/seeds/eggs/source-engine/egg-garrys-mod.json
+++ b/database/seeds/eggs/source-engine/egg-garrys-mod.json
@@ -3,12 +3,12 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2018-01-21T16:59:47-06:00",
+    "exported_at": "2018-02-26T19:08:48-06:00",
     "name": "Garrys Mod",
     "author": "support@pterodactyl.io",
     "description": "Garrys Mod, is a sandbox physics game created by Garry Newman, and developed by his company, Facepunch Studios.",
     "image": "quay.io\/pterodactyl\/core:source",
-    "startup": ".\/srcds_run -game garrysmod -console -port {{SERVER_PORT}} +ip 0.0.0.0 +map {{SRCDS_MAP}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}}",
+    "startup": ".\/srcds_run -game garrysmod -console -port {{SERVER_PORT}} +ip 0.0.0.0 +map {{SRCDS_MAP}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}} +host_workshop_collection {{GMOD_WORKSHOP}} +gamemode {{GMOD_GM}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"gameserver Steam ID\",\r\n    \"userInteraction\": []\r\n}",
@@ -17,7 +17,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\n# Garry's Mod Installation Script\n#\n# Server Files: \/mnt\/server\napt -y update\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\n\ncd \/tmp\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\n\nmkdir -p \/mnt\/server\/steamcmd\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\ncd \/mnt\/server\/steamcmd\n\n# SteamCMD fails otherwise for some reason, even running as root.\n# This is changed at the end of the install process anyways.\nchown -R root:root \/mnt\n\nexport HOME=\/mnt\/server\n.\/steamcmd.sh +login anonymous +force_install_dir \/mnt\/server +app_update 4020 +quit\n\nmkdir -p \/mnt\/server\/.steam\/sdk32\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so",
+            "script": "#!\/bin\/bash\r\n# Garry's Mod Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napt -y update\r\napt -y --no-install-recommends install curl lib32gcc1 ca-certificates\r\n\r\ncd \/tmp\r\ncurl -sSL -o steamcmd.tar.gz http:\/\/media.steampowered.com\/installer\/steamcmd_linux.tar.gz\r\n\r\nmkdir -p \/mnt\/server\/steamcmd\r\ntar -xzvf steamcmd.tar.gz -C \/mnt\/server\/steamcmd\r\ncd \/mnt\/server\/steamcmd\r\n\r\n# SteamCMD fails otherwise for some reason, even running as root.\r\n# This is changed at the end of the install process anyways.\r\nchown -R root:root \/mnt\r\n\r\nexport HOME=\/mnt\/server\r\n.\/steamcmd.sh +login anonymous +force_install_dir \/mnt\/server +app_update 4020 +quit\r\n\r\nmkdir -p \/mnt\/server\/css\r\n.\/steamcmd.sh +login anonymous +force_install_dir \/mnt\/server\/css +app_update 232330 +quit\r\n\r\nmkdir -p \/mnt\/server\/tf2\r\n.\/steamcmd.sh +login anonymous +force_install_dir \/mnt\/server\/tf2 +app_update 232250 +quit\r\n\r\nmkdir -p \/mnt\/server\/.steam\/sdk32\r\ncp -v linux32\/steamclient.so ..\/.steam\/sdk32\/steamclient.so",
             "container": "ubuntu:16.04",
             "entrypoint": "bash"
         }
@@ -40,6 +40,24 @@
             "user_viewable": 1,
             "user_editable": 1,
             "rules": "required|string|alpha_num|size:32"
+        },
+        {
+            "name": "Workshop Collection",
+            "description": "Dedicated servers can install addons straight from workshop collections, but it requires an addition to the startup parameter. The server will download the collection at startup.",
+            "env_variable": "GMOD_WORKSHOP",
+            "default_value": "",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "numeric"
+        },
+        {
+            "name": "Gamemode",
+            "description": "Default gamemode the server should run on startup",
+            "env_variable": "GMOD_GM",
+            "default_value": "sandbox",
+            "user_viewable": 1,
+            "user_editable": 1,
+            "rules": "required|string|max:50"
         }
     ]
 }


### PR DESCRIPTION
Added 2 new extremely common vars used in the startup command and 2 extremely common mounted games for Garry's Mod.

Vars:

Workshop Collection (This is not a required var, ignored if blank. Almost always used and should be added)
Gamemode (Almost ALWAYS used and should be added)

Games commonly mounted:
Counter-Strike Source (Every server has this mounted [99.9999%])
Team Fortress 2 (Almost every server has this mounted [99.9%])

Despite taking up space, they are almost 100% always added and 99.9% of the time, disk space is never an issue. Without having them in the install script, it'll force non-technical users to find workarounds with the startup script to try to download these 2 commonly mounted games. By adding them to the install script, they can avoid messing up the server.

Install has been verified on my server multiple times and no errors presented. 