### PR TITLE
Add Max Concurrent Connections for database users

### DIFF
--- a/app/Contracts/Repository/DatabaseRepositoryInterface.php
+++ b/app/Contracts/Repository/DatabaseRepositoryInterface.php
@@ -68,7 +68,7 @@ interface DatabaseRepositoryInterface extends RepositoryInterface
      * @param string $username
      * @param string $remote
      * @param string $password
-     * @param string $max_connections
+     * @param $max_connections
      * @return bool
      */
     public function createUser(string $username, string $remote, string $password, string $max_connections): bool;

--- a/app/Contracts/Repository/DatabaseRepositoryInterface.php
+++ b/app/Contracts/Repository/DatabaseRepositoryInterface.php
@@ -68,9 +68,10 @@ interface DatabaseRepositoryInterface extends RepositoryInterface
      * @param string $username
      * @param string $remote
      * @param string $password
+     * @param string $max_connections
      * @return bool
      */
-    public function createUser(string $username, string $remote, string $password): bool;
+    public function createUser(string $username, string $remote, string $password, string $max_connections): bool;
 
     /**
      * Give a specific user access to a given database.

--- a/app/Http/Requests/Admin/Servers/Databases/StoreServerDatabaseRequest.php
+++ b/app/Http/Requests/Admin/Servers/Databases/StoreServerDatabaseRequest.php
@@ -25,6 +25,7 @@ class StoreServerDatabaseRequest extends AdminFormRequest
                     $query->where('database_host_id', $this->input('database_host_id') ?? 0);
                 }),
             ],
+            'max_connections' => 'nullable',
             'remote' => 'required|string|regex:/^[0-9%.]{1,15}$/',
             'database_host_id' => 'required|integer|exists:database_hosts,id',
         ];

--- a/app/Models/Database.php
+++ b/app/Models/Database.php
@@ -41,6 +41,7 @@ class Database extends Model
     protected $casts = [
         'server_id' => 'integer',
         'database_host_id' => 'integer',
+        'max_connections' => 'integer',
     ];
 
     /**
@@ -51,7 +52,7 @@ class Database extends Model
         'database_host_id' => 'required|exists:database_hosts,id',
         'database' => 'required|string|alpha_dash|between:3,100',
         'username' => 'string|alpha_dash|between:3,100',
-        'max_connections' => 'nullable',
+        'max_connections' => 'nullable|integer',
         'remote' => 'required|string|regex:/^[0-9%.]{1,15}$/',
         'password' => 'string',
     ];

--- a/app/Models/Database.php
+++ b/app/Models/Database.php
@@ -51,7 +51,7 @@ class Database extends Model
         'database_host_id' => 'required|exists:database_hosts,id',
         'database' => 'required|string|alpha_dash|between:3,100',
         'username' => 'string|alpha_dash|between:3,100',
-        'max_connections' => 'string',
+        'max_connections' => 'nullable',
         'remote' => 'required|string|regex:/^[0-9%.]{1,15}$/',
         'password' => 'string',
     ];

--- a/app/Models/Database.php
+++ b/app/Models/Database.php
@@ -30,7 +30,7 @@ class Database extends Model
      * @var array
      */
     protected $fillable = [
-        'server_id', 'database_host_id', 'database', 'username', 'password', 'remote',
+        'server_id', 'database_host_id', 'database', 'username', 'password', 'remote', 'max_connections',
     ];
 
     /**
@@ -51,6 +51,7 @@ class Database extends Model
         'database_host_id' => 'required|exists:database_hosts,id',
         'database' => 'required|string|alpha_dash|between:3,100',
         'username' => 'string|alpha_dash|between:3,100',
+        'max_connections' => 'string',
         'remote' => 'required|string|regex:/^[0-9%.]{1,15}$/',
         'password' => 'string',
     ];

--- a/app/Repositories/Eloquent/DatabaseRepository.php
+++ b/app/Repositories/Eloquent/DatabaseRepository.php
@@ -135,12 +135,16 @@ class DatabaseRepository extends EloquentRepository implements DatabaseRepositor
      * @param string $username
      * @param string $remote
      * @param string $password
-     * @param string $max_connections
+     * @param $max_connections
      * @return bool
      */
-    public function createUser(string $username, string $remote, string $password, string $max_connections): bool
+    public function createUser(string $username, string $remote, string $password, $max_connections): bool
     {
-        return $this->run(sprintf('CREATE USER `%s`@`%s` IDENTIFIED BY \'%s\' WITH MAX_USER_CONNECTIONS %s', $username, $remote, $password, $max_connections));
+        if (!$max_connections) {
+            return $this->run(sprintf('CREATE USER `%s`@`%s` IDENTIFIED BY \'%s\'', $username, $remote, $password));
+        } else {
+            return $this->run(sprintf('CREATE USER `%s`@`%s` IDENTIFIED BY \'%s\' WITH MAX_USER_CONNECTIONS %s', $username, $remote, $password, $max_connections));
+        }
     }
 
     /**

--- a/app/Repositories/Eloquent/DatabaseRepository.php
+++ b/app/Repositories/Eloquent/DatabaseRepository.php
@@ -135,11 +135,12 @@ class DatabaseRepository extends EloquentRepository implements DatabaseRepositor
      * @param string $username
      * @param string $remote
      * @param string $password
+     * @param string $max_connections
      * @return bool
      */
-    public function createUser(string $username, string $remote, string $password): bool
+    public function createUser(string $username, string $remote, string $password, string $max_connections): bool
     {
-        return $this->run(sprintf('CREATE USER `%s`@`%s` IDENTIFIED BY \'%s\'', $username, $remote, $password));
+        return $this->run(sprintf('CREATE USER `%s`@`%s` IDENTIFIED BY \'%s\' WITH MAX_USER_CONNECTIONS %s', $username, $remote, $password, $max_connections));
     }
 
     /**

--- a/app/Services/Databases/DatabaseManagementService.php
+++ b/app/Services/Databases/DatabaseManagementService.php
@@ -84,7 +84,8 @@ class DatabaseManagementService
             $this->repository->createUser(
                 $database->username,
                 $database->remote,
-                $this->encrypter->decrypt($database->password)
+                $this->encrypter->decrypt($database->password),
+                $database->max_connections
             );
             $this->repository->assignUserToDatabase(
                 $database->database,

--- a/app/Services/Databases/DatabasePasswordService.php
+++ b/app/Services/Databases/DatabasePasswordService.php
@@ -71,7 +71,7 @@ class DatabasePasswordService
             ]);
 
             $this->repository->dropUser($database->username, $database->remote);
-            $this->repository->createUser($database->username, $database->remote, $password);
+            $this->repository->createUser($database->username, $database->remote, $password, $database->max_connections);
             $this->repository->assignUserToDatabase($database->database, $database->username, $database->remote);
             $this->repository->flush();
         });

--- a/app/Transformers/Api/Application/ServerDatabaseTransformer.php
+++ b/app/Transformers/Api/Application/ServerDatabaseTransformer.php
@@ -56,6 +56,7 @@ class ServerDatabaseTransformer extends BaseTransformer
             'database' => $model->database,
             'username' => $model->username,
             'remote' => $model->remote,
+            'max_connections' => $model->max_connections,
             'created_at' => Chronos::createFromFormat(Chronos::DEFAULT_TO_STRING_FORMAT, $model->created_at)
                 ->setTimezone(config('app.timezone'))
                 ->toIso8601String(),

--- a/app/Transformers/Api/Client/DatabaseTransformer.php
+++ b/app/Transformers/Api/Client/DatabaseTransformer.php
@@ -58,6 +58,7 @@ class DatabaseTransformer extends BaseClientTransformer
             'name' => $model->database,
             'username' => $model->username,
             'connections_from' => $model->remote,
+            'max_connections' => $model->max_connections,
         ];
     }
 

--- a/database/migrations/2020_04_22_055500_add_max_connections_column.php
+++ b/database/migrations/2020_04_22_055500_add_max_connections_column.php
@@ -14,7 +14,7 @@ class AddMaxConnectionsColumnToDatabasesTable extends Migration
     public function up()
     {
         Schema::table('databases', function (Blueprint $table) {
-            $table->integer('max_connections')->nullable(false)->default(0)->after('password');
+            $table->integer('max_connections')->nullable()->default(0)->after('password');
         });
     }
 

--- a/database/migrations/2020_04_22_055500_add_max_connections_column.php
+++ b/database/migrations/2020_04_22_055500_add_max_connections_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMaxConnectionsColumnToDatabasesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('databases', function (Blueprint $table) {
+            $table->integer('max_connections')->nullable(false)->default(0)->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('databases', function (Blueprint $table) {
+            $table->dropColumn('max_connections');
+        });
+    }
+}

--- a/resources/scripts/api/server/getServerDatabases.ts
+++ b/resources/scripts/api/server/getServerDatabases.ts
@@ -6,6 +6,7 @@ export interface ServerDatabase {
     username: string;
     connectionString: string;
     allowConnectionsFrom: string;
+    maxConnections: string;
     password?: string;
 }
 
@@ -15,6 +16,7 @@ export const rawDataToServerDatabase = (data: any): ServerDatabase => ({
     username: data.username,
     connectionString: `${data.host.address}:${data.host.port}`,
     allowConnectionsFrom: data.connections_from,
+    maxConnections: data.max_connections,
     password: data.relationships && data.relationships.password ? data.relationships.password.attributes.password : undefined,
 });
 

--- a/resources/scripts/api/server/getServerDatabases.ts
+++ b/resources/scripts/api/server/getServerDatabases.ts
@@ -6,7 +6,6 @@ export interface ServerDatabase {
     username: string;
     connectionString: string;
     allowConnectionsFrom: string;
-    maxConnections: string;
     password?: string;
 }
 
@@ -16,7 +15,6 @@ export const rawDataToServerDatabase = (data: any): ServerDatabase => ({
     username: data.username,
     connectionString: `${data.host.address}:${data.host.port}`,
     allowConnectionsFrom: data.connections_from,
-    maxConnections: data.max_connections,
     password: data.relationships && data.relationships.password ? data.relationships.password.attributes.password : undefined,
 });
 

--- a/resources/scripts/components/server/databases/DatabaseRow.tsx
+++ b/resources/scripts/components/server/databases/DatabaseRow.tsx
@@ -51,9 +51,6 @@ export default ({ database, className }: Props) => {
                 addError({ key: 'database:delete', message: httpErrorToHuman(error) });
             });
     };
-    if (!database.maxConnections){
-        database.maxConnections = "Unlimited"
-    }
     
     return (
         <React.Fragment>
@@ -153,10 +150,6 @@ export default ({ database, className }: Props) => {
                 <div className={'ml-8 text-center'}>
                     <p className={'text-sm'}>{database.username}</p>
                     <p className={'mt-1 text-2xs text-neutral-500 uppercase select-none'}>Username</p>
-                </div>
-                <div className={'ml-8 text-center'}>
-                    <p className={'text-sm'}>{database.maxConnections}</p>
-                    <p className={'mt-1 text-2xs text-neutral-500 uppercase select-none'}>Max Connections</p>
                 </div>
                 <div className={'ml-8'}>
                     <button className={'btn btn-sm btn-secondary mr-2'} onClick={() => setConnectionVisible(true)}>

--- a/resources/scripts/components/server/databases/DatabaseRow.tsx
+++ b/resources/scripts/components/server/databases/DatabaseRow.tsx
@@ -51,7 +51,10 @@ export default ({ database, className }: Props) => {
                 addError({ key: 'database:delete', message: httpErrorToHuman(error) });
             });
     };
-
+    if (!database.maxConnections){
+        database.maxConnections = "Unlimited"
+    }
+    
     return (
         <React.Fragment>
             <Formik

--- a/resources/scripts/components/server/databases/DatabaseRow.tsx
+++ b/resources/scripts/components/server/databases/DatabaseRow.tsx
@@ -151,6 +151,10 @@ export default ({ database, className }: Props) => {
                     <p className={'text-sm'}>{database.username}</p>
                     <p className={'mt-1 text-2xs text-neutral-500 uppercase select-none'}>Username</p>
                 </div>
+                <div className={'ml-8 text-center'}>
+                    <p className={'text-sm'}>{database.max_connections}</p>
+                    <p className={'mt-1 text-2xs text-neutral-500 uppercase select-none'}>Max Connections</p>
+                </div>
                 <div className={'ml-8'}>
                     <button className={'btn btn-sm btn-secondary mr-2'} onClick={() => setConnectionVisible(true)}>
                         <FontAwesomeIcon icon={faEye} fixedWidth={true}/>

--- a/resources/scripts/components/server/databases/DatabaseRow.tsx
+++ b/resources/scripts/components/server/databases/DatabaseRow.tsx
@@ -152,7 +152,7 @@ export default ({ database, className }: Props) => {
                     <p className={'mt-1 text-2xs text-neutral-500 uppercase select-none'}>Username</p>
                 </div>
                 <div className={'ml-8 text-center'}>
-                    <p className={'text-sm'}>{database.max_connections}</p>
+                    <p className={'text-sm'}>{database.maxConnections}</p>
                     <p className={'mt-1 text-2xs text-neutral-500 uppercase select-none'}>Max Connections</p>
                 </div>
                 <div className={'ml-8'}>

--- a/resources/views/admin/databases/view.blade.php
+++ b/resources/views/admin/databases/view.blade.php
@@ -99,6 +99,7 @@
                         <th>Database Name</th>
                         <th>Username</th>
                         <th>Connections From</th>
+                        <th>Max Connections</th>
                         <th></th>
                     </tr>
                     @foreach($databases as $database)
@@ -107,6 +108,7 @@
                             <td class="middle">{{ $database->database }}</td>
                             <td class="middle">{{ $database->username }}</td>
                             <td class="middle">{{ $database->remote }}</td>
+                            <td class="middle">{{ $database->max_connections }}</td>
                             <td class="text-center">
                                 <a href="{{ route('admin.servers.view.database', $database->getRelation('server')->id) }}">
                                     <button class="btn btn-xs btn-primary">Manage</button>

--- a/resources/views/admin/databases/view.blade.php
+++ b/resources/views/admin/databases/view.blade.php
@@ -108,7 +108,11 @@
                             <td class="middle">{{ $database->database }}</td>
                             <td class="middle">{{ $database->username }}</td>
                             <td class="middle">{{ $database->remote }}</td>
-                            <td class="middle">{{ $database->max_connections }}</td>
+                            @if($database->max_connections != null)
+                                <td class="middle">{{ $database->max_connections }}</td>
+                            @else
+                                <td class="middle">Unlimited</td>
+                            @endif
                             <td class="text-center">
                                 <a href="{{ route('admin.servers.view.database', $database->getRelation('server')->id) }}">
                                     <button class="btn btn-xs btn-primary">Manage</button>

--- a/resources/views/admin/servers/view/database.blade.php
+++ b/resources/views/admin/servers/view/database.blade.php
@@ -46,7 +46,11 @@
                             <td>{{ $database->username }}</td>
                             <td>{{ $database->remote }}</td>
                             <td><code>{{ $database->host->host }}:{{ $database->host->port }}</code></td>
-                            <td>{{ $database->max_connections }}</td>
+                            @if($database->max_connections != null)
+                                <td>{{ $database->max_connections }}</td>
+                            @else
+                                <td>Unlimited</td>
+                            @endif
                             <td class="text-center">
                                 <button data-action="reset-password" data-id="{{ $database->id }}" class="btn btn-xs btn-primary"><i class="fa fa-refresh"></i></button>
                                 <button data-action="remove" data-id="{{ $database->id }}" class="btn btn-xs btn-danger"><i class="fa fa-trash"></i></button>
@@ -86,9 +90,9 @@
                         <p class="text-muted small">This should reflect the IP address that connections are allowed from. Uses standard MySQL notation. If unsure leave as <code>%</code>.</p>
                     </div>
                     <div class="form-group">
-                        <label for="pmax_connections" class="control-label">Max Concurrent Connections</label>
-                        <input id="pmax_connections" type="text" name="max_connections" class="form-control" value="150" />
-                        <p class="text-muted small">This should reflect the max number of concurrent connections from this user to the database. Use <code>0</code> for unlimited</p>
+                        <label for="pmax_connections" class="control-label">Concurrent Connections</label>
+                        <input id="pmax_connections" type="text" name="max_connections" class="form-control"/>
+                        <p class="text-muted small">This should reflect the max number of concurrent connections from this user to the database. Leave empty for unlimited.</p>
                     </div>
                 </div>
                 <div class="box-footer">

--- a/resources/views/admin/servers/view/database.blade.php
+++ b/resources/views/admin/servers/view/database.blade.php
@@ -37,6 +37,7 @@
                         <th>Username</th>
                         <th>Connections From</th>
                         <th>Host</th>
+                        <th>Max Conenctions</th>
                         <th></th>
                     </tr>
                     @foreach($server->databases as $database)
@@ -45,6 +46,7 @@
                             <td>{{ $database->username }}</td>
                             <td>{{ $database->remote }}</td>
                             <td><code>{{ $database->host->host }}:{{ $database->host->port }}</code></td>
+                            <td>{{ $database->max_connections }}</td>
                             <td class="text-center">
                                 <button data-action="reset-password" data-id="{{ $database->id }}" class="btn btn-xs btn-primary"><i class="fa fa-refresh"></i></button>
                                 <button data-action="remove" data-id="{{ $database->id }}" class="btn btn-xs btn-danger"><i class="fa fa-trash"></i></button>
@@ -82,6 +84,11 @@
                         <label for="pRemote" class="control-label">Connections</label>
                         <input id="pRemote" type="text" name="remote" class="form-control" value="%" />
                         <p class="text-muted small">This should reflect the IP address that connections are allowed from. Uses standard MySQL notation. If unsure leave as <code>%</code>.</p>
+                    </div>
+                    <div class="form-group">
+                        <label for="pmax_connections" class="control-label">Max Concurrent Connections</label>
+                        <input id="pmax_connections" type="text" name="max_connections" class="form-control" value="150" />
+                        <p class="text-muted small">This should reflect the max number of concurrent connections from this user to the database. Use <code>0</code> for unlimited</p>
                     </div>
                 </div>
                 <div class="box-footer">


### PR DESCRIPTION
Closes #1849

Allows database users to be limited to a number of concurrent connections to prevent one user from connecting hundreds of times and bottlenecking the MySQL server.