### PR TITLE
Escape the database name when granting permissions to it

### DIFF
--- a/app/Repositories/Eloquent/DatabaseRepository.php
+++ b/app/Repositories/Eloquent/DatabaseRepository.php
@@ -154,7 +154,7 @@ class DatabaseRepository extends EloquentRepository implements DatabaseRepositor
     {
         return $this->run(sprintf(
             'GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, INDEX, EXECUTE ON `%s`.* TO `%s`@`%s`',
-            $database,
+            str_replace(array('_', '%'), array('\\_', '\\%'), $database),
             $username,
             $remote
         ));


### PR DESCRIPTION
These should be escaped as MySQL may take them in a different way than it should, specially the underscore.