### PR TITLE
More correct link to connect nodes

### DIFF
--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -191,7 +191,7 @@ class Node extends Model implements CleansAttributes, ValidableContract
                 'count' => 3,
             ],
             'remote' => [
-                'base' => route('index'),
+                'base' => config('app.url'),
             ],
             'uploads' => [
                 'size_limit' => $this->upload_size,


### PR DESCRIPTION
Some developers can change the routes at their discretion, but the connection always goes to the root