### PR TITLE
add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      
+      - name: Create release branch and bump version
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          BRANCH=release/${REF:10}
+          git config --local user.email "ci@pterodactyl.io"
+          git config --local user.name "Pterodactyl CI"
+          git checkout -b $BRANCH
+          git push -u origin $BRANCH
+          sed -i "s/    'version' => 'canary',/    'version' => '${REF:11}',/" config/app.php
+          git add config/app.php
+          git commit -m "bump version for release"
+          git push
+
+      - name: Build assets
+        run: |
+          yarn install
+          yarn run build:production
+      
+      - name: Create release archive
+        run: |
+          rm -rf node_modules/ test/ codecov.yml CODE_OF_CONDUCT.md CONTRIBUTING.md phpunit.dusk.xml phpunit.xml Vagrantfile
+          tar -czf panel.tar.gz *
+
+      - name: Extract changelog
+        id: extract_changelog
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          sed -n "/^## ${REF:10}/,/^## /{/^## /b;p}" CHANGELOG.md > ./RELEASE_CHANGELOG
+          echo ::set-output name=version_name::`sed -nr "s/^## (${REF:10} .*)$/\1/p" CHANGELOG.md`
+
+      - name: Create checksum and add to changelog
+        run: |
+          SUM=`sha256sum panel.tar.gz`
+          echo -e "\n#### SHA256 Checksum\n\n\`\`\`\n$SUM\n\`\`\`\n" >> ./RELEASE_CHANGELOG
+          echo $SUM > checksum.txt
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ steps.extract_changelog.outputs.version_name }}
+          body_path: ./RELEASE_CHANGELOG
+          draft: true
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') }}
+      
+      - name: Upload binary
+        id: upload-release-archive
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: panel.tar.gz
+          asset_name: panel.tar.gz
+          asset_content_type: application/gzip
+      
+      - name: Upload checksum
+        id: upload-release-checksum 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: ./checksum.txt
+          asset_name: checksum.txt
+          asset_content_type: text/plain

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: tests
 on:
   push:
+    branch-ignore:
+      - 'master'
+      - 'release/**'
   pull_request:
 jobs:
   integration_tests:


### PR DESCRIPTION
This adds automation for releases.

* builds assets
* creates release archive
* extracts the changelog and appends the sha256sum of the binary.
* creates a release branch and commits version
* creates a draft release
* uploads archive and checksum

The changelog is extracted from CHANGELOG.md. It takes everything between /^## <tag>/ and /^##/, aka. everything between the h2 of the current version and the next h2.
The name of the release is also extracted from the changelog from the full h2 line of the release.

If the version contains beta or alpha the release is marked as a pre-release.

![image](https://user-images.githubusercontent.com/1710904/86523509-e1f71300-be6d-11ea-94e9-0a7d1393e156.png)
![image](https://user-images.githubusercontent.com/1710904/86523512-e7ecf400-be6d-11ea-8ae0-436277cfb5bf.png)
