### PR TITLE
Allow changing back to unlimited CPU quota

### DIFF
--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -113,7 +113,7 @@ class Server extends Model
         'memory' => 'required|numeric|min:0',
         'swap' => 'required|numeric|min:-1',
         'io' => 'required|numeric|between:10,1000',
-        'cpu' => 'required|numeric|min:0',
+        'cpu' => 'required|numeric|min:-1',
         'threads' => 'nullable|regex:/^[0-9-,]+$/',
         'oom_disabled' => 'sometimes|boolean',
         'disk' => 'required|numeric|min:0',

--- a/database/migrations/2020_05_19_094911_allow_unlimited_cpu_quota.php
+++ b/database/migrations/2020_05_19_094911_allow_unlimited_cpu_quota.php
@@ -1,8 +1,8 @@
 <?php
   
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class AllowUnlimitedCpuQuota extends Migration
 {

--- a/database/migrations/2020_05_19_094911_allow_unlimited_cpu_quota.php
+++ b/database/migrations/2020_05_19_094911_allow_unlimited_cpu_quota.php
@@ -1,5 +1,5 @@
 <?php
-  
+
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2020_05_19_094911_allow_unlimited_cpu_quota.php
+++ b/database/migrations/2020_05_19_094911_allow_unlimited_cpu_quota.php
@@ -1,0 +1,32 @@
+<?php
+  
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AllowUnlimitedCpuQuota extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->integer('cpu')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->integer('cpu')->unsigned()->change();
+        });
+    }
+}

--- a/resources/scripts/components/dashboard/ServerRow.tsx
+++ b/resources/scripts/components/dashboard/ServerRow.tsx
@@ -48,7 +48,7 @@ export default ({ server, className }: { server: Server; className: string | und
 
     const alarms = { cpu: false, memory: false, disk: false };
     if (stats) {
-        alarms.cpu = server.limits.cpu === 0 ? false : (stats.cpuUsagePercent >= (server.limits.cpu * 0.9));
+        alarms.cpu = server.limits.cpu === -1 ? false : (stats.cpuUsagePercent >= (server.limits.cpu * 0.9));
         alarms.memory = isAlarmState(stats.memoryUsageInBytes, server.limits.memory);
         alarms.disk = server.limits.disk === 0 ? false : isAlarmState(stats.diskUsageInBytes, server.limits.disk);
     }

--- a/resources/views/admin/servers/new.blade.php
+++ b/resources/views/admin/servers/new.blade.php
@@ -150,7 +150,7 @@
                         <label for="pCPU">CPU Limit</label>
 
                         <div class="input-group">
-                            <input type="text" id="pCPU" name="cpu" class="form-control" value="{{ old('cpu', 0) }}" />
+                            <input type="text" id="pCPU" name="cpu" class="form-control" value="{{ old('cpu', -1) }}" />
                             <span class="input-group-addon">%</span>
                         </div>
 

--- a/resources/views/admin/servers/view/index.blade.php
+++ b/resources/views/admin/servers/view/index.blade.php
@@ -60,7 +60,7 @@
                             <tr>
                                 <td>CPU Limit</td>
                                 <td>
-                                    @if($server->cpu === 0)
+                                    @if($server->cpu === -1)
                                         <code>Unlimited</code>
                                     @else
                                         <code>{{ $server->cpu }}%</code>


### PR DESCRIPTION
Noticed this bug while trying to play around with CPU quotas in the panel on my testing servers. Setting the quota to anything initially works, but when setting it back to zero to remove the quota, the setting does not apply. Docker only accepts `-1` as an unlimited parameter for CPU quota.

This PR fixes this misunderstanding and allows for setting of CPU quotas back to unlimited.