### PR TITLE
Fixed RegEx validate database password

### DIFF
--- a/tests/Unit/Services/Databases/DatabasePasswordServiceTest.php
+++ b/tests/Unit/Services/Databases/DatabasePasswordServiceTest.php
@@ -60,7 +60,7 @@ class DatabasePasswordServiceTest extends TestCase
         $this->dynamic->shouldReceive('set')->with('dynamic', $model->database_host_id)->once()->andReturnNull();
 
         $this->encrypter->expects('encrypt')->with(m::on(function ($string) {
-            preg_match_all('/[!@+=^-]/', $string, $matches, PREG_SET_ORDER);
+            preg_match_all('/[!@+=.^-]/', $string, $matches, PREG_SET_ORDER);
             $this->assertTrue(count($matches) >= 2 && count($matches) <= 6, "Failed asserting that [{$string}] contains 2 to 6 special characters.");
             $this->assertTrue(strlen($string) === 24, "Failed asserting that [{$string}] is 24 characters in length.");
 

--- a/tests/Unit/Services/Databases/DatabasePasswordServiceTest.php
+++ b/tests/Unit/Services/Databases/DatabasePasswordServiceTest.php
@@ -60,7 +60,8 @@ class DatabasePasswordServiceTest extends TestCase
         $this->dynamic->shouldReceive('set')->with('dynamic', $model->database_host_id)->once()->andReturnNull();
 
         $this->encrypter->expects('encrypt')->with(m::on(function ($string) {
-            preg_match_all('/[!@+=.^-]/', $string, $matches, PREG_SET_ORDER);
+            $pattern = preg_quote(' !"#$%&\'()*+,-./:;<=>?@[\]^_`/{}|\|~', '#');
+            preg_match_all("#[{$pattern}]#", $string, $matches, PREG_SET_ORDER);
             $this->assertTrue(count($matches) >= 2 && count($matches) <= 6, "Failed asserting that [{$string}] contains 2 to 6 special characters.");
             $this->assertTrue(strlen($string) === 24, "Failed asserting that [{$string}] is 24 characters in length.");
 

--- a/tests/Unit/Services/Databases/DatabasePasswordServiceTest.php
+++ b/tests/Unit/Services/Databases/DatabasePasswordServiceTest.php
@@ -60,8 +60,7 @@ class DatabasePasswordServiceTest extends TestCase
         $this->dynamic->shouldReceive('set')->with('dynamic', $model->database_host_id)->once()->andReturnNull();
 
         $this->encrypter->expects('encrypt')->with(m::on(function ($string) {
-            $pattern = preg_quote(' !"#$%&\'()*+,-./:;<=>?@[\]^_`/{}|\|~', '#');
-            preg_match_all("#[{$pattern}]#", $string, $matches, PREG_SET_ORDER);
+            preg_match_all('/[!@+=.^-]/', $string, $matches, PREG_SET_ORDER);
             $this->assertTrue(count($matches) >= 2 && count($matches) <= 6, "Failed asserting that [{$string}] contains 2 to 6 special characters.");
             $this->assertTrue(strlen($string) === 24, "Failed asserting that [{$string}] is 24 characters in length.");
 


### PR DESCRIPTION
Failed asserting that [aIIXVo8WqAQ4uhvN.!uZtMeQ] contains 2 to 6 special characters.

Test:
```
<?php

$pattern = preg_quote(' !"#$%&\'()*+,-./:;<=>?@[\]^_`/{}|\|~', '#');

preg_match_all("#[{$pattern}]#", "aIIXVo8WqAQ4uhvN.!uZtMeQ", $matches, PREG_SET_ORDER);
var_dump(count($matches));
var_dump(count($matches) >= 2 && count($matches) <= 6);

preg_match_all("#[{$pattern}]#", 'he||o wor|d', $matches, PREG_SET_ORDER);
var_dump(count($matches));
var_dump(count($matches) >= 2 && count($matches) <= 6);

preg_match_all("#[{$pattern}]#", 'djsjKjffEf,mmddmd', $matches, PREG_SET_ORDER);
var_dump(count($matches));
var_dump(count($matches) >= 2 && count($matches) <= 6);
```

Result:
```
int(2)
bool(true)
int(4)
bool(true)
int(1)
bool(false)
```