### PR TITLE
<code></code> was displaying in plain text - password requirements

### DIFF
--- a/resources/lang/de/base.php
+++ b/resources/lang/de/base.php
@@ -25,7 +25,7 @@ return [
         'update_identity' => 'Konto bearbeiten',
         'update_pass' => 'Passwort ändern',
         'update_user' => 'Benutzer aktualisieren',
-        'username_help' => 'Dein Benutzername muss für dein Konto einzigartig sein und darf nur die folgenden Zeichen enthalten: :requirements.',
+        'username_help' => 'Dein Benutzername muss für dein Konto einzigartig sein und darf nur die folgenden Zeichen enthalten: ',
     ],
     'api' => [
         'index' => [

--- a/resources/lang/en/base.php
+++ b/resources/lang/en/base.php
@@ -68,7 +68,7 @@ return [
         'first_name' => 'First Name',
         'last_name' => 'Last Name',
         'update_identity' => 'Update Identity',
-        'username_help' => 'Your username must be unique to your account, and may only contain the following characters: :requirements.',
+        'username_help' => 'Your username must be unique to your account, and may only contain the following characters: ',
         'language' => 'Language',
     ],
     'security' => [

--- a/resources/lang/es/base.php
+++ b/resources/lang/es/base.php
@@ -32,7 +32,7 @@ return [
         'update_identity' => 'Actualización De La Identidad',
         'update_pass' => 'Cambiar contraseña',
         'update_user' => 'Actualizar usuario',
-        'username_help' => 'Tu nombre de usuario debe ser único, y solo puede contener estos caracteres: :requirements.',
+        'username_help' => 'Tu nombre de usuario debe ser único, y solo puede contener estos caracteres: ',
     ],
     'api' => [
         'index' => [

--- a/resources/lang/et/base.php
+++ b/resources/lang/et/base.php
@@ -29,7 +29,7 @@ return [
         'update_identitity' => 'Uuenda informatsiooni',
         'update_pass' => 'Uuenda salasõna',
         'update_user' => 'Uuenda kasutajat ',
-        'username_help' => 'Sinu kasutajanimi peab olema unikaalne sinu kasutajale ja võib ainult sisaldada järgmiseid märke: :requirements',
+        'username_help' => 'Sinu kasutajanimi peab olema unikaalne sinu kasutajale ja võib ainult sisaldada järgmiseid märke: ',
     ],
     'api' => [
         'index' => [

--- a/resources/lang/fr/base.php
+++ b/resources/lang/fr/base.php
@@ -31,7 +31,7 @@ return [
         'update_identitity' => 'Modifier les informations',
         'update_pass' => 'Modifier le mot de passe',
         'update_user' => "Modifier l'utilisateur",
-        'username_help' => "Votre nom d'utilisateur doit être unique à votre compte et ne doit être composé que des caractères suivants : :requirements.",
+        'username_help' => "Votre nom d'utilisateur doit être unique à votre compte et ne doit être composé que des caractères suivants: ",
     ],
     'api' => [
         'index' => [

--- a/resources/lang/it/base.php
+++ b/resources/lang/it/base.php
@@ -31,7 +31,7 @@ return [
         'update_identitity' => 'Aggiorna Identità',
         'update_pass' => 'Aggiorna Password',
         'update_user' => 'Aggiorna utente',
-        'username_help' => 'II tuo username deve essere unico nel tuo account, e può contenere solo i seguenti caratteri: :requisements.',
+        'username_help' => 'II tuo username deve essere unico nel tuo account, e può contenere solo i seguenti caratteri: ',
     ],
     'api' => [
         'index' => [

--- a/resources/lang/nl/base.php
+++ b/resources/lang/nl/base.php
@@ -30,7 +30,7 @@ return [
         'update_identitity' => 'Identiteit Bijwerken',
         'update_pass' => 'Wachtwoord Bijwerken',
         'update_user' => 'Gebruiker Bijwerken',
-        'username_help' => 'Uw gebruikersnaam moet uniek zijn en mag enkel de volgende characters bevatten: :requirements.',
+        'username_help' => 'Uw gebruikersnaam moet uniek zijn en mag enkel de volgende characters bevatten: ',
     ],
     'api' => [
         'index' => [

--- a/resources/lang/ro/base.php
+++ b/resources/lang/ro/base.php
@@ -29,8 +29,7 @@ return [
         'update_identitity' => 'Actualizează Identitatea',
         'update_pass' => 'Actualizează Parola',
         'update_user' => 'Actualizează Utilizator',
-        'username_help' => 'Numele tău de utilizator trebuie să fie unic contului tau, el poate conține următoarele caractere:
-:requirements.',
+        'username_help' => 'Numele tău de utilizator trebuie să fie unic contului tau, el poate conține următoarele caractere: ',
     ],
     'api' => [
         'index' => [

--- a/resources/lang/tr/base.php
+++ b/resources/lang/tr/base.php
@@ -22,7 +22,7 @@ return [
         'update_identitity' => 'Güncelle',
         'update_pass' => 'Güncelle',
         'update_user' => 'Güncelle',
-        'username_help' => 'Kullanıcı adınız hesabınıza özgün olmalı ve belirtilen karakterleri barındırmalıdır. :requirements.',
+        'username_help' => 'Kullanıcı adınız hesabınıza özgün olmalı ve belirtilen karakterleri barındırmalıdır. ',
     ],
     'api' => [
         'index' => [

--- a/resources/lang/zh/base.php
+++ b/resources/lang/zh/base.php
@@ -68,7 +68,7 @@ return [
         'first_name' => '姓',
         'last_name' => '名',
         'update_identity' => '更新个人信息',
-        'username_help' => '您的用户名必须唯一（未被使用），并满足以下要求: :requirements.',
+        'username_help' => '您的用户名必须唯一（未被使用），并满足以下要求: ',
     ],
     'security' => [
         'session_mgmt_disabled' => '为了安全原因，您的此次会话无法访问用户管理.',

--- a/resources/themes/pterodactyl/base/account.blade.php
+++ b/resources/themes/pterodactyl/base/account.blade.php
@@ -86,7 +86,7 @@
                                     <label for="password" class="control-label">@lang('strings.username')</label>
                                     <div>
                                         <input type="text" class="form-control" name="username" value="{{ Auth::user()->username }}" />
-                                        <p class="text-muted small no-margin">@lang('base.account.username_help', [ 'requirements' => '<code>a-z A-Z 0-9 _ - .</code>'])</p>
+                                        <p class="text-muted small no-margin">@lang('base.account.username_help')<code>a-z A-Z 0-9 _ - .</code></p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Password requirements area was showing html tags in plain text.

Previously looked like this.
![9bjy4nc](https://user-images.githubusercontent.com/33970333/50613154-80797100-0e91-11e9-98f2-5b8ef7a7bfe8.png)
It now looks like this.
![klgpg0q](https://user-images.githubusercontent.com/33970333/50613173-925b1400-0e91-11e9-9b8c-df826fccc943.png)
