### PR TITLE
Simple query exception logging

### DIFF
--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -78,7 +78,7 @@ class SettingsServiceProvider extends ServiceProvider
                 return [$setting->key => $setting->value];
             })->toArray();
         } catch (QueryException $exception) {
-            $log->notice('A query exception was encountered while trying to load settings from the database.');
+            $log->notice('A query exception was encountered while trying to load settings from the database: ' . $exception->getMessage());
 
             return;
         }


### PR DESCRIPTION
Right now, we drop the exception encountered during boot() of the SettingsServiceProvider. This leads to a mostly unhelpful message. I have added `$exception->getMessage()` to the message logged to the Laravel logs.