### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ This project follows [Semantic Versioning](http://semver.org) guidelines.
 * Fixes an issue with the locations API endpoint referencing an invalid namespace.
 * Fixes the `store()` function on the locations API not working due to an incorrect return typehint.
 * Fixes daemon secrets not being able to be reset on a Node.
- 
+* Fixes an issue where files were not editable due to missing URL encoding in the file manager.
+* Fixed checking of language changes
+* Fixed Spigot egg not building versions other than `latest`.
+* Fixed the Forge egg install script.
+
 ### Updated
 * Upgraded core to use Laravel `5.7.14`.
 


### PR DESCRIPTION
Added Pull - #1411 (Fixed checking of language changes)
Added Pull - #1419 (Fixed Spigot egg not building versions other than `latest`.)
Added Pull - #1449 (Fixed the Forge egg install script.)
Added Pull - #1451 (Fixes an issue where files were not editable due to missing URL encoding in the file manager.)

I sure it all should've been added a long time ago