### PR TITLE
Change Console Chart yAxes to start at 0 and calculate maximum depending on server config

### DIFF
--- a/public/themes/pterodactyl/js/frontend/console.js
+++ b/public/themes/pterodactyl/js/frontend/console.js
@@ -301,6 +301,13 @@ $(document).ready(function () {
                 },
                 animation: {
                     duration: 1,
+                },
+                scales: {
+                    yAxes: [{
+                        ticks: {
+                            beginAtZero: true
+                        }
+                    }]
                 }
             }
         });
@@ -346,6 +353,13 @@ $(document).ready(function () {
                 },
                 animation: {
                     duration: 1,
+                },
+                scales: {
+                    yAxes: [{
+                        ticks: {
+                            beginAtZero: true
+                        }
+                    }]
                 }
             }
         });

--- a/public/themes/pterodactyl/js/frontend/console.js
+++ b/public/themes/pterodactyl/js/frontend/console.js
@@ -258,8 +258,10 @@ $(document).ready(function () {
 
             // memory.cmax is the maximum given by the container
             // memory.amax is given by the json config
-            // Use memory.cmax here because memory.amax can be smaller than memory.total
-            MemoryChart.config.options.scales.yAxes[0].ticks.max = proc.data.memory.cmax / (1000 * 1000);
+            // use the maximum of both
+            // with no limit memory.cmax will always be higher
+            // but with limit memory.amax is sometimes still smaller than memory.total
+            MemoryChart.config.options.scales.yAxes[0].ticks.max = Math.max(proc.data.memory.cmax, proc.data.memory.amax) / (1000 * 1000);
 
             if (Pterodactyl.server.cpu > 0) {
                 // if there is a cpu limit defined use 100% as maximum

--- a/public/themes/pterodactyl/js/frontend/console.js
+++ b/public/themes/pterodactyl/js/frontend/console.js
@@ -255,6 +255,29 @@ $(document).ready(function () {
 
             TimeLabels.push($.format.date(new Date(), 'HH:mm:ss'));
 
+
+            // memory.cmax is the maximum given by the container
+            // memory.amax is given by the json config
+            // Use memory.cmax here because memory.amax can be smaller than memory.total
+            MemoryChart.config.options.scales.yAxes[0].ticks.max = proc.data.memory.cmax / (1000 * 1000);
+
+            if (Pterodactyl.server.cpu > 0) {
+                // if there is a cpu limit defined use 100% as maximum
+                CPUChart.config.options.scales.yAxes[0].ticks.max = 100;
+            } else {
+                // if there is no cpu limit defined use linux percentage
+                // and find maximum in all values
+                var maxCpu = 1;
+                for(var i = 0; i < CPUData.length; i++) {
+                    maxCpu = Math.max(maxCpu, parseFloat(CPUData[i]))
+                }
+
+                maxCpu = Math.ceil(maxCpu / 100) * 100;
+                CPUChart.config.options.scales.yAxes[0].ticks.max = maxCpu;
+            }
+
+
+
             CPUChart.update();
             MemoryChart.update();
         });


### PR DESCRIPTION
Neither the cpu chart nor the memory chart use a minimum/maximum for the yAxes values.  
This results in the memory chart having +/-2MB of the servers memory and the cpu chart having negative values.