### PR TITLE
Fixed TooManyLoginAttempts not work correctly

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -12,7 +12,7 @@ return [
     |
     */
     'lockout' => [
-        'time' => 120,
+        'time' => 2,
         'attempts' => 3,
     ],
 


### PR DESCRIPTION
We use username(), so the cache key will be created correctly

<img width="567" alt="image" src="https://user-images.githubusercontent.com/28255085/62419525-c813e580-b68a-11e9-9db9-8e070049dab3.png">

Variables have also changed:
<img width="620" alt="image" src="https://user-images.githubusercontent.com/28255085/62419538-08736380-b68b-11e9-909d-eae15d40cbd2.png">
