### PR TITLE
Added cast for 'public' field

### DIFF
--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -48,6 +48,7 @@ class Node extends Model implements CleansAttributes, ValidableContract
         'daemonListen' => 'integer',
         'daemonSFTP' => 'integer',
         'behind_proxy' => 'boolean',
+        'public' => 'boolean',
     ];
 
     /**


### PR DESCRIPTION
The missing cast was resulting in the API to send a 0 or 1 instead of true or false for the public field