### PR TITLE
Fixed Admin user profile textboxes

### DIFF
--- a/resources/views/admin/users/view.blade.php
+++ b/resources/views/admin/users/view.blade.php
@@ -30,25 +30,25 @@
                     <div class="form-group">
                         <label for="email" class="control-label">Email</label>
                         <div>
-                            <input readonly type="email" name="email" value="{{ $user->email }}" class="form-control form-autocomplete-stop">
+                            <input type="email" name="email" value="{{ $user->email }}" class="form-control form-autocomplete-stop">
                         </div>
                     </div>
                     <div class="form-group">
                         <label for="registered" class="control-label">Username</label>
                         <div>
-                            <input readonly type="text" name="username" value="{{ $user->username }}" class="form-control form-autocomplete-stop">
+                            <input type="text" name="username" value="{{ $user->username }}" class="form-control form-autocomplete-stop">
                         </div>
                     </div>
                     <div class="form-group">
                         <label for="registered" class="control-label">Client First Name</label>
                         <div>
-                            <input readonly type="text" name="name_first" value="{{ $user->name_first }}" class="form-control form-autocomplete-stop">
+                            <input type="text" name="name_first" value="{{ $user->name_first }}" class="form-control form-autocomplete-stop">
                         </div>
                     </div>
                     <div class="form-group">
                         <label for="registered" class="control-label">Client Last Name</label>
                         <div>
-                            <input readonly type="text" name="name_last" value="{{ $user->name_last }}" class="form-control form-autocomplete-stop">
+                            <input type="text" name="name_last" value="{{ $user->name_last }}" class="form-control form-autocomplete-stop">
                         </div>
                     </div>
                     <div class="form-group">
@@ -80,7 +80,7 @@
                     <div class="form-group no-margin-bottom">
                         <label for="password" class="control-label">Password <span class="field-optional"></span></label>
                         <div>
-                            <input readonly type="password" id="password" name="password" class="form-control form-autocomplete-stop">
+                            <input type="password" id="password" name="password" class="form-control form-autocomplete-stop">
                             <p class="text-muted small">Leave blank to keep this user's password the same. User will not receive any notification if password is changed.</p>
                         </div>
                     </div>


### PR DESCRIPTION
Text boxes on the user view page were set to read-only not allowing admins to change user values