### PR TITLE
Add migration and validation rules for 'threads' column, fixes other errors on nest/egg pages

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -23,6 +23,7 @@ use Znck\Eloquent\Traits\BelongsToThrough;
  * @property int $disk
  * @property int $io
  * @property int $cpu
+ * @property string $threads
  * @property bool $oom_disabled
  * @property int $allocation_id
  * @property int $nest_id
@@ -109,6 +110,7 @@ class Server extends Validable
         'swap' => 'required|numeric|min:-1',
         'io' => 'required|numeric|between:10,1000',
         'cpu' => 'required|numeric|min:0',
+        'threads' => 'sometimes|regex:/^[0-9-,]+$/',
         'oom_disabled' => 'sometimes|boolean',
         'disk' => 'required|numeric|min:0',
         'allocation_id' => 'required|bail|unique:servers|exists:allocations,id',

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -110,7 +110,7 @@ class Server extends Validable
         'swap' => 'required|numeric|min:-1',
         'io' => 'required|numeric|between:10,1000',
         'cpu' => 'required|numeric|min:0',
-        'threads' => 'sometimes|regex:/^[0-9-,]+$/',
+        'threads' => 'nullable|regex:/^[0-9-,]+$/',
         'oom_disabled' => 'sometimes|boolean',
         'disk' => 'required|numeric|min:0',
         'allocation_id' => 'required|bail|unique:servers|exists:allocations,id',

--- a/database/migrations/2020_04_03_203624_add_threads_column_to_servers_table.php
+++ b/database/migrations/2020_04_03_203624_add_threads_column_to_servers_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class AddThreadsColumnToServersTable extends Migration
 {

--- a/database/migrations/2020_04_03_203624_add_threads_column_to_servers_table.php
+++ b/database/migrations/2020_04_03_203624_add_threads_column_to_servers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddThreadsColumnToServersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->string('threads')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->dropColumn('threads');
+        });
+    }
+}

--- a/resources/views/admin/eggs/variables.blade.php
+++ b/resources/views/admin/eggs/variables.blade.php
@@ -48,7 +48,7 @@
                 <div class="box-header with-border">
                     <h3 class="box-title">{{ $variable->name }}</h3>
                 </div>
-                <form action="{{ route('admin.nests.egg.variables.edit', ['id' => $egg->id, 'variable' => $variable->id]) }}" method="POST">
+                <form action="{{ route('admin.nests.egg.variables.edit', ['egg' => $egg->id, 'variable' => $variable->id]) }}" method="POST">
                     <div class="box-body">
                         <div class="form-group">
                             <label class="form-label">Name</label>

--- a/resources/views/admin/eggs/view.blade.php
+++ b/resources/views/admin/eggs/view.blade.php
@@ -160,7 +160,7 @@
                 <div class="box-footer">
                     {!! csrf_field() !!}
                     <button type="submit" name="_method" value="PATCH" class="btn btn-primary btn-sm pull-right">Save</button>
-                    <a href="{{ route('admin.nests.egg.export', ['option' => $egg->id]) }}" class="btn btn-sm btn-info pull-right" style="margin-right:10px;">Export</a>
+                    <a href="{{ route('admin.nests.egg.export', $egg->id) }}" class="btn btn-sm btn-info pull-right" style="margin-right:10px;">Export</a>
                     <button id="deleteButton" type="submit" name="_method" value="DELETE" class="btn btn-danger btn-sm muted muted-hover">
                         <i class="fa fa-trash-o"></i>
                     </button>

--- a/resources/views/admin/packs/view.blade.php
+++ b/resources/views/admin/packs/view.blade.php
@@ -138,7 +138,7 @@
             {!! csrf_field() !!}
             <button type="submit" class="btn btn-sm btn-success pull-right">Export</button>
         </form>
-        <form action="{{ route('admin.packs.view.export', ['id' => $pack->id, 'files' => 'with-files']) }}" method="POST">
+        <form action="{{ route('admin.packs.view.export', ['pack' => $pack->id, 'files' => 'with-files']) }}" method="POST">
             {!! csrf_field() !!}
             <button type="submit" class="btn btn-sm pull-right muted muted-hover" style="margin-right:10px;">Export with Archive</button>
         </form>

--- a/resources/views/admin/servers/view/index.blade.php
+++ b/resources/views/admin/servers/view/index.blade.php
@@ -75,7 +75,13 @@
                             </tr>
                             <tr>
                                 <td>CPU Threads</td>
-                                <td><code>{{ $server->threads }}</code></td>
+                                <td>
+                                    @if($server->threads != null)
+                                        <code>{{ $server->threads }}</code>
+                                    @else
+                                        <code>Not Set</code>
+                                    @endif
+                                </td>
                             </tr>
                             <tr>
                                 <td>Default Connection</td>

--- a/resources/views/admin/servers/view/index.blade.php
+++ b/resources/views/admin/servers/view/index.blade.php
@@ -79,7 +79,7 @@
                                     @if($server->threads != null)
                                         <code>{{ $server->threads }}</code>
                                     @else
-                                        <code>Not Set</code>
+                                        <code>n/a</code>
                                     @endif
                                 </td>
                             </tr>


### PR DESCRIPTION
* Adds a migration for the `threads` column on the `servers` table
* Adds validation rules for the `threads` column
* Fixes an error with the `admin.nests.egg.export` route on `admin/eggs/view.blade.php`
* Fixes an error with the `admin.nests.egg.variables.edit` route on `admin/eggs/view.blade.php`
* Fixes an error with the `admin.packs.view.export` route on `admin/packs/view.blade.php`
* Displays `Not Set` for when the `threads` column is null on `admin/servers/view/index.blade.php`