### PR TITLE
Change to BytesToHuman on server view for limits, to match index page. Changes to CPU/Memory Graph 

### DIFF
--- a/resources/scripts/components/server/ServerConsole.tsx
+++ b/resources/scripts/components/server/ServerConsole.tsx
@@ -112,7 +112,7 @@ export default () => {
                             className={'mr-1'}
                         />
                         &nbsp;{bytesToHuman(memory)}
-                        <span className={'text-neutral-500'}> / {server.limits.memory} MB</span>
+                        <span className={'text-neutral-500'}> / {bytesToHuman(server.limits.memory * 1000 * 1000)}</span>
                     </p>
                     <p className={'text-xs mt-2'}>
                         <FontAwesomeIcon
@@ -121,7 +121,7 @@ export default () => {
                             className={'mr-1'}
                         />
                         &nbsp;{bytesToHuman(disk)}
-                        <span className={'text-neutral-500'}> / {server.limits.disk} MB</span>
+                        <span className={'text-neutral-500'}> / {bytesToHuman(server.limits.disk * 1000 * 1000)}</span>
                     </p>
                 </TitledGreyBox>
                 {!server.isInstalling ?

--- a/resources/scripts/components/server/StatGraphs.tsx
+++ b/resources/scripts/components/server/StatGraphs.tsx
@@ -17,14 +17,14 @@ const chartDefaults: ChartConfiguration = {
             enabled: false,
         },
         animation: {
-            duration: 250,
+            duration: 0,
         },
         elements: {
             point: {
                 radius: 0,
             },
             line: {
-                tension: 0.1,
+                tension: 0.3,
                 backgroundColor: 'rgba(15, 178, 184, 0.45)',
                 borderColor: '#32D0D9',
             },


### PR DESCRIPTION
Changes server view to use bytestohuman to show 10 GB as it does on the main index.

![image](https://user-images.githubusercontent.com/1757840/82976564-69b74b00-9fad-11ea-8f62-dda559f61854.png)

![image](https://user-images.githubusercontent.com/1757840/82976573-6d4ad200-9fad-11ea-80e2-ed877364d86f.png)

Changed:
![image](https://user-images.githubusercontent.com/1757840/82976595-80f63880-9fad-11ea-8b48-55f5ffc755e0.png)



Removed animation duration on the graph so it doesn't look likes it glitching when a new value is pushed, also made it a little more curvier.


