### PR TITLE
Warn users about uploading folders not working and resolve #599

### DIFF
--- a/public/themes/pterodactyl/js/frontend/files/upload.js
+++ b/public/themes/pterodactyl/js/frontend/files/upload.js
@@ -61,6 +61,18 @@
         event.preventDefault();
     }, false);
 
+    window.foldersDetectedInDrag = function (event) {
+        var folderDetected = false;
+        var files = event.dataTransfer.files;
+        for (var i = 0, f; f = files[i]; i++) {
+            if (!f.type && f.size === 0) {
+                return true;
+            }
+        }
+
+        return folderDetected;
+    };
+
     var dropCounter = 0;
     $('#load_files').bind({
         dragenter: function (event) {
@@ -75,6 +87,15 @@
             }
         },
         drop: function (event) {
+            if (window.foldersDetectedInDrag(event.originalEvent)) {
+                $.notify({
+                    message: 'Folder uploads are not supported. Please use SFTP to upload whole directories.',
+                }, {
+                    type: 'warning',
+                    delay: 0
+                });
+            }
+
             dropCounter = 0;
             $(this).removeClass('hasFileHover');
         }


### PR DESCRIPTION
The reason that this is a warning is because it's technically impossible to tell if the dragged item is a file or a folder: https://stackoverflow.com/questions/25016442/how-to-distinguish-if-a-file-or-folder-is-being-dragged-prior-to-it-being-droppe

The best bet is to check for a size of 0 and no extension. However this would still allow people to drop empty extensionless files if wanted.

[[meta] Chrome History, I have now mastered Drag + Dropz](https://user-images.githubusercontent.com/1296882/40645151-7f568c94-62f3-11e8-81ef-daacc71f4484.png)
