### PR TITLE
make source eggs use SERVER_IP instead of 0.0.0.0

### DIFF
--- a/database/seeds/eggs/source-engine/egg-custom-source-engine-game.json
+++ b/database/seeds/eggs/source-engine/egg-custom-source-engine-game.json
@@ -8,7 +8,7 @@
     "author": "support@pterodactyl.io",
     "description": "This option allows modifying the startup arguments and other details to run a custom SRCDS based game on the panel.",
     "image": "quay.io\/pterodactyl\/core:source",
-    "startup": ".\/srcds_run -game {{SRCDS_GAME}} -console -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +ip 0.0.0.0 -strictportbind -norestart",
+    "startup": ".\/srcds_run -game {{SRCDS_GAME}} -console -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +ip {{SERVER_IP}} -strictportbind -norestart",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"gameserver Steam ID\",\r\n    \"userInteraction\": []\r\n}",


### PR DESCRIPTION
This should be applied to all source egg instances that use +ip 0.0.0.0