### PR TITLE
Fix docker entrypoint database check

### DIFF
--- a/.dev/docker/entrypoint.sh
+++ b/.dev/docker/entrypoint.sh
@@ -49,7 +49,7 @@ fi
 
 ## check for DB up before starting the panel
 echo "Checking database status."
-until nc -z -v -w30 $DB_HOST 3306
+until nc -z -v -w30 $DB_HOST $DB_PORT
 
 do
   echo "Waiting for database connection..."

--- a/config/database.php
+++ b/config/database.php
@@ -97,6 +97,7 @@ return [
 
         'default' => [
             'host' => env('REDIS_HOST', 'localhost'),
+            'scheme' => env('REDIS_SCHEME', 'tcp'),
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
             'database' => env('REDIS_DATABASE', 0),
@@ -104,9 +105,14 @@ return [
 
         'sessions' => [
             'host' => env('REDIS_HOST', 'localhost'),
+            'scheme' => env('REDIS_SCHEME', 'tcp'),
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
             'database' => env('REDIS_DATABASE_SESSIONS', 1),
+        ],
+
+        'options' => [
+            'ssl'    => ['verify_peer' => false],
         ],
     ],
 ];


### PR DESCRIPTION
The Database port was hard coded to 3306 and not taking into consideration the DB_PORT environment variable

This was causing an endless loop when starting. 