### PR TITLE
Fix "installed" server update

### DIFF
--- a/app/Http/Controllers/Daemon/ActionController.php
+++ b/app/Http/Controllers/Daemon/ActionController.php
@@ -53,7 +53,7 @@ class ActionController extends Controller
 
         Server::where('id', $server->id)
             ->update([
-                'installed' => ($status === 'installed') ? 1 : 2
+                'installed' => ($status === 'installed') ? 1 : 2,
             ]);
 
         // Only fire event if server installed successfully.

--- a/app/Http/Controllers/Daemon/ActionController.php
+++ b/app/Http/Controllers/Daemon/ActionController.php
@@ -51,8 +51,10 @@ class ActionController extends Controller
             ], 403);
         }
 
-        $server->installed = ($status === 'installed') ? 1 : 2;
-        $server->save();
+        Server::where('id', $server->id)
+            ->update([
+                'installed' => ($status === 'installed') ? 1 : 2
+            ]);
 
         // Only fire event if server installed successfully.
         if ($server->installed === 1) {

--- a/resources/themes/pterodactyl/admin/servers/index.blade.php
+++ b/resources/themes/pterodactyl/admin/servers/index.blade.php
@@ -59,10 +59,12 @@
                                 <td class="text-center">
                                     @if($server->suspended)
                                         <span class="label bg-maroon">Suspended</span>
-                                    @elseif(! $server->installed)
+                                    @elseif($server->installed === 0)
                                         <span class="label label-warning">Installing</span>
-                                    @else
+                                    @elseif($server->installed === 1)
                                         <span class="label label-success">Active</span>
+                                    @elseif($server->installed === 2)
+                                        <span class="label label-danger">Install Failed</span>
                                     @endif
                                 </td>
                                 <td class="text-center">


### PR DESCRIPTION
Currently, the daemon POSTs "installed" or "error" to `/daemon/install` on the panel. However, for some reason the `$server->save()` in the current code does not cause a SQL update to occur, and thus the install is stuck as "installing" even though the daemon has called back to report success or failure. I issue the update a slightly different way which does cause a SQL update.