### PR TITLE
Allow changing back to unrestricted CPU quota

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -113,7 +113,7 @@ class Server extends Model
         'memory' => 'required|numeric|min:0',
         'swap' => 'required|numeric|min:-1',
         'io' => 'required|numeric|between:10,1000',
-        'cpu' => 'required|numeric|min:0',
+        'cpu' => 'required|numeric|min:-1',
         'threads' => 'nullable|regex:/^[0-9-,]+$/',
         'oom_disabled' => 'sometimes|boolean',
         'disk' => 'required|numeric|min:0',


### PR DESCRIPTION
Found a little bug trying to set one of my testing servers back to unlimited quota. `0` does not work as unlimited as Docker appears to only interpret `-1` as unlimited.