### PR TITLE
Treat white space in terminal output as preformatted...

### DIFF
--- a/public/themes/pterodactyl/css/terminal.css
+++ b/public/themes/pterodactyl/css/terminal.css
@@ -26,6 +26,7 @@
 
 #terminal > .cmd {
     padding: 1px 0;
+    white-space: pre;
 }
 
 #terminal_input {


### PR DESCRIPTION
I'm suggesting this change so any apps that use ascii art/other formatting will appear the same in pterodactyl panel as they do in a linux terminal or windows command prompt.

For example, an application I'm developing running on windows:

![command-prompt](http://www.ascensiongamedev.com/resources/filehost/249e830da66b2be5bd95a9aa44f7f84a.png)


The same application being viewed within pterodactyl:

![panel-current](http://www.ascensiongamedev.com/resources/filehost/46b52f9ac0412d85561962cfcd29bec6.png)


With this simple css modification:

![panel-fixed](http://www.ascensiongamedev.com/resources/filehost/6fee30828d7d9bbd82f1de5430db33ce.png)


