### PR TITLE
Client API Creation Limit

### DIFF
--- a/app/Http/Controllers/Base/ClientApiController.php
+++ b/app/Http/Controllers/Base/ClientApiController.php
@@ -78,11 +78,11 @@ class ClientApiController extends Controller
      */
     public function store(CreateClientApiKeyRequest $request): RedirectResponse
     {
-        
-       $Count = $this->repository->findCountWhere([
+
+       $count = $this->repository->findCountWhere([
        ['user_id', '=', $request->user()->id],
        ['key_type', '=', ApiKey::TYPE_ACCOUNT]]);
-       if ($Count >= 5) {
+       if ($count >= 5) {
         throw new DisplayException(
             'Cannot assign more than 5 Client API keys to an account.'
         );

--- a/app/Http/Controllers/Base/ClientApiController.php
+++ b/app/Http/Controllers/Base/ClientApiController.php
@@ -78,11 +78,15 @@ class ClientApiController extends Controller
      */
     public function store(CreateClientApiKeyRequest $request): RedirectResponse
     {
-        if ($this->repository->findCountWhere(['user_id' => $request->user()->id]) >= 5) {
-            throw new DisplayException(
-                'Cannot assign more than 5 Client API keys to an account.'
-            );
-        }
+        
+       $Count = $this->repository->findCountWhere([
+       ['user_id', '=', $request->user()->id],
+       ['key_type', '=', ApiKey::TYPE_ACCOUNT]]);
+       if ($Count >= 5) {
+        throw new DisplayException(
+            'Cannot assign more than 5 Client API keys to an account.'
+        );
+       }
 
         $allowedIps = null;
         if (! is_null($request->input('allowed_ips'))) {

--- a/app/Http/Controllers/Base/ClientApiController.php
+++ b/app/Http/Controllers/Base/ClientApiController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Response;
 use Pterodactyl\Models\ApiKey;
 use Illuminate\Http\RedirectResponse;
 use Prologue\Alerts\AlertsMessageBag;
+use Pterodactyl\Exceptions\DisplayException;
 use Pterodactyl\Http\Controllers\Controller;
 use Pterodactyl\Services\Api\KeyCreationService;
 use Pterodactyl\Http\Requests\Base\CreateClientApiKeyRequest;
@@ -77,6 +78,12 @@ class ClientApiController extends Controller
      */
     public function store(CreateClientApiKeyRequest $request): RedirectResponse
     {
+        if ($this->repository->findCountWhere(['user_id' => $request->user()->id]) >= 5) {
+            throw new DisplayException(
+                'Cannot assign more than 5 Client API keys to an account.'
+            );
+        }
+
         $allowedIps = null;
         if (! is_null($request->input('allowed_ips'))) {
             $allowedIps = json_encode(explode(PHP_EOL, $request->input('allowed_ips')));

--- a/app/Http/Controllers/Base/ClientApiController.php
+++ b/app/Http/Controllers/Base/ClientApiController.php
@@ -79,14 +79,14 @@ class ClientApiController extends Controller
     public function store(CreateClientApiKeyRequest $request): RedirectResponse
     {
 
-       $count = $this->repository->findCountWhere([
-       ['user_id', '=', $request->user()->id],
-       ['key_type', '=', ApiKey::TYPE_ACCOUNT]]);
-       if ($count >= 5) {
-        throw new DisplayException(
+        $count = $this->repository->findCountWhere([
+            ['user_id', '=', $request->user()->id],
+            ['key_type', '=', ApiKey::TYPE_ACCOUNT], ]);
+        if ($count >= 5) {
+            throw new DisplayException(
             'Cannot assign more than 5 Client API keys to an account.'
         );
-       }
+        }
 
         $allowedIps = null;
         if (! is_null($request->input('allowed_ips'))) {

--- a/config/app.php
+++ b/config/app.php
@@ -9,7 +9,7 @@ return [
     | change this value if you are not maintaining your own internal versions.
     */
 
-    'version' => 'canary',
+    'version' => '0.7.17',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This was a security issue detailed here: https://github.com/pterodactyl/panel/security/advisories/GHSA-pjmh-7xfm-r4x9

Dane, you missed adding it to the Client API too. We don't want Client APIs to exceed more than 5 at a time.