### PR TITLE
update teamspeak egg

### DIFF
--- a/database/seeds/eggs/voice-servers/egg-teamspeak3-server.json
+++ b/database/seeds/eggs/voice-servers/egg-teamspeak3-server.json
@@ -3,21 +3,21 @@
     "meta": {
         "version": "PTDL_v1"
     },
-    "exported_at": "2019-05-01T16:35:15+00:00",
+    "exported_at": "2019-07-05T11:59:29-04:00",
     "name": "Teamspeak3 Server",
     "author": "support@pterodactyl.io",
     "description": "VoIP software designed with security in mind, featuring crystal clear voice quality, endless customization options, and scalabilty up to thousands of simultaneous users.",
-    "image": "quay.io/parkervcp/pterodactyl-images:base_debian",
-    "startup": ".\/ts3server_minimal_runscript.sh default_voice_port={{SERVER_PORT}} query_port={{SERVER_PORT}}  license_accepted=1",
+    "image": "quay.io\/parkervcp\/pterodactyl-images:base_debian",
+    "startup": ".\/ts3server default_voice_port={{SERVER_PORT}} query_port={{SERVER_PORT}} filetransfer_ip=0.0.0.0 filetransfer_port={{FILE_TRANSFER}} license_accepted=1",
     "config": {
         "files": "{}",
-        "startup": "{\"done\": \"listening on 0.0.0.0:\", \"userInteraction\": []}",
-        "logs": "{\"custom\": true, \"location\": \"logs\/ts3.log\"}",
+        "startup": "{\r\n    \"done\": \"listening on 0.0.0.0:\",\r\n    \"userInteraction\": []\r\n}",
+        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/ts3.log\"\r\n}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\n# TS3 Installation Script\n#\n# Server Files: \/mnt\/server\napk update\napk add tar curl\n\ncd \/mnt\/server\n\ncurl http:\/\/dl.4players.de\/ts\/releases\/${TS_VERSION}\/teamspeak3-server_linux_amd64-${TS_VERSION}.tar.bz2 | tar xj --strip-components=1",
+            "script": "#!\/bin\/ash\r\n# TS3 Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\napk add --no-cache tar curl jq\r\n\r\nif [ -z ${TS_VERSION} ] || [ ${TS_VERSION} == latest ]; then\r\n    TS_VERSION=$(wget https:\/\/teamspeak.com\/versions\/server.json -qO - | jq -r '.linux.x86_64.version')\r\nfi\r\n\r\ncd \/mnt\/server\r\n\r\n\r\necho -e \"getting files from http:\/\/files.teamspeak-services.com\/releases\/server\/${TS_VERSION}\/teamspeak3-server_linux_amd64-${TS_VERSION}.tar.bz2\"\r\ncurl http:\/\/files.teamspeak-services.com\/releases\/server\/${TS_VERSION}\/teamspeak3-server_linux_amd64-${TS_VERSION}.tar.bz2 | tar xj --strip-components=1",
             "container": "alpine:3.9",
             "entrypoint": "ash"
         }
@@ -27,10 +27,19 @@
             "name": "Server Version",
             "description": "The version of Teamspeak 3 to use when running the server.",
             "env_variable": "TS_VERSION",
-            "default_value": "3.7.1",
+            "default_value": "latest",
             "user_viewable": 1,
             "user_editable": 1,
-            "rules": "required|regex:\/^([0-9_\\.-]{5,10})$\/"
+            "rules": "required|string|max:6"
+        },
+        {
+            "name": "File Transfer Port",
+            "description": "The Teamspeak file transfer port",
+            "env_variable": "FILE_TRANSFER",
+            "default_value": "30033",
+            "user_viewable": 1,
+            "user_editable": 0,
+            "rules": "required|integer|between:1,65535"
         }
     ]
 }


### PR DESCRIPTION
Install Script
    Update to use --no-cache for apk and add jq.
    Update to use the teamspeak file servers.
    New handler for latest release version using the teamspeak json available publicly.
New Variables
    Variable for setting the FileTransfer port
New Start command
    Use ts3server executable instead of the shell script.

This would supersede #1627 as it would replace getting versions with getting the latest.