### PR TITLE
Show Unlimited instead of 0MB for disk space on about page ( Admin Side )

### DIFF
--- a/resources/views/admin/servers/view/index.blade.php
+++ b/resources/views/admin/servers/view/index.blade.php
@@ -97,7 +97,13 @@
                             </tr>
                             <tr>
                                 <td>Disk Space</td>
-                                <td><code>{{ $server->disk }}MB</code></td>
+                                <td>
+                                    @if($server->disk === 0)
+                                        <code>Unlimited</code>
+                                    @else
+                                        <code>{{ $server->disk }}MB</code>
+                                    @endif
+                                </td>
                             </tr>
                             <tr>
                                 <td>Block IO Weight</td>


### PR DESCRIPTION
I guess I missed this one when I set everything to show unlimited when its 0.

Shows Unlimited disk space instead of 0 on admin about page.