### PR TITLE
Add 'db:backup' command to artisan command line

### DIFF
--- a/app/Console/Commands/BackupDatabase.php
+++ b/app/Console/Commands/BackupDatabase.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pterodactyl\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class BackupDatabase extends Command
+{
+    protected $signature = 'db:backup';
+
+    protected $description = 'Provides a exported sql file of the panels current database.';
+
+    /**
+     *
+     * @param \Illuminate\Contracts\Config\Repository $config
+     */
+    public function __construct(ConfigRepository $config)
+    {
+        parent::__construct();
+        $this->config = $config;
+        $this->process = new Process(sprintf(
+            'mysqldump -h %s -P %s -u%s -p%s %s > %s',
+            $this->config->get('database.connections.mysql.host'),
+            $this->config->get('database.connections.mysql.port'),
+            $this->config->get('database.connections.mysql.username'),
+            $this->config->get('database.connections.mysql.password'),
+            $this->config->get('database.connections.mysql.database'),
+            storage_path('../backup.sql')
+        ));
+    }
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        try {
+            $this->process->mustRun();
+            $this->info('The database backup has completed successfully.');
+        } catch (ProcessFailedException $exception) {
+            $this->error('The backup process has failed...');
+            $this->error($exception->getMessage());
+        }
+    }
+}

--- a/app/Console/Commands/BackupDatabase.php
+++ b/app/Console/Commands/BackupDatabase.php
@@ -11,7 +11,7 @@ class BackupDatabase extends Command
 {
     protected $signature = 'db:backup';
 
-    protected $description = 'Provides a exported sql file of the panels current database.';
+    protected $description = 'Provides an exported sql file of the panels current database.';
 
     /**
      * @param \Illuminate\Contracts\Config\Repository $config
@@ -27,7 +27,7 @@ class BackupDatabase extends Command
             $this->config->get('database.connections.mysql.username'),
             $this->config->get('database.connections.mysql.password'),
             $this->config->get('database.connections.mysql.database'),
-            storage_path('../backup.sql')
+            storage_path('../' . $this->config->get('database.connections.mysql.database') . '-' . date('Y-m-d-H-i') . '.sql')
         ));
     }
 

--- a/app/Console/Commands/BackupDatabase.php
+++ b/app/Console/Commands/BackupDatabase.php
@@ -30,6 +30,7 @@ class BackupDatabase extends Command
             storage_path('../backup.sql')
         ));
     }
+
     /**
      * Run the command.
      * @return mixed

--- a/app/Console/Commands/BackupDatabase.php
+++ b/app/Console/Commands/BackupDatabase.php
@@ -14,7 +14,6 @@ class BackupDatabase extends Command
     protected $description = 'Provides a exported sql file of the panels current database.';
 
     /**
-     *
      * @param \Illuminate\Contracts\Config\Repository $config
      */
     public function __construct(ConfigRepository $config)
@@ -32,7 +31,7 @@ class BackupDatabase extends Command
         ));
     }
     /**
-     * Run the command
+     * Run the command.
      * @return mixed
      */
     public function handle()


### PR DESCRIPTION
Allows users to export the panel's database to an SQL file using `mysqldump`, uses the config values in the .env, This is reliant on MySQL / MariaDB being installed on the machine the panel is running on.

If there is a better way of doing this, please do show.

![](https://cdn.discordapp.com/attachments/297133809130799127/718324958463262730/2020-06-05_00-46-41.gif)