### PR TITLE
Add return type hints and missing test dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,9 @@
         "barryvdh/laravel-ide-helper": "^2.6",
         "codedungeon/phpunit-result-printer": "0.25.1",
         "friendsofphp/php-cs-fixer": "^2.16.1",
+        "fzaninotto/faker": "^1.9.1",
         "laravel/dusk": "^5.11",
+        "mockery/mockery": "^1.0",
         "php-mock/php-mock-phpunit": "^2.6",
         "phpunit/phpunit": "^7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2318244deed430b3f0b3df9ee4977759",
+    "content-hash": "b6a885effd46e896377825b057886f23",
     "packages": [
         {
             "name": "appstract/laravel-blade-directives",
@@ -1655,12 +1655,6 @@
                 "sftp",
                 "storage"
             ],
-            "funding": [
-                {
-                    "url": "https://offset.earth/frankdejonge",
-                    "type": "other"
-                }
-            ],
             "time": "2020-03-17T18:58:12+00:00"
         },
         {
@@ -2075,16 +2069,6 @@
                 "date",
                 "datetime",
                 "time"
-            ],
-            "funding": [
-                {
-                    "url": "https://opencollective.com/Carbon",
-                    "type": "open_collective"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-31T13:43:19+00:00"
         },
@@ -3098,12 +3082,6 @@
                 "spatie",
                 "transform"
             ],
-            "funding": [
-                {
-                    "url": "https://spatie.be/open-source/support-us",
-                    "type": "custom"
-                }
-            ],
             "time": "2020-03-02T18:40:49+00:00"
         },
         {
@@ -3286,20 +3264,6 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T11:41:10+00:00"
         },
         {
@@ -3353,20 +3317,6 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:56:45+00:00"
         },
         {
@@ -3423,20 +3373,6 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -3493,20 +3429,6 @@
             ],
             "description": "Symfony ErrorHandler Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T14:07:33+00:00"
         },
         {
@@ -3577,20 +3499,6 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -3698,20 +3606,6 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -3767,20 +3661,6 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T14:07:33+00:00"
         },
         {
@@ -3871,20 +3751,6 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T14:59:15+00:00"
         },
         {
@@ -3947,20 +3813,6 @@
                 "mime",
                 "mime-type"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:56:45+00:00"
         },
         {
@@ -4018,20 +3870,6 @@
                 "ctype",
                 "polyfill",
                 "portable"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-02-27T09:26:54+00:00"
         },
@@ -4091,20 +3929,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-09T19:04:49+00:00"
         },
@@ -4168,20 +3992,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-09T19:04:49+00:00"
         },
         {
@@ -4241,20 +4051,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-09T19:04:49+00:00"
         },
         {
@@ -4311,20 +4107,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-09T19:04:49+00:00"
         },
         {
@@ -4379,20 +4161,6 @@
                 "polyfill",
                 "portable",
                 "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-02-27T09:26:54+00:00"
         },
@@ -4452,20 +4220,6 @@
                 "portable",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-02-27T09:26:54+00:00"
         },
         {
@@ -4518,20 +4272,6 @@
                 "polyfill",
                 "shim"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-02T11:55:35+00:00"
         },
         {
@@ -4581,20 +4321,6 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -4670,20 +4396,6 @@
                 "routing",
                 "uri",
                 "url"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-30T11:41:10+00:00"
         },
@@ -4819,20 +4531,6 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -4966,20 +4664,6 @@
                 "debug",
                 "dump"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -5039,20 +4723,6 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-30T11:41:10+00:00"
         },
         {
@@ -5164,12 +4834,6 @@
                 "dotenv",
                 "env",
                 "environment"
-            ],
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-27T23:36:02+00:00"
         },
@@ -5687,16 +5351,6 @@
                 "dependency",
                 "package"
             ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-13T19:34:27+00:00"
         },
         {
@@ -5861,12 +5515,6 @@
             "keywords": [
                 "Xdebug",
                 "performance"
-            ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                }
             ],
             "time": "2020-03-01T12:26:26+00:00"
         },
@@ -6083,6 +5731,104 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "time": "2019-11-25T22:10:32+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/fc10d778e4b84d5bd315dad194661e091d307c6f",
+                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
+                "squizlabs/php_codesniffer": "^2.9.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2019-12-12T13:22:17+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "1.3.3",
+                "phpunit/phpunit": "~4.0",
+                "satooshi/php-coveralls": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "time": "2016-01-20T08:20:44+00:00"
         },
         {
             "name": "hassankhan/config",
@@ -6335,6 +6081,71 @@
                 "debugbar"
             ],
             "time": "2019-11-24T09:46:11+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "reference": "f69bbde7d7a75d6b2862d9ca8fab1cd28014b4be",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "~2.0",
+                "lib-pcre": ">=7.0",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "time": "2019-12-26T09:49:15+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -8030,20 +7841,6 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:56:45+00:00"
         },
         {
@@ -8097,20 +7894,6 @@
                 "config",
                 "configuration",
                 "options"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-03-27T16:56:45+00:00"
         },
@@ -8221,20 +8004,6 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-27T16:56:45+00:00"
         },
         {

--- a/tests/Browser/BrowserTestCase.php
+++ b/tests/Browser/BrowserTestCase.php
@@ -49,7 +49,7 @@ abstract class BrowserTestCase extends TestCase
     /**
      * Setup tests.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         // Don't accidentally run the migrations aganist the non-testing database. Ask me
         // how many times I've accidentally dropped my database...
@@ -97,7 +97,7 @@ abstract class BrowserTestCase extends TestCase
      * Tear down the test and delete all cookies from the browser instance to address
      * instances where the test would be kicked over to the login page.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         /** @var \Pterodactyl\Tests\Browser\PterodactylBrowser $browser */
         foreach (static::$browsers as $browser) {

--- a/tests/Browser/Processes/Authentication/LoginProcessTest.php
+++ b/tests/Browser/Processes/Authentication/LoginProcessTest.php
@@ -14,7 +14,7 @@ class LoginProcessTest extends BrowserTestCase
     /**
      * Setup tests.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Browser/Processes/Dashboard/DashboardTestCase.php
+++ b/tests/Browser/Processes/Dashboard/DashboardTestCase.php
@@ -14,7 +14,7 @@ abstract class DashboardTestCase extends BrowserTestCase
     /**
      * Setup tests and provide a default user to calling functions.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Api/Application/ApplicationApiIntegrationTestCase.php
+++ b/tests/Integration/Api/Application/ApplicationApiIntegrationTestCase.php
@@ -31,7 +31,7 @@ abstract class ApplicationApiIntegrationTestCase extends IntegrationTestCase
      * Bootstrap application API tests. Creates a default admin user and associated API key
      * and also sets some default headers required for accessing the API.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Api/Application/Nests/EggControllerTest.php
+++ b/tests/Integration/Api/Application/Nests/EggControllerTest.php
@@ -18,7 +18,7 @@ class EggControllerTest extends ApplicationApiIntegrationTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/Api/Application/Nests/NestControllerTest.php
+++ b/tests/Integration/Api/Application/Nests/NestControllerTest.php
@@ -17,7 +17,7 @@ class NestControllerTest extends ApplicationApiIntegrationTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -12,7 +12,7 @@ abstract class IntegrationTestCase extends TestCase
     /**
      * Setup base integration test cases.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -22,7 +22,7 @@ abstract class TestCase extends BaseTestCase
     /**
      * Tear down tests.
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 

--- a/tests/Unit/Commands/Environment/EmailSettingsCommandTest.php
+++ b/tests/Unit/Commands/Environment/EmailSettingsCommandTest.php
@@ -29,7 +29,7 @@ class EmailSettingsCommandTest extends CommandTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Commands/Location/DeleteLocationCommandTest.php
+++ b/tests/Unit/Commands/Location/DeleteLocationCommandTest.php
@@ -36,7 +36,7 @@ class DeleteLocationCommandTest extends CommandTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Commands/Location/MakeLocationCommandTest.php
+++ b/tests/Unit/Commands/Location/MakeLocationCommandTest.php
@@ -30,7 +30,7 @@ class MakeLocationCommandTest extends CommandTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Commands/Maintenance/CleanServiceBackupFilesCommandTest.php
+++ b/tests/Unit/Commands/Maintenance/CleanServiceBackupFilesCommandTest.php
@@ -30,7 +30,7 @@ class CleanServiceBackupFilesCommandTest extends CommandTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Commands/Schedule/ProcessRunnableCommandTest.php
+++ b/tests/Unit/Commands/Schedule/ProcessRunnableCommandTest.php
@@ -38,7 +38,7 @@ class ProcessRunnableCommandTest extends CommandTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Commands/Server/BulkPowerActionCommandTest.php
+++ b/tests/Unit/Commands/Server/BulkPowerActionCommandTest.php
@@ -27,7 +27,7 @@ class BulkPowerActionCommandTest extends CommandTestCase
     /**
      * Setup test.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Commands/User/DeleteUserCommandTest.php
+++ b/tests/Unit/Commands/User/DeleteUserCommandTest.php
@@ -32,7 +32,7 @@ class DeleteUserCommandTest extends CommandTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Commands/User/DisableTwoFactorCommandTest.php
+++ b/tests/Unit/Commands/User/DisableTwoFactorCommandTest.php
@@ -30,7 +30,7 @@ class DisableTwoFactorCommandTest extends CommandTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Commands/User/MakeUserCommandTest.php
+++ b/tests/Unit/Commands/User/MakeUserCommandTest.php
@@ -30,7 +30,7 @@ class MakeUserCommandTest extends CommandTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Controllers/Admin/DatabaseControllerTest.php
+++ b/tests/Unit/Http/Controllers/Admin/DatabaseControllerTest.php
@@ -65,7 +65,7 @@ class DatabaseControllerTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Controllers/Admin/MailControllerTest.php
+++ b/tests/Unit/Http/Controllers/Admin/MailControllerTest.php
@@ -40,7 +40,7 @@ class MailControllerTest extends ControllerTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Controllers/Admin/StatisticsControllerTest.php
+++ b/tests/Unit/Http/Controllers/Admin/StatisticsControllerTest.php
@@ -54,7 +54,7 @@ class StatisticsControllerTest extends ControllerTestCase
      */
     private $userRepository;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Controllers/Base/IndexControllerTest.php
+++ b/tests/Unit/Http/Controllers/Base/IndexControllerTest.php
@@ -52,7 +52,7 @@ class IndexControllerTest extends ControllerTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Controllers/Base/SecurityControllerTest.php
+++ b/tests/Unit/Http/Controllers/Base/SecurityControllerTest.php
@@ -44,7 +44,7 @@ class SecurityControllerTest extends ControllerTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Controllers/ControllerTestCase.php
+++ b/tests/Unit/Http/Controllers/ControllerTestCase.php
@@ -19,7 +19,7 @@ abstract class ControllerTestCase extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/API/AuthenticateKeyTest.php
+++ b/tests/Unit/Http/Middleware/API/AuthenticateKeyTest.php
@@ -34,7 +34,7 @@ class AuthenticateKeyTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Chronos::setTestNow(Chronos::now());

--- a/tests/Unit/Http/Middleware/API/SetSessionDriverTest.php
+++ b/tests/Unit/Http/Middleware/API/SetSessionDriverTest.php
@@ -17,7 +17,7 @@ class SetSessionDriverTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/Api/Daemon/DaemonAuthenticateTest.php
+++ b/tests/Unit/Http/Middleware/Api/Daemon/DaemonAuthenticateTest.php
@@ -20,7 +20,7 @@ class DaemonAuthenticateTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/DaemonAuthenticateTest.php
+++ b/tests/Unit/Http/Middleware/DaemonAuthenticateTest.php
@@ -17,7 +17,7 @@ class DaemonAuthenticateTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/LanguageMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/LanguageMiddlewareTest.php
@@ -17,7 +17,7 @@ class LanguageMiddlewareTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/MaintenanceMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/MaintenanceMiddlewareTest.php
@@ -19,7 +19,7 @@ class MaintenanceMiddlewareTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/MiddlewareTestCase.php
+++ b/tests/Unit/Http/Middleware/MiddlewareTestCase.php
@@ -14,7 +14,7 @@ abstract class MiddlewareTestCase extends TestCase
     /**
      * Setup tests with a mocked request object and normal attributes.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/RedirectIfAuthenticatedTest.php
+++ b/tests/Unit/Http/Middleware/RedirectIfAuthenticatedTest.php
@@ -17,7 +17,7 @@ class RedirectIfAuthenticatedTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/RequireTwoFactorAuthenticationTest.php
+++ b/tests/Unit/Http/Middleware/RequireTwoFactorAuthenticationTest.php
@@ -18,7 +18,7 @@ class RequireTwoFactorAuthenticationTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/Server/AccessingValidServerTest.php
+++ b/tests/Unit/Http/Middleware/Server/AccessingValidServerTest.php
@@ -30,7 +30,7 @@ class AccessingValidServerTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/Server/AuthenticateAsSubuserTest.php
+++ b/tests/Unit/Http/Middleware/Server/AuthenticateAsSubuserTest.php
@@ -19,7 +19,7 @@ class AuthenticateAsSubuserTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/Server/DatabaseBelongsToServerTest.php
+++ b/tests/Unit/Http/Middleware/Server/DatabaseBelongsToServerTest.php
@@ -19,7 +19,7 @@ class DatabaseBelongsToServerTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/Server/ScheduleBelongsToServerTest.php
+++ b/tests/Unit/Http/Middleware/Server/ScheduleBelongsToServerTest.php
@@ -22,7 +22,7 @@ class ScheduleBelongsToServerTest extends MiddlewareTestCase
      */
     private $repository;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Http/Middleware/Server/SubuserBelongsToServerTest.php
+++ b/tests/Unit/Http/Middleware/Server/SubuserBelongsToServerTest.php
@@ -27,7 +27,7 @@ class SubuserBelongsToServerTest extends MiddlewareTestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Jobs/Schedule/RunTaskJobTest.php
+++ b/tests/Unit/Jobs/Schedule/RunTaskJobTest.php
@@ -54,7 +54,7 @@ class RunTaskJobTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Bus::fake();

--- a/tests/Unit/Services/Allocations/AllocationDeletionServiceTest.php
+++ b/tests/Unit/Services/Allocations/AllocationDeletionServiceTest.php
@@ -15,7 +15,7 @@ class AllocationDeletionServiceTest extends TestCase
      */
     private $repository;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Allocations/AssignmentServiceTest.php
+++ b/tests/Unit/Services/Allocations/AssignmentServiceTest.php
@@ -29,7 +29,7 @@ class AssignmentServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Allocations/SetDefaultAllocationServiceTest.php
+++ b/tests/Unit/Services/Allocations/SetDefaultAllocationServiceTest.php
@@ -44,7 +44,7 @@ class SetDefaultAllocationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Api/KeyCreationServiceTest.php
+++ b/tests/Unit/Services/Api/KeyCreationServiceTest.php
@@ -27,7 +27,7 @@ class KeyCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/DaemonKeys/DaemonKeyCreationServiceTest.php
+++ b/tests/Unit/Services/DaemonKeys/DaemonKeyCreationServiceTest.php
@@ -59,7 +59,7 @@ class DaemonKeyCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/DaemonKeys/DaemonKeyProviderServiceTest.php
+++ b/tests/Unit/Services/DaemonKeys/DaemonKeyProviderServiceTest.php
@@ -48,7 +48,7 @@ class DaemonKeyProviderServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Carbon::setTestNow(Carbon::now());

--- a/tests/Unit/Services/DaemonKeys/DaemonKeyUpdateServiceTest.php
+++ b/tests/Unit/Services/DaemonKeys/DaemonKeyUpdateServiceTest.php
@@ -44,7 +44,7 @@ class DaemonKeyUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/DaemonKeys/RevokeMultipleDaemonKeysServiceTest.php
+++ b/tests/Unit/Services/DaemonKeys/RevokeMultipleDaemonKeysServiceTest.php
@@ -30,7 +30,7 @@ class RevokeMultipleDaemonKeysServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Databases/DatabasePasswordServiceTest.php
+++ b/tests/Unit/Services/Databases/DatabasePasswordServiceTest.php
@@ -36,7 +36,7 @@ class DatabasePasswordServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Databases/DeployServerDatabaseServiceTest.php
+++ b/tests/Unit/Services/Databases/DeployServerDatabaseServiceTest.php
@@ -31,7 +31,7 @@ class DeployServerDatabaseServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Databases/Hosts/HostCreationServiceTest.php
+++ b/tests/Unit/Services/Databases/Hosts/HostCreationServiceTest.php
@@ -42,7 +42,7 @@ class HostCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Databases/Hosts/HostDeletionServiceTest.php
+++ b/tests/Unit/Services/Databases/Hosts/HostDeletionServiceTest.php
@@ -25,7 +25,7 @@ class HostDeletionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Databases/Hosts/HostUpdateServiceTest.php
+++ b/tests/Unit/Services/Databases/Hosts/HostUpdateServiceTest.php
@@ -42,7 +42,7 @@ class HostUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/EggConfigurationServiceTest.php
+++ b/tests/Unit/Services/Eggs/EggConfigurationServiceTest.php
@@ -23,7 +23,7 @@ class EggConfigurationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/EggCreationServiceTest.php
+++ b/tests/Unit/Services/Eggs/EggCreationServiceTest.php
@@ -41,7 +41,7 @@ class EggCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/EggDeletionServiceTest.php
+++ b/tests/Unit/Services/Eggs/EggDeletionServiceTest.php
@@ -38,7 +38,7 @@ class EggDeletionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/EggUpdateServiceTest.php
+++ b/tests/Unit/Services/Eggs/EggUpdateServiceTest.php
@@ -37,7 +37,7 @@ class EggUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/Scripts/InstallScriptServiceTest.php
+++ b/tests/Unit/Services/Eggs/Scripts/InstallScriptServiceTest.php
@@ -48,7 +48,7 @@ class InstallScriptServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/Sharing/EggExporterServiceTest.php
+++ b/tests/Unit/Services/Eggs/Sharing/EggExporterServiceTest.php
@@ -40,7 +40,7 @@ class EggExporterServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/Sharing/EggImporterServiceTest.php
+++ b/tests/Unit/Services/Eggs/Sharing/EggImporterServiceTest.php
@@ -62,7 +62,7 @@ class EggImporterServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/Sharing/EggUpdateImporterServiceTest.php
+++ b/tests/Unit/Services/Eggs/Sharing/EggUpdateImporterServiceTest.php
@@ -45,7 +45,7 @@ class EggUpdateImporterServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/Variables/VariableCreationServiceTest.php
+++ b/tests/Unit/Services/Eggs/Variables/VariableCreationServiceTest.php
@@ -25,7 +25,7 @@ class VariableCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Eggs/Variables/VariableUpdateServiceTest.php
+++ b/tests/Unit/Services/Eggs/Variables/VariableUpdateServiceTest.php
@@ -32,7 +32,7 @@ class VariableUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Helpers/SoftwareVersionServiceTest.php
+++ b/tests/Unit/Services/Helpers/SoftwareVersionServiceTest.php
@@ -51,7 +51,7 @@ class SoftwareVersionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Locations/LocationCreationServiceTest.php
+++ b/tests/Unit/Services/Locations/LocationCreationServiceTest.php
@@ -30,7 +30,7 @@ class LocationCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Locations/LocationDeletionServiceTest.php
+++ b/tests/Unit/Services/Locations/LocationDeletionServiceTest.php
@@ -37,7 +37,7 @@ class LocationDeletionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Locations/LocationUpdateServiceTest.php
+++ b/tests/Unit/Services/Locations/LocationUpdateServiceTest.php
@@ -30,7 +30,7 @@ class LocationUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Nests/NestCreationServiceTest.php
+++ b/tests/Unit/Services/Nests/NestCreationServiceTest.php
@@ -34,7 +34,7 @@ class NestCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Nests/NestDeletionServiceTest.php
+++ b/tests/Unit/Services/Nests/NestDeletionServiceTest.php
@@ -37,7 +37,7 @@ class NestDeletionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Nests/NestUpdateServiceTest.php
+++ b/tests/Unit/Services/Nests/NestUpdateServiceTest.php
@@ -29,7 +29,7 @@ class NestUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Nodes/NodeCreationServiceTest.php
+++ b/tests/Unit/Services/Nodes/NodeCreationServiceTest.php
@@ -32,7 +32,7 @@ class NodeCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Nodes/NodeDeletionServiceTest.php
+++ b/tests/Unit/Services/Nodes/NodeDeletionServiceTest.php
@@ -42,7 +42,7 @@ class NodeDeletionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Nodes/NodeUpdateServiceTest.php
+++ b/tests/Unit/Services/Nodes/NodeUpdateServiceTest.php
@@ -36,7 +36,7 @@ class NodeUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Packs/ExportPackServiceTest.php
+++ b/tests/Unit/Services/Packs/ExportPackServiceTest.php
@@ -45,7 +45,7 @@ class ExportPackServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Packs/PackCreationServiceTest.php
+++ b/tests/Unit/Services/Packs/PackCreationServiceTest.php
@@ -54,7 +54,7 @@ class PackCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Packs/PackDeletionServiceTest.php
+++ b/tests/Unit/Services/Packs/PackDeletionServiceTest.php
@@ -49,7 +49,7 @@ class PackDeletionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Packs/PackUpdateServiceTest.php
+++ b/tests/Unit/Services/Packs/PackUpdateServiceTest.php
@@ -37,7 +37,7 @@ class PackUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Packs/TemplateUploadServiceTest.php
+++ b/tests/Unit/Services/Packs/TemplateUploadServiceTest.php
@@ -49,7 +49,7 @@ class TemplateUploadServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Schedules/ProcessScheduleServiceTest.php
+++ b/tests/Unit/Services/Schedules/ProcessScheduleServiceTest.php
@@ -33,7 +33,7 @@ class ProcessScheduleServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Servers/EnvironmentServiceTest.php
+++ b/tests/Unit/Services/Servers/EnvironmentServiceTest.php
@@ -27,7 +27,7 @@ class EnvironmentServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Servers/ReinstallServerServiceTest.php
+++ b/tests/Unit/Services/Servers/ReinstallServerServiceTest.php
@@ -55,7 +55,7 @@ class ReinstallServerServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Servers/ServerConfigurationStructureServiceTest.php
+++ b/tests/Unit/Services/Servers/ServerConfigurationStructureServiceTest.php
@@ -26,7 +26,7 @@ class ServerConfigurationStructureServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Servers/ServerCreationServiceTest.php
+++ b/tests/Unit/Services/Servers/ServerCreationServiceTest.php
@@ -89,7 +89,7 @@ class ServerCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Servers/ServerDeletionServiceTest.php
+++ b/tests/Unit/Services/Servers/ServerDeletionServiceTest.php
@@ -52,7 +52,7 @@ class ServerDeletionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Servers/StartupCommandViewServiceTest.php
+++ b/tests/Unit/Services/Servers/StartupCommandViewServiceTest.php
@@ -22,7 +22,7 @@ class StartupCommandViewServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Servers/StartupModificationServiceTest.php
+++ b/tests/Unit/Services/Servers/StartupModificationServiceTest.php
@@ -57,7 +57,7 @@ class StartupModificationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Servers/SuspensionServiceTest.php
+++ b/tests/Unit/Services/Servers/SuspensionServiceTest.php
@@ -62,7 +62,7 @@ class SuspensionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Servers/VariableValidatorServiceTest.php
+++ b/tests/Unit/Services/Servers/VariableValidatorServiceTest.php
@@ -34,7 +34,7 @@ class VariableValidatorServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Subusers/PermissionCreationServiceTest.php
+++ b/tests/Unit/Services/Subusers/PermissionCreationServiceTest.php
@@ -29,7 +29,7 @@ class PermissionCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Subusers/SubuserCreationServiceTest.php
+++ b/tests/Unit/Services/Subusers/SubuserCreationServiceTest.php
@@ -65,7 +65,7 @@ class SubuserCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Subusers/SubuserUpdateServiceTest.php
+++ b/tests/Unit/Services/Subusers/SubuserUpdateServiceTest.php
@@ -64,7 +64,7 @@ class SubuserUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Users/ToggleTwoFactorServiceTest.php
+++ b/tests/Unit/Services/Users/ToggleTwoFactorServiceTest.php
@@ -41,7 +41,7 @@ class ToggleTwoFactorServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         Carbon::setTestNow(Carbon::now());

--- a/tests/Unit/Services/Users/TwoFactorSetupServiceTest.php
+++ b/tests/Unit/Services/Users/TwoFactorSetupServiceTest.php
@@ -30,7 +30,7 @@ class TwoFactorSetupServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Users/UserCreationServiceTest.php
+++ b/tests/Unit/Services/Users/UserCreationServiceTest.php
@@ -41,7 +41,7 @@ class UserCreationServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Users/UserDeletionServiceTest.php
+++ b/tests/Unit/Services/Users/UserDeletionServiceTest.php
@@ -47,7 +47,7 @@ class UserDeletionServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/Services/Users/UserUpdateServiceTest.php
+++ b/tests/Unit/Services/Users/UserUpdateServiceTest.php
@@ -31,7 +31,7 @@ class UserUpdateServiceTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Laravel 5.8 added support for PHPUnit 8 ([PR](https://github.com/laravel/framework/pull/27441)) and since then requires `: void` on all `setUp()` and `tearDown()` methods. This PR adds that return type. I've also added two missing dependencies (Faker and Mockery) that are required for testing.

About a quarter of all tests still seem to be failing (at least on my machine), so it would take a bit more effort to get them all green. But it's a start!