### PR TITLE
Add ALLOCATION_LIMIT to env

### DIFF
--- a/app/Services/Servers/EnvironmentService.php
+++ b/app/Services/Servers/EnvironmentService.php
@@ -105,6 +105,7 @@ class EnvironmentService
             'STARTUP' => 'startup',
             'P_SERVER_LOCATION' => 'location.short',
             'P_SERVER_UUID' => 'uuid',
+            'ALLOCATION_LIMIT' => 'allocation_limit',
         ];
     }
 }

--- a/database/seeds/eggs/source-engine/egg-counter--strike--global-offensive.json
+++ b/database/seeds/eggs/source-engine/egg-counter--strike--global-offensive.json
@@ -8,7 +8,7 @@
     "author": "support@pterodactyl.io",
     "description": "Counter-Strike: Global Offensive is a multiplayer first-person shooter video game developed by Hidden Path Entertainment and Valve Corporation.",
     "image": "quay.io\/pterodactyl\/core:source",
-    "startup": ".\/srcds_run -game csgo -console -port {{SERVER_PORT}} +ip 0.0.0.0 +map {{SRCDS_MAP}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}}",
+    "startup": ".\/srcds_run -game csgo -console -port {{SERVER_PORT}} +ip 0.0.0.0 +map {{SRCDS_MAP}} +maxplayers {{ALLOCATION_LIMIT}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Connection to Steam servers successful\",\r\n    \"userInteraction\": []\r\n}",

--- a/database/seeds/eggs/source-engine/egg-custom-source-engine-game.json
+++ b/database/seeds/eggs/source-engine/egg-custom-source-engine-game.json
@@ -8,7 +8,7 @@
     "author": "support@pterodactyl.io",
     "description": "This option allows modifying the startup arguments and other details to run a custom SRCDS based game on the panel.",
     "image": "quay.io\/pterodactyl\/core:source",
-    "startup": ".\/srcds_run -game {{SRCDS_GAME}} -console -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +ip 0.0.0.0 -strictportbind -norestart",
+    "startup": ".\/srcds_run -game {{SRCDS_GAME}} -console -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +ip 0.0.0.0 +maxplayers {{ALLOCATION_LIMIT}} -strictportbind -norestart",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"gameserver Steam ID\",\r\n    \"userInteraction\": []\r\n}",

--- a/database/seeds/eggs/source-engine/egg-garrys-mod.json
+++ b/database/seeds/eggs/source-engine/egg-garrys-mod.json
@@ -8,7 +8,7 @@
     "author": "support@pterodactyl.io",
     "description": "Garrys Mod, is a sandbox physics game created by Garry Newman, and developed by his company, Facepunch Studios.",
     "image": "quay.io\/pterodactyl\/core:source",
-    "startup": ".\/srcds_run -game garrysmod -console -port {{SERVER_PORT}} +ip 0.0.0.0 +map {{SRCDS_MAP}} +gamemode {{GAMEMODE}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}} +host_workshop_collection {{WORKSHOP_ID}} +maxplayers {{MAX_PLAYERS}}  -tickrate {{TICKRATE}}",
+    "startup": ".\/srcds_run -game garrysmod -console -port {{SERVER_PORT}} +ip 0.0.0.0 +map {{SRCDS_MAP}} +maxplayers {{ALLOCATION_LIMIT}} +gamemode {{GAMEMODE}} -strictportbind -norestart +sv_setsteamaccount {{STEAM_ACC}} +host_workshop_collection {{WORKSHOP_ID}} +maxplayers {{MAX_PLAYERS}}  -tickrate {{TICKRATE}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"gameserver Steam ID\",\r\n    \"userInteraction\": []\r\n}",

--- a/database/seeds/eggs/source-engine/egg-insurgency.json
+++ b/database/seeds/eggs/source-engine/egg-insurgency.json
@@ -8,7 +8,7 @@
     "author": "support@pterodactyl.io",
     "description": "Take to the streets for intense close quarters combat, where a team's survival depends upon securing crucial strongholds and destroying enemy supply in this multiplayer and cooperative Source Engine based experience.",
     "image": "quay.io\/pterodactyl\/core:source",
-    "startup": ".\/srcds_run -game {{SRCDS_GAME}} -console -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +ip 0.0.0.0 -strictportbind -norestart",
+    "startup": ".\/srcds_run -game {{SRCDS_GAME}} -console -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +ip 0.0.0.0 +maxplayers {{ALLOCATION_LIMIT}} -strictportbind -norestart",
     "config": {
         "files": "{}",
         "startup": "{\"done\": \"gameserver Steam ID\", \"userInteraction\": []}",

--- a/database/seeds/eggs/source-engine/egg-team-fortress2.json
+++ b/database/seeds/eggs/source-engine/egg-team-fortress2.json
@@ -8,7 +8,7 @@
     "author": "support@pterodactyl.io",
     "description": "Team Fortress 2 is a team-based first-person shooter multiplayer video game developed and published by Valve Corporation. It is the sequel to the 1996 mod Team Fortress for Quake and its 1999 remake.",
     "image": "quay.io\/pterodactyl\/core:source",
-    "startup": ".\/srcds_run -game {{SRCDS_GAME}} -console -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +ip 0.0.0.0 -strictportbind -norestart",
+    "startup": ".\/srcds_run -game {{SRCDS_GAME}} -console -port {{SERVER_PORT}} +map {{SRCDS_MAP}} +ip 0.0.0.0 +maxplayers {{ALLOCATION_LIMIT}} -strictportbind -norestart",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"gameserver Steam ID\",\r\n    \"userInteraction\": []\r\n}",

--- a/database/seeds/eggs/terraria/egg-terraria-server--t-shock.json
+++ b/database/seeds/eggs/terraria/egg-terraria-server--t-shock.json
@@ -10,7 +10,7 @@
     "image": "quay.io\/pterodactyl\/core:mono",
     "startup": null,
     "config": {
-        "files": "{\"tshock\/config.json\":{\"parser\": \"json\", \"find\":{\"ServerPort\": \"{{server.build.default.port}}\", \"MaxSlots\": \"{{server.build.env.MAX_SLOTS}}\"}}}",
+        "files": "{\"tshock\/config.json\":{\"parser\": \"json\", \"find\":{\"ServerPort\": \"{{server.build.default.port}}\", \"MaxSlots\": \"{{server.build.env.ALLOCATION_LIMIT}}\"}}}",
         "startup": "{\"done\": \"Type 'help' for a list of commands\", \"userInteraction\": []}",
         "logs": "{\"custom\": false, \"location\": \"ServerLog.txt\"}",
         "stop": "exit"
@@ -31,15 +31,6 @@
             "user_viewable": 1,
             "user_editable": 1,
             "rules": "required|regex:\/^([0-9_\\.-]{5,10})$\/"
-        },
-        {
-            "name": "Maximum Slots",
-            "description": "Total number of slots to allow on the server.",
-            "env_variable": "MAX_SLOTS",
-            "default_value": "20",
-            "user_viewable": 1,
-            "user_editable": 0,
-            "rules": "required|numeric|digits_between:1,3"
         }
     ]
 }

--- a/database/seeds/eggs/voice-servers/egg-mumble-server.json
+++ b/database/seeds/eggs/voice-servers/egg-mumble-server.json
@@ -10,7 +10,7 @@
     "image": "quay.io\/pterodactyl\/core:glibc",
     "startup": ".\/murmur.x86 -fg",
     "config": {
-        "files": "{\"murmur.ini\":{\"parser\": \"ini\", \"find\":{\"logfile\": \"murmur.log\", \"port\": \"{{server.build.default.port}}\", \"host\": \"0.0.0.0\", \"users\": \"{{server.build.env.MAX_USERS}}\"}}}",
+        "files": "{\"murmur.ini\":{\"parser\": \"ini\", \"find\":{\"logfile\": \"murmur.log\", \"port\": \"{{server.build.default.port}}\", \"host\": \"0.0.0.0\", \"users\": \"{{server.build.env.ALLOCATION_LIMIT}}\"}}}",
         "startup": "{\"done\": \"Server listening on\", \"userInteraction\": [ \"Generating new server certificate\"]}",
         "logs": "{\"custom\": true, \"location\": \"logs\/murmur.log\"}",
         "stop": "^C"
@@ -23,15 +23,6 @@
         }
     },
     "variables": [
-        {
-            "name": "Maximum Users",
-            "description": "Maximum concurrent users on the mumble server.",
-            "env_variable": "MAX_USERS",
-            "default_value": "100",
-            "user_viewable": 1,
-            "user_editable": 0,
-            "rules": "required|numeric|digits_between:1,5"
-        },
         {
             "name": "Server Version",
             "description": "Version of Mumble Server to download and use.",


### PR DESCRIPTION
Add ALLOCATION_LIMIT to environment variables and use it in servers where players/slots is usually restricted directly by host and not by allocated resources (like in the case of minecraft or rust)