### PR TITLE
Improve the Vagrantfile a little

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,6 @@ Vagrant.configure("2") do |config|
     config.vm.network :forwarded_port, guest: 3306, host: 53306
 
     # Config for the vagrant-dns plugin (https://github.com/BerlinVagrant/vagrant-dns)
-    config.dns.tld = "app"
-    config.dns.patterns = [/^pterodactyl.app$/]
+    config.dns.tld = "test"
+    config.dns.patterns = [/^pterodactyl.test$/]
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/xenial64"
+    config.vm.box = "bento/ubuntu-16.04"
 
     config.vm.synced_folder "./", "/var/www/html/pterodactyl",
         owner: "www-data", group: "www-data"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,10 +4,6 @@ Vagrant.configure("2") do |config|
     config.vm.synced_folder "./", "/var/www/html/pterodactyl",
         owner: "www-data", group: "www-data"
 
-    #config.vm.provision :file, source: ".dev/vagrant/pterdactyl.conf", destination: "/etc/nginx/sites-available/pterodactyl.conf"
-    #config.vm.provision :file, source: ".dev/vagrant/pteroq.service", destination: "/etc/systemd/system/pteroq.service"
-    #config.vm.provision :file, source: ".dev/vagrant/mailhog.service", destination: "/etc/systemd/system/mailhog.service"
-    #config.vm.provision :file, source: ".dev/vagrant/.env", destination: "/var/www/html/pterodactyl/.env"
     config.vm.provision :shell, path: ".dev/vagrant/provision.sh"
 
     config.vm.network :private_network, ip: "192.168.50.2"


### PR DESCRIPTION
Now using a Vagrant guidelines compliant image, not the official one from ubuntu (they use a user called "ubuntu" instead of "vagrant" for example)

Also now using a .test top level domain for the vagrant dns plugin as Google bought the .app domain and are enforcing HTTPS on it (annoying for development). The .test TLD is protected for testing and development.