### PR TITLE
Fixed 500 error on POST /api/application/nodes

### DIFF
--- a/app/Http/Requests/Api/Application/Nodes/StoreNodeRequest.php
+++ b/app/Http/Requests/Api/Application/Nodes/StoreNodeRequest.php
@@ -74,7 +74,6 @@ class StoreNodeRequest extends ApplicationApiRequest
         $response = parent::validated();
         $response['daemonListen'] = $response['daemon_listen'];
         $response['daemonSFTP'] = $response['daemon_sftp'];
-        $response['daemonBase'] = $response['daemon_base'];
 
         unset($response['daemon_base'], $response['daemon_listen'], $response['daemon_sftp']);
 


### PR DESCRIPTION
Line 77 is not needed as daemon_base does not exist because the API still takes the daemon base parameter as ```daemonBase``` NOT ```daemon_base```.