### PR TITLE
Fix #1526 - Bulk Power

### DIFF
--- a/app/Repositories/Daemon/BaseRepository.php
+++ b/app/Repositories/Daemon/BaseRepository.php
@@ -81,6 +81,10 @@ abstract class BaseRepository implements BaseRepositoryInterface
     public function setServer(Server $server)
     {
         $this->server = $server;
+        
+        if ($this->getNode()->id !== $server->node_id) {
+            $this->setNode($this->getServer()->getRelation('node'));
+        }
 
         return $this;
     }

--- a/app/Repositories/Daemon/BaseRepository.php
+++ b/app/Repositories/Daemon/BaseRepository.php
@@ -81,7 +81,7 @@ abstract class BaseRepository implements BaseRepositoryInterface
     public function setServer(Server $server)
     {
         $this->server = $server;
-        
+
         if ($this->getNode()->id !== $server->node_id) {
             $this->setNode($this->getServer()->getRelation('node'));
         }


### PR DESCRIPTION
Upon noticing a pattern in Discord support and further conversations with Trixter in #supporters. We determined this would be a good fix for some of the issues happening when re-using the power repository over multiple nodes.

This PR makes sure that the node id that's current set is the same node id of the server being set. If it's not, it will update it. This ensure that the proper HTTP client is being passed back, which should fix #1526.