### PR TITLE
Fix #terminal css line formatting

### DIFF
--- a/public/themes/pterodactyl/css/terminal.css
+++ b/public/themes/pterodactyl/css/terminal.css
@@ -27,6 +27,7 @@
 #terminal > .cmd {
     padding: 1px 0;
     word-wrap: break-word;
+    white-space: pre-wrap;
 }
 
 #terminal_input {


### PR DESCRIPTION
Add missing [white-space: pre-wrap] to [#terminal > .cmd]

Before
![before](https://i.imgur.com/lNAFDCU.png)

After
![after](https://i.imgur.com/g41Kfuf.png)