### PR TITLE
Add in info boxes to node server view

### DIFF
--- a/public/themes/pterodactyl/js/admin/node/view-servers.js
+++ b/public/themes/pterodactyl/js/admin/node/view-servers.js
@@ -17,6 +17,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+var totalDiskArray = [];
+var totalRamArray = [];
+var totalCPUArray = [];
+
 (function initSocket() {
     if (typeof $.notifyDefaults !== 'function') {
         console.error('Notify does not appear to be loaded.');

--- a/public/themes/pterodactyl/js/admin/node/view-servers.js
+++ b/public/themes/pterodactyl/js/admin/node/view-servers.js
@@ -121,28 +121,28 @@ var totalCPUArray = [];
 })();
 function updateInfoBox() {
 
-var CurrentDiskValue = 0;
-var CurrentRamValue = 0;
-var CurrentCPUValue = 0;
-for (var key in totalDiskArray) {
-  CurrentDiskValue=CurrentDiskValue+totalDiskArray[key];
-}
-for (var key in totalRamArray) {
-  CurrentRamValue=CurrentRamValue+totalRamArray[key];
-}
-for (var key in totalCPUArray) {
-  CurrentCPUValue=CurrentCPUValue+totalCPUArray[key];
-}
-if(CurrentDiskValue >9999){
-$("#diskUsage").text("Usage: "+CurrentDiskValue/1000 +"GB");
-}else{
-$("#diskUsage").text("Usage: "+CurrentDiskValue +"MB");
-}
+    var CurrentDiskValue = 0;
+    var CurrentRamValue = 0;
+    var CurrentCPUValue = 0;
+    for (var key in totalDiskArray) {
+        CurrentDiskValue = CurrentDiskValue + totalDiskArray[key];
+    }
+    for (var key in totalRamArray) {
+        CurrentRamValue = CurrentRamValue + totalRamArray[key];
+    }
+    for (var key in totalCPUArray) {
+        CurrentCPUValue = CurrentCPUValue + totalCPUArray[key];
+    }
+    if (CurrentDiskValue > 9999) {
+        $("#diskUsage").text("Usage: " + CurrentDiskValue / 1000 + "GB");
+    } else {
+        $("#diskUsage").text("Usage: " + CurrentDiskValue + "MB");
+    }
 
-if(CurrentRamValue >9999){
-$("#ramUsage").text("Usage: "+CurrentRamValue/1000 +"GB");
-}else{
-$("#ramUsage").text("Usage: "+CurrentRamValue +"MB");
-}
-$("#cpuUsage").text("Usage: "+CurrentCPUValue.toFixed(4) +"%");
+    if (CurrentRamValue > 9999) {
+        $("#ramUsage").text("Usage: " + CurrentRamValue / 1000 + "GB");
+    } else {
+        $("#ramUsage").text("Usage: " + CurrentRamValue + "MB");
+    }
+    $("#cpuUsage").text("Usage: " + CurrentCPUValue.toFixed(4) + "%");
 }

--- a/public/themes/pterodactyl/js/admin/node/view-servers.js
+++ b/public/themes/pterodactyl/js/admin/node/view-servers.js
@@ -101,13 +101,44 @@
                     currentCpu = parseFloat(((info.proc.cpu.total / cpuMax) * 100).toFixed(2).toString());
                 }
                 element.find('[data-action="memory"]').html(parseInt(info.proc.memory.total / (1024 * 1024)));
+                totalRamArray[uuid] = parseInt(info.proc.memory.total / (1024 * 1024));
                 element.find('[data-action="disk"]').html(parseInt(info.proc.disk.used));
+                totalDiskArray[uuid] = parseInt(info.proc.disk.used);
                 element.find('[data-action="cpu"]').html(currentCpu);
+                totalCPUArray[uuid] = currentCpu;
             } else {
                 element.find('[data-action="memory"]').html('--');
                 element.find('[data-action="disk"]').html('--');
                 element.find('[data-action="cpu"]').html('--');
             }
         });
+        updateInfoBox();
     });
 })();
+function updateInfoBox() {
+
+var CurrentDiskValue = 0;
+var CurrentRamValue = 0;
+var CurrentCPUValue = 0;
+for (var key in totalDiskArray) {
+  CurrentDiskValue=CurrentDiskValue+totalDiskArray[key];
+}
+for (var key in totalRamArray) {
+  CurrentRamValue=CurrentRamValue+totalRamArray[key];
+}
+for (var key in totalCPUArray) {
+  CurrentCPUValue=CurrentCPUValue+totalCPUArray[key];
+}
+if(CurrentDiskValue >9999){
+$("#diskUsage").text("Usage: "+CurrentDiskValue/1000 +"GB");
+}else{
+$("#diskUsage").text("Usage: "+CurrentDiskValue +"MB");
+}
+
+if(CurrentRamValue >9999){
+$("#ramUsage").text("Usage: "+CurrentRamValue/1000 +"GB");
+}else{
+$("#ramUsage").text("Usage: "+CurrentRamValue +"MB");
+}
+$("#cpuUsage").text("Usage: "+CurrentCPUValue.toFixed(4) +"%");
+}

--- a/resources/views/admin/nodes/view/servers.blade.php
+++ b/resources/views/admin/nodes/view/servers.blade.php
@@ -34,6 +34,35 @@
     </div>
 </div>
 <div class="row">
+    <div class="col-xs-12 col-md-4">
+        <div class="info-box bg-blue">
+            <span class="info-box-icon"><i class="ion ion-ios-barcode-outline"></i></span>
+            <div class="info-box-content number-info-box-content">
+                <span class="info-box-text">Total RAM</span>
+                <span class="info-box-number" id="ramUsage">Waiting for data</span>
+            </div>
+        </div>
+    </div>
+    <div class="col-xs-12 col-md-4">
+        <div class="info-box bg-blue">
+            <span class="info-box-icon"><i class="ion ion-stats-bars"></i></span>
+            <div class="info-box-content number-info-box-content">
+                <span class="info-box-text">Total Disk Space</span>
+                <span class="info-box-number" id="diskUsage">Waiting for data</span>
+            </div>
+        </div>
+    </div>
+    <div class="col-xs-12 col-md-4">
+        <div class="info-box bg-blue">
+            <span class="info-box-icon"><i class="fa fa-microchip"></i></span>
+            <div class="info-box-content number-info-box-content">
+                <span class="info-box-text">Total CPU usage</span>
+                <span class="info-box-number" id="cpuUsage">Waiting for data</span>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="row">
     <div class="col-sm-12">
         <div class="box box-primary">
             <div class="box-header with-border">


### PR DESCRIPTION
This adds 3 boxes into the "/admin/nodes/view/x/servers" view that adds up total Disk/Ram/CPU usage.
This helps to see current total usage at a glance, without pulling out a calculator. 
This is how it looks:
![image](https://user-images.githubusercontent.com/33436545/66663818-ac5d2a80-ec4b-11e9-9e6d-121cd9df61a9.png)
