### PR TITLE
Improved non-interactive command support

### DIFF
--- a/app/Console/Commands/Server/BulkPowerActionCommand.php
+++ b/app/Console/Commands/Server/BulkPowerActionCommand.php
@@ -91,7 +91,7 @@ class BulkPowerActionCommand extends Command
         }
 
         $count = $this->repository->getServersForPowerActionCount($servers, $nodes);
-        if (! $this->confirm(trans('command/messages.server.power.confirm', ['action' => $action, 'count' => $count]))) {
+        if (! $this->confirm(trans('command/messages.server.power.confirm', ['action' => $action, 'count' => $count])) && $this->input->isInteractive()) {
             return;
         }
 

--- a/app/Console/Commands/Server/BulkReinstallActionCommand.php
+++ b/app/Console/Commands/Server/BulkReinstallActionCommand.php
@@ -71,7 +71,7 @@ class BulkReinstallActionCommand extends Command
     {
         $servers = $this->getServersToProcess();
 
-        if (! $this->confirm(trans('command/messages.server.reinstall.confirm'))) {
+        if (! $this->confirm(trans('command/messages.server.reinstall.confirm')) && $this->input->isInteractive()) {
             return;
         }
 


### PR DESCRIPTION
The following commands no longer need confirmation when the input is not interactive:

 - server:bulk-power
 - server:reinstall