### PR TITLE
CSS Changes

### DIFF
--- a/public/themes/pterodactyl/css/pterodactyl.css
+++ b/public/themes/pterodactyl/css/pterodactyl.css
@@ -522,7 +522,7 @@ body {
 }
 
 .skin-blue .sidebar-menu>li.header {
-    color: #444a5d;
+    color: #797979;
     background: #0e111582;
 }
 
@@ -603,19 +603,7 @@ body {
     border-bottom: 1px solid #1f2933;
 }
 
-.box.box-success {
-    border-top-color: #1f2933;
-}
-
-.box.box-primary {
-    border-top-color: #1f2933;
-}
-
 .box.box-default {
-    border-top-color: #1f2933;
-}
-
-.box.box-danger {
     border-top-color: #1f2933;
 }
 
@@ -822,4 +810,26 @@ fieldset[disabled] .form-control {
 
 .well-sm {
     padding: 9px;
+}
+
+.small-box h3, .small-box p {
+    color: #c3c3c3;
+}
+
+.small-box-footer {
+    color: #288afb;
+}
+
+.small-box .icon {
+    color: #cad1d8;
+}
+
+.bg-gray {
+    background-color: #33404d !important;
+}
+
+pre {
+    color: #cad1d8;
+    background-color: #515f6cbb;
+    border-color: #1f2933;
 }

--- a/resources/views/admin/nodes/view/allocation.blade.php
+++ b/resources/views/admin/nodes/view/allocation.blade.php
@@ -83,8 +83,6 @@
                             <td class="col-sm-1 middle">
                                 @if(is_null($allocation->server_id))
                                     <button data-action="deallocate" data-id="{{ $allocation->id }}" class="btn btn-sm btn-danger"><i class="fa fa-trash-o"></i></button>
-                                @else
-                                    <button class="btn btn-sm disabled"><i class="fa fa-trash-o"></i></button>
                                 @endif
                             </td>
                         </tr>

--- a/resources/views/admin/nodes/view/index.blade.php
+++ b/resources/views/admin/nodes/view/index.blade.php
@@ -132,7 +132,7 @@
                         </div>
                     </div>
                     <div class="col-sm-12">
-                        <div class="info-box bg-gray">
+                        <div class="info-box bg-blue">
                             <span class="info-box-icon"><i class="ion ion-social-buffer-outline"></i></span>
                             <div class="info-box-content" style="padding: 23px 10px 0;">
                                 <span class="info-box-text">Total Servers</span>


### PR DESCRIPTION
More CSS Changes...

Server overview page now looks more..... fluid
Boxes have their correct color top colors back. When the admin side was changed to dark theme all but yellow was changed to a single color, this is reverted.
The node overview page uses blue over the gray box for total servers.
Lightened the text color on the sidebar
Removed the delete button for allocations that are assigned.
Changes Node configuration box to not hurt eyes