### PR TITLE
Allow description fields to be optional

### DIFF
--- a/app/Http/Requests/Admin/Egg/EggFormRequest.php
+++ b/app/Http/Requests/Admin/Egg/EggFormRequest.php
@@ -20,7 +20,7 @@ class EggFormRequest extends AdminFormRequest
     {
         $rules = [
             'name' => 'required|string|max:255',
-            'description' => 'required|string',
+            'description' => 'nullable|string',
             'docker_image' => 'required|string|max:255',
             'startup' => 'required|string',
             'config_from' => 'sometimes|bail|nullable|numeric',

--- a/app/Http/Requests/Admin/Nest/StoreNestFormRequest.php
+++ b/app/Http/Requests/Admin/Nest/StoreNestFormRequest.php
@@ -20,7 +20,7 @@ class StoreNestFormRequest extends AdminFormRequest
     {
         return [
             'name' => 'required|string|min:1|max:255',
-            'description' => 'string|nullable|',
+            'description' => 'string|nullable',
         ];
     }
 }

--- a/app/Http/Requests/Admin/Nest/StoreNestFormRequest.php
+++ b/app/Http/Requests/Admin/Nest/StoreNestFormRequest.php
@@ -20,7 +20,7 @@ class StoreNestFormRequest extends AdminFormRequest
     {
         return [
             'name' => 'required|string|min:1|max:255',
-            'description' => 'required|nullable|string',
+            'description' => 'string|nullable|',
         ];
     }
 }

--- a/app/Models/Egg.php
+++ b/app/Models/Egg.php
@@ -8,7 +8,7 @@ namespace Pterodactyl\Models;
  * @property int $nest_id
  * @property string $author
  * @property string $name
- * @property string $description
+ * @property string|null $description
  * @property string $docker_image
  * @property string|null $config_files
  * @property string|null $config_startup
@@ -95,7 +95,7 @@ class Egg extends Model
         'nest_id' => 'required|bail|numeric|exists:nests,id',
         'uuid' => 'required|string|size:36',
         'name' => 'required|string|max:255',
-        'description' => 'required|string',
+        'description' => 'string|nullable',
         'author' => 'required|string|email',
         'docker_image' => 'required|string|max:255',
         'startup' => 'required|nullable|string',

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -31,7 +31,7 @@ class Location extends Model
      */
     public static $validationRules = [
         'short' => 'required|string|between:1,60|unique:locations,short',
-        'long' => 'required|string|between:1,255',
+        'long' => 'string|nullable|between:1,255',
     ];
 
     /**

--- a/app/Models/Nest.php
+++ b/app/Models/Nest.php
@@ -7,7 +7,7 @@ namespace Pterodactyl\Models;
  * @property string $uuid
  * @property string $author
  * @property string $name
- * @property string $description
+ * @property string|null $description
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  *
@@ -46,7 +46,7 @@ class Nest extends Model
     public static $validationRules = [
         'author' => 'required|string|email',
         'name' => 'required|string|max:255',
-        'description' => 'sometimes|nullable|string',
+        'description' => 'nullable|string',
     ];
 
     /**

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -13,7 +13,7 @@ use Illuminate\Contracts\Encryption\Encrypter;
  * @property string $uuid
  * @property bool $public
  * @property string $name
- * @property string $description
+ * @property string|null $description
  * @property int $location_id
  * @property string $fqdn
  * @property string $scheme
@@ -111,7 +111,7 @@ class Node extends Model
      */
     public static $validationRules = [
         'name' => 'required|regex:/^([\w .-]{1,100})$/',
-        'description' => 'string',
+        'description' => 'string|nullable',
         'location_id' => 'required|exists:locations,id',
         'public' => 'boolean',
         'fqdn' => 'required|string',

--- a/database/migrations/2020_04_17_203438_allow_nullable_descriptions.php
+++ b/database/migrations/2020_04_17_203438_allow_nullable_descriptions.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AllowNullableDescriptions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('eggs', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+
+        Schema::table('nests', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+
+        Schema::table('nodes', function (Blueprint $table) {
+            $table->text('description')->nullable()->change();
+        });
+
+        Schema::table('locations', function (Blueprint $table) {
+            $table->text('long')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('eggs', function (Blueprint $table) {
+            $table->text('description')->nullable(false)->change();
+        });
+
+        Schema::table('nests', function (Blueprint $table) {
+            $table->text('description')->nullable(false)->change();
+        });
+
+        Schema::table('nodes', function (Blueprint $table) {
+            $table->text('description')->nullable(false)->change();
+        });
+
+        Schema::table('locations', function (Blueprint $table) {
+            $table->text('long')->nullable(false)->change();
+        });
+    }
+}

--- a/resources/views/admin/eggs/view.blade.php
+++ b/resources/views/admin/eggs/view.blade.php
@@ -89,7 +89,7 @@
                         </div>
                         <div class="col-sm-6">
                             <div class="form-group">
-                                <label for="pDescription" class="control-label">Description <span class="field-required"></span></label>
+                                <label for="pDescription" class="control-label">Description</label>
                                 <textarea id="pDescription" name="description" class="form-control" rows="6">{{ $egg->description }}</textarea>
                                 <p class="text-muted small">A description of this Egg that will be displayed throughout the Panel as needed.</p>
                             </div>

--- a/resources/views/admin/nests/view.blade.php
+++ b/resources/views/admin/nests/view.blade.php
@@ -32,7 +32,7 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="control-label">Description <span class="field-required"></span></label>
+                        <label class="control-label">Description</label>
                         <div>
                             <textarea name="description" class="form-control" rows="7">{{ $nest->description }}</textarea>
                         </div>


### PR DESCRIPTION
Allows for Nest, Node, Location, and Egg description fields to be blank / nullable.
Removed "required" wording next to them as well

Closes #1922

Partially takes care of #1894 