### PR TITLE
Fix cron jobs by removing the extra unusable argument

### DIFF
--- a/app/Services/Schedules/ProcessScheduleService.php
+++ b/app/Services/Schedules/ProcessScheduleService.php
@@ -63,7 +63,7 @@ class ProcessScheduleService
     {
         $this->repository->loadTasks($schedule);
 
-        $formattedCron = sprintf('%s %s %s * %s *',
+        $formattedCron = sprintf('%s %s %s * %s',
             $schedule->cron_minute,
             $schedule->cron_hour,
             $schedule->cron_day_of_month,

--- a/app/Services/Schedules/ScheduleCreationService.php
+++ b/app/Services/Schedules/ScheduleCreationService.php
@@ -86,7 +86,7 @@ class ScheduleCreationService
      */
     private function getCronTimestamp(array $data)
     {
-        $formattedCron = sprintf('%s %s %s * %s *',
+        $formattedCron = sprintf('%s %s %s * %s',
             array_get($data, 'cron_minute', '*'),
             array_get($data, 'cron_hour', '*'),
             array_get($data, 'cron_day_of_month', '*'),

--- a/app/Services/Schedules/ScheduleUpdateService.php
+++ b/app/Services/Schedules/ScheduleUpdateService.php
@@ -98,7 +98,7 @@ class ScheduleUpdateService
      */
     private function getCronTimestamp(array $data)
     {
-        $formattedCron = sprintf('%s %s %s * %s *',
+        $formattedCron = sprintf('%s %s %s * %s',
             array_get($data, 'cron_minute', '*'),
             array_get($data, 'cron_hour', '*'),
             array_get($data, 'cron_day_of_month', '*'),

--- a/tests/Unit/Services/Schedules/ProcessScheduleServiceTest.php
+++ b/tests/Unit/Services/Schedules/ProcessScheduleServiceTest.php
@@ -60,7 +60,7 @@ class ProcessScheduleServiceTest extends TestCase
 
         $this->repository->shouldReceive('loadTasks')->with($model)->once()->andReturn($model);
 
-        $formatted = sprintf('%s %s %s * %s *', $model->cron_minute, $model->cron_hour, $model->cron_day_of_month, $model->cron_day_of_week);
+        $formatted = sprintf('%s %s %s * %s', $model->cron_minute, $model->cron_hour, $model->cron_day_of_month, $model->cron_day_of_week);
         $this->repository->shouldReceive('update')->with($model->id, [
             'is_processing' => true,
             'next_run_at' => CronExpression::factory($formatted)->getNextRunDate(),

--- a/tests/Unit/Services/Schedules/ScheduleCreationServiceTest.php
+++ b/tests/Unit/Services/Schedules/ScheduleCreationServiceTest.php
@@ -64,7 +64,7 @@ class ScheduleCreationServiceTest extends TestCase
         $this->connection->shouldReceive('beginTransaction')->withNoArgs()->once()->andReturnNull();
         $this->repository->shouldReceive('create')->with([
             'server_id' => $server->id,
-            'next_run_at' => CronExpression::factory('* * * * * *')->getNextRunDate(),
+            'next_run_at' => CronExpression::factory('* * * * *')->getNextRunDate(),
             'test_key' => 'value',
         ])->once()->andReturn($schedule);
         $this->connection->shouldReceive('commit')->withNoArgs()->once()->andReturnNull();
@@ -85,7 +85,7 @@ class ScheduleCreationServiceTest extends TestCase
         $this->connection->shouldReceive('beginTransaction')->withNoArgs()->once()->andReturnNull();
         $this->repository->shouldReceive('create')->with([
             'server_id' => $server->id,
-            'next_run_at' => CronExpression::factory('* * * * * *')->getNextRunDate(),
+            'next_run_at' => CronExpression::factory('* * * * *')->getNextRunDate(),
             'test_key' => 'value',
         ])->once()->andReturn($schedule);
 

--- a/tests/Unit/Services/Schedules/ScheduleUpdateServiceTest.php
+++ b/tests/Unit/Services/Schedules/ScheduleUpdateServiceTest.php
@@ -64,7 +64,7 @@ class ScheduleUpdateServiceTest extends TestCase
 
         $this->connection->shouldReceive('beginTransaction')->once()->withNoArgs();
         $this->repository->shouldReceive('update')->once()->with($schedule->id, array_merge($data, [
-            'next_run_at' => CronExpression::factory('1 2 3 * 4 *')->getNextRunDate(),
+            'next_run_at' => CronExpression::factory('1 2 3 * 4')->getNextRunDate(),
         ]))->andReturn($schedule);
 
         $this->taskRepository->shouldReceive('deleteWhere')->once()->with([['schedule_id', '=', $schedule->id]]);


### PR DESCRIPTION
In Laravel 5.5 this simply errors out silently: https://github.com/laravel/framework/issues/23092

