### PR TITLE
Fix environment_variables name

### DIFF
--- a/app/Services/Servers/EnvironmentService.php
+++ b/app/Services/Servers/EnvironmentService.php
@@ -78,7 +78,7 @@ class EnvironmentService
         }
 
         // Process variables set in the configuration file.
-        foreach ($this->config->get('pterodactyl.environment_mappings', []) as $key => $object) {
+        foreach ($this->config->get('pterodactyl.environment_variables', []) as $key => $object) {
             if (is_callable($object)) {
                 $variables[$key] = call_user_func($object, $server);
             } else {

--- a/tests/Unit/Services/Servers/EnvironmentServiceTest.php
+++ b/tests/Unit/Services/Servers/EnvironmentServiceTest.php
@@ -12,7 +12,7 @@ use Pterodactyl\Contracts\Repository\ServerRepositoryInterface;
 
 class EnvironmentServiceTest extends TestCase
 {
-    const CONFIG_MAPPING = 'pterodactyl.environment_mappings';
+    const CONFIG_MAPPING = 'pterodactyl.environment_variables';
 
     /**
      * @var \Illuminate\Contracts\Config\Repository|\Mockery\Mock


### PR DESCRIPTION
config/pterodactyl.php defines "environment_variables", while "environment_mappings" is then used in the app. I think environment_variables is a better name and should be used.