### PR TITLE
Update load environment only notice

### DIFF
--- a/resources/themes/pterodactyl/partials/admin/settings/notice.blade.php
+++ b/resources/themes/pterodactyl/partials/admin/settings/notice.blade.php
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-xs-12">
                 <div class="alert alert-danger">
-                    Your Panel is currently configured to read settings from the environment only. You will need to set <code>LOAD_ENVIRONMENT_ONLY=false</code> in your environment file in order to load settings dynamically.
+                    Your Panel is currently configured to read settings from the environment only. You will need to set <code>APP_ENVIRONMENT_ONLY=false</code> in your environment file in order to load settings dynamically.
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Updates notice to reflect the correct name of the value to edit, less confusion

As its called `APP_ENVIROMENT_ONLY` and not `LOAD_ENVIROMENT_ONLY`

https://github.com/pterodactyl/panel/blob/develop/config/pterodactyl.php#L14