### PR TITLE
Update terminal.css

### DIFF
--- a/public/themes/pterodactyl/css/terminal.css
+++ b/public/themes/pterodactyl/css/terminal.css
@@ -26,6 +26,7 @@
 
 #terminal > .cmd {
     padding: 1px 0;
+    word-wrap: break-word;
 }
 
 #terminal_input {


### PR DESCRIPTION
Fix for some terminal output not being wrapped properly on mobile
e.g.
overflow-x: auto; just to show 
`ServerLog: [FAdmin] prop_physics(models/props_building_details/storefront_template001a_bars.mdl) Got removed` is not being wrapped on mobile properly https://i.imgur.com/etQyafC.png