### PR TITLE
Match original database password length when doing a password reset

### DIFF
--- a/app/Http/Controllers/Admin/ServersController.php
+++ b/app/Http/Controllers/Admin/ServersController.php
@@ -599,7 +599,7 @@ class ServersController extends Controller
             ['id', '=', $request->input('database')],
         ]);
 
-        $this->databasePasswordService->handle($database, str_random(20));
+        $this->databasePasswordService->handle($database, str_random(16));
 
         return response('', 204);
     }

--- a/app/Http/Controllers/Server/DatabaseController.php
+++ b/app/Http/Controllers/Server/DatabaseController.php
@@ -142,7 +142,7 @@ class DatabaseController extends Controller
     {
         $this->authorize('reset-db-password', $request->attributes->get('server'));
 
-        $password = str_random(20);
+        $password = str_random(16);
         $this->passwordService->handle($request->attributes->get('database'), $password);
 
         return response()->json(['password' => $password]);


### PR DESCRIPTION
When creating a new database the password length is 16, but when performing a password reset, the new password is created with a length of 20 characters. While I'm not sure if this was done on purpose, this PR matches the 16 character length on password resets for consistency. 