### PR TITLE
Fix an edge case where files could not be edited from the file manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This project follows [Semantic Versioning](http://semver.org) guidelines.
 * Fixes an issue with the locations API endpoint referencing an invalid namespace.
 * Fixes the `store()` function on the locations API not working due to an incorrect return typehint.
 * Fixes daemon secrets not being able to be reset on a Node.
- 
+* Fixes an issue where files were not editable due to missing URL encoding in the file manager.
+
 ### Updated
 * Upgraded core to use Laravel `5.7.14`.
 

--- a/resources/themes/pterodactyl/server/files/list.blade.php
+++ b/resources/themes/pterodactyl/server/files/list.blade.php
@@ -141,7 +141,7 @@
                     <td data-identifier="name" data-name="{{ rawurlencode($file['entry']) }}" data-path="@if($file['directory'] !== ''){{ rawurlencode($file['directory']) }}@endif/">
                         @if(in_array($file['mime'], $editableMime))
                             @can('edit-files', $server)
-                                <a href="/server/{{ $server->uuidShort }}/files/edit/@if($file['directory'] !== ''){{ $file['directory'] }}/@endif{{ $file['entry'] }}" class="edit_file">{{ $file['entry'] }}</a>
+                                <a href="/server/{{ $server->uuidShort }}/files/edit/@if($file['directory'] !== ''){{ rawurlencode($file['directory']) }}/@endif{{ rawurlencode($file['entry']) }}" class="edit_file">{{ $file['entry'] }}</a>
                             @else
                                 {{ $file['entry'] }}
                             @endcan


### PR DESCRIPTION
Due to missing URL encoding, files could not be edited in some cases where the file path contains URL characters with special meaning.  
For more details, please view the issue.
Fixes: #1450 