### PR TITLE
Possible fix for allocation creation issue (#1568).

### DIFF
--- a/app/Http/Requests/Api/Application/Allocations/StoreAllocationRequest.php
+++ b/app/Http/Requests/Api/Application/Allocations/StoreAllocationRequest.php
@@ -40,7 +40,7 @@ class StoreAllocationRequest extends ApplicationApiRequest
         return [
             'allocation_ip' => $data['ip'],
             'allocation_ports' => $data['ports'],
-            'allocation_alias' => $data['alias'],
+            'allocation_alias' => $data['alias'] !== null ? $data['alias'] : null,
         ];
     }
 }

--- a/app/Services/Allocations/AssignmentService.php
+++ b/app/Services/Allocations/AssignmentService.php
@@ -86,7 +86,7 @@ class AssignmentService
                             'node_id' => $node->id,
                             'ip' => $ip->__toString(),
                             'port' => (int) $unit,
-                            'ip_alias' => array_get($data, 'allocation_alias'),
+                            'ip_alias' => array_get($data, 'allocation_alias', null),
                             'server_id' => null,
                         ];
                     }
@@ -99,7 +99,7 @@ class AssignmentService
                         'node_id' => $node->id,
                         'ip' => $ip->__toString(),
                         'port' => (int) $port,
-                        'ip_alias' => array_get($data, 'allocation_alias'),
+                        'ip_alias' => array_get($data, 'allocation_alias', null),
                         'server_id' => null,
                     ];
                 }


### PR DESCRIPTION
Now, it's only a hunch...so if someone could replicate it that would be wonderful since I don't have a full setup with the panel/daemon that I could test on.

I noticed that when validating the request it doesn't actually require the IP alias, but it's setting the allocation alias when it's passing it along. Based on the log, it's failing at the request point because it's trying to set the variable `allocation_alias` with a value from the data array when it doesn't exist. So I've added a quick check with the request and a default on the service as well. So if something fails anywhere...it's default to `null`.

Reference issue #1568 