### PR TITLE
Reset Passcode (Missing 500.blade.php) issue fix

### DIFF
--- a/resources/themes/pterodactyl/errors/500.blade.php
+++ b/resources/themes/pterodactyl/errors/500.blade.php
@@ -1,0 +1,26 @@
+{{-- Pterodactyl - Panel --}}
+{{-- Copyright (c) 2015 - 2017 Dane Everitt <dane@daneeveritt.com> --}}
+
+{{-- This software is licensed under the terms of the MIT license. --}}
+{{-- https://opensource.org/licenses/MIT --}}
+@extends('layouts.error')
+
+@section('title')
+    HTTP 500 ERROR
+@endsection
+
+@section('content-header')
+@endsection
+
+@section('content')
+<div class="row">
+    <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-12">
+        <div class="box box-danger">
+            <div class="box-body text-center">
+                <h1 class="text-red" style="font-size: 160px !important;font-weight: 100 !important;">500</h1>
+                <p class="text-muted">Whoops! Something went wrong.</p>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
I had an issue with my reset passcode functionality where it wouldn't send any email or something without a 500.blade.php file. This will help people who are having the same issue. This pull request is related to #1521.

Note: This is a specific issue that happened to me, I noticed others were having the same issue so this would fix most people's issue. For those who aren't experiencing this issue won't do anything. 