### PR TITLE
External modding support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
             "app/helpers.php"
         ],
         "psr-4": {
-            "Pterodactyl\\": "app/"
+            "Pterodactyl\\": "app/",
+            "Entrypoint\\": "entrypoint/"
         }
     },
     "autoload-dev": {

--- a/config/app.php
+++ b/config/app.php
@@ -184,6 +184,11 @@ return [
         Pterodactyl\Providers\ViewComposerServiceProvider::class,
 
         /*
+         * Add Entrypoint provider
+         */
+        Entrypoint\Providers\EntrypointServiceProvider::class,
+
+        /*
          * Additional Dependencies
          */
         Igaster\LaravelTheme\themeServiceProvider::class,

--- a/entrypoint/Http/Controllers/Base/IndexController.php
+++ b/entrypoint/Http/Controllers/Base/IndexController.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Entrypoint\Http\Controllers\Base;
+
+use Entrypoint\Http\Controllers\Controller;
+
+
+class IndexController extends Controller
+{
+    /**
+     * @return string
+     */
+    public function index(){
+        return 'success!';
+    }
+}

--- a/entrypoint/Http/Controllers/Base/IndexController.php
+++ b/entrypoint/Http/Controllers/Base/IndexController.php
@@ -11,7 +11,9 @@ class IndexController extends Controller
     /**
      * @return string
      */
-    public function index(){
+
+    public function index()
+    {
         return 'success!';
     }
 }

--- a/entrypoint/Http/Controllers/Controller.php
+++ b/entrypoint/Http/Controllers/Controller.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Entrypoint\Http\Controllers;
+
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
+abstract class Controller extends BaseController
+{
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+}

--- a/entrypoint/Providers/EntrypointServiceProvider.php
+++ b/entrypoint/Providers/EntrypointServiceProvider.php
@@ -40,10 +40,10 @@ class EntrypointServiceProvider extends ServiceProvider
 
         /*
          * Example of an extension of the base routes.
+         * Route::middleware(['web', 'auth', 'csrf'])
+            ->namespace($this->namespace . '\Base')
+            ->group(base_path('routes/entrypoint/base.php'));
          */
-//        Route::middleware(['web', 'auth', 'csrf'])
-//            ->namespace($this->namespace . '\Base')
-//            ->group(base_path('routes/entrypoint/base.php'));
     }
 
 }

--- a/entrypoint/providers/EntrypointServiceProvider.php
+++ b/entrypoint/providers/EntrypointServiceProvider.php
@@ -9,8 +9,8 @@
 
 namespace Entrypoint\Providers;
 
-use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 
 class EntrypointServiceProvider extends ServiceProvider
 {
@@ -22,8 +22,7 @@ class EntrypointServiceProvider extends ServiceProvider
      * @var string
      */
     protected $namespace = 'Entrypoint\Http\Controllers';
-
-
+    
     /**
      * Define the routes for the application.
      */
@@ -33,13 +32,13 @@ class EntrypointServiceProvider extends ServiceProvider
     }
 
     /**
-     *
      * This is the main entry-point to introduce new route files into pterodactyl. This is the cleanest way to add without introducing vendor packages.
      * @return void
      */
     protected function mapEntrypointRoutes()
     {
-        /**
+
+        /*
          * Example of an extension of the base routes.
          */
 //        Route::middleware(['web', 'auth', 'csrf'])

--- a/entrypoint/providers/EntrypointServiceProvider.php
+++ b/entrypoint/providers/EntrypointServiceProvider.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: atlas
+ * Date: 3/13/2019
+ * Time: 4:01 AM
+ */
+
+namespace Entrypoint\Providers;
+
+
+class EntrypointServiceProvider
+{
+    /**
+     * This namespace is applied to the controller routes in your routes file.
+     *
+     * This is a custom namespace that you can change yourself to fit your needs.
+     *
+     * @var string
+     */
+    protected $namespace = 'Entrypoint\Http\Controllers';
+
+
+    /**
+     * Define the routes for the application.
+     */
+    public function map()
+    {
+        $this->mapEntrypointRoutes();
+    }
+
+    /**
+     *
+     * This is the main entrypoint to introduce new route files into pterodactyl. This is the cleanest way to add without introducing vendor packages.
+     * @return void
+     */
+    protected function mapEntrypointRoutes()
+    {
+        /**
+         * Example of an extension of the base routes.
+         */
+//        Route::middleware(['web', 'auth', 'csrf'])
+//            ->namespace($this->namespace . '\Base')
+//            ->group(base_path('routes/entrypoint/base.php'));
+    }
+
+}

--- a/entrypoint/providers/EntrypointServiceProvider.php
+++ b/entrypoint/providers/EntrypointServiceProvider.php
@@ -34,7 +34,7 @@ class EntrypointServiceProvider extends ServiceProvider
 
     /**
      *
-     * This is the main entrypoint to introduce new route files into pterodactyl. This is the cleanest way to add without introducing vendor packages.
+     * This is the main entry-point to introduce new route files into pterodactyl. This is the cleanest way to add without introducing vendor packages.
      * @return void
      */
     protected function mapEntrypointRoutes()

--- a/entrypoint/providers/EntrypointServiceProvider.php
+++ b/entrypoint/providers/EntrypointServiceProvider.php
@@ -22,7 +22,7 @@ class EntrypointServiceProvider extends ServiceProvider
      * @var string
      */
     protected $namespace = 'Entrypoint\Http\Controllers';
-    
+
     /**
      * Define the routes for the application.
      */

--- a/entrypoint/providers/EntrypointServiceProvider.php
+++ b/entrypoint/providers/EntrypointServiceProvider.php
@@ -1,15 +1,18 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: atlas
- * Date: 3/13/2019
- * Time: 4:01 AM
+ * Pterodactyl - Panel
+ * Copyright (c) 2015 - 2017 Dane Everitt <dane@daneeveritt.com>.
+ *
+ * This software is licensed under the terms of the MIT license.
+ * https://opensource.org/licenses/MIT
  */
 
 namespace Entrypoint\Providers;
 
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
 
-class EntrypointServiceProvider
+class EntrypointServiceProvider extends ServiceProvider
 {
     /**
      * This namespace is applied to the controller routes in your routes file.

--- a/routes/entrypoint/base.php
+++ b/routes/entrypoint/base.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Pterodactyl - Panel
+ * Copyright (c) 2015 - 2017 Dane Everitt <dane@daneeveritt.com>.
+ *
+ * This software is licensed under the terms of the MIT license.
+ * https://opensource.org/licenses/MIT
+ */
+
+/*
+ * This is a basic example of how extension can work, as laravel will automatically add extra routes to an existing group without hassle.
+ */
+
+//Route::get('/example', 'IndexController@Index')->name('index.example');


### PR DESCRIPTION
Pterodactyl currently doesn't provide any easy way to add modding support or extending without editing core files. This feature gives users their own namespace, provider, and route examples. This PR gives the user options to make future mods for their own projects while still being able to keep up to date with Pterodactyl with little to no hassle.