### PR TITLE
Save maxconnection value to DB

### DIFF
--- a/app/Http/Controllers/Admin/ServersController.php
+++ b/app/Http/Controllers/Admin/ServersController.php
@@ -323,6 +323,7 @@ class ServersController extends Controller
             'database' => $request->input('database'),
             'remote' => $request->input('remote'),
             'database_host_id' => $request->input('database_host_id'),
+            'max_connections' => $request->input('max_connections'),
         ]);
 
         return redirect()->route('admin.servers.view.database', $server)->withInput();


### PR DESCRIPTION
Fixes #2047

Apparently I never had the value saved to the database so it was never actually used...... I probably missed that file in the original PR. 

Using beta 4 as a base and editing this file restores functionality 