### PR TITLE
Use appropiate infinity signs

### DIFF
--- a/resources/themes/pterodactyl/admin/nodes/view/servers.blade.php
+++ b/resources/themes/pterodactyl/admin/nodes/view/servers.blade.php
@@ -57,7 +57,7 @@
                             <td><a href="{{ route('admin.servers.view', $server->id) }}">{{ $server->name }}</a></td>
                             <td><a href="{{ route('admin.users.view', $server->owner_id) }}">{{ $server->user->username }}</a></td>
                             <td>{{ $server->nest->name }} ({{ $server->egg->name }})</td>
-                            <td class="text-center"><span data-action="memory">NaN</span> / {{ $server->memory === 0 ? '&infin;' : $server->memory }} MB</td>
+                            <td class="text-center"><span data-action="memory">NaN</span> / {{ $server->memory === 0 ? '∞' : $server->memory }} MB</td>
                             <td class="text-center">{{ $server->disk }} MB</td>
                             <td class="text-center"><span data-action="cpu" data-cpumax="{{ $server->cpu }}">NaN</span> %</td>
                             <td class="text-center" data-action="status">NaN</td>

--- a/resources/themes/pterodactyl/base/index.blade.php
+++ b/resources/themes/pterodactyl/base/index.blade.php
@@ -53,7 +53,7 @@
                                 <td><a href="{{ route('server.index', $server->uuidShort) }}">{{ $server->name }}</a></td>
                                 <td>{{ $server->getRelation('node')->name }}</td>
                                 <td><code>{{ $server->getRelation('allocation')->alias }}:{{ $server->getRelation('allocation')->port }}</code></td>
-                                <td class="text-center hidden-sm hidden-xs"><span data-action="memory">--</span> / {{ $server->memory === 0 ? '&infin;' : $server->memory }} MB</td>
+                                <td class="text-center hidden-sm hidden-xs"><span data-action="memory">--</span> / {{ $server->memory === 0 ? '∞' : $server->memory }} MB</td>
                                 <td class="text-center hidden-sm hidden-xs"><span data-action="cpu" data-cpumax="{{ $server->cpu }}">--</span> %</td>
                                 <td class="text-center">
                                     @if($server->user->id === Auth::user()->id)

--- a/resources/themes/pterodactyl/server/databases/index.blade.php
+++ b/resources/themes/pterodactyl/server/databases/index.blade.php
@@ -87,7 +87,7 @@
                 @if($overLimit)
                     <div class="box-body">
                         <div class="alert alert-danger no-margin">
-                            You are currently using <strong>{{ count($databases) }}</strong> of your <strong>{{ $server->database_limit ?? '&infin;' }}</strong> allowed databases.
+                            You are currently using <strong>{{ count($databases) }}</strong> of your <strong>{{ $server->database_limit ?? '∞' }}</strong> allowed databases.
                         </div>
                     </div>
                 @else


### PR DESCRIPTION
This should fix a problem occuring in
 `Chrome 67.0.3396.99 (Official Build) (64-bit) (cohort: Stable)`

Difference: Using the unicode symbol and the HTML symbol
![image](https://user-images.githubusercontent.com/30688640/43459959-7693ab88-94cf-11e8-8686-2501dc7b537c.png)
