### PR TITLE
Fix the wrong field being ticket for allocation input on node settings (#1549)

### DIFF
--- a/resources/themes/pterodactyl/admin/nodes/view/settings.blade.php
+++ b/resources/themes/pterodactyl/admin/nodes/view/settings.blade.php
@@ -67,8 +67,8 @@
                     <div class="form-group col-xs-12">
                         <label for="public" class="control-label">Allow Automatic Allocation <sup><a data-toggle="tooltip" data-placement="top" title="Allow automatic allocation to this Node?">?</a></sup></label>
                         <div>
-                            <input type="radio" name="public" value="1" {{ (old('public', $node->public) === '1') ? 'checked' : '' }} id="public_1" checked> <label for="public_1" style="padding-left:5px;">Yes</label><br />
-                            <input type="radio" name="public" value="0" {{ (old('public', $node->public) === '0') ? 'checked' : '' }} id="public_0"> <label for="public_0" style="padding-left:5px;">No</label>
+                            <input type="radio" name="public" value="1" {{ (old('public', $node->public)) ? 'checked' : '' }} id="public_1" checked> <label for="public_1" style="padding-left:5px;">Yes</label><br />
+                            <input type="radio" name="public" value="0" {{ (old('public', $node->public)) ? '' : 'checked' }} id="public_0"> <label for="public_0" style="padding-left:5px;">No</label>
                         </div>
                     </div>
                     <div class="form-group col-xs-12">


### PR DESCRIPTION
I found that when checking just the `public` field, false is not returning `0` unless you cast it to an integer. Casting will not work properly for the way it's setup (I tried a few different combinations, just in case someone suggested it). I tested and noticed conditionals still work as expected (obviously) but since we do a strict comparison with a string, it will also result in the first item being checked.

I just changed it to a normal conditional, however...it may not work with the return of the `old` input. So we could add an or condition or remove the strict conditional checking and it could work as well, but not sure if that's the route you'd like to take. I'll update my commits accordingly depending on the decision.

Reference Issue #1549