### PR TITLE
Fix default values not applied in server creation

### DIFF
--- a/app/Services/Servers/ServerCreationService.php
+++ b/app/Services/Servers/ServerCreationService.php
@@ -242,16 +242,16 @@ class ServerCreationService
             'io' => Arr::get($data, 'io'),
             'cpu' => Arr::get($data, 'cpu'),
             'threads' => Arr::get($data, 'threads'),
-            'oom_disabled' => Arr::get($data, 'oom_disabled', true),
+            'oom_disabled' => Arr::get($data, 'oom_disabled') ?? true,
             'allocation_id' => Arr::get($data, 'allocation_id'),
             'nest_id' => Arr::get($data, 'nest_id'),
             'egg_id' => Arr::get($data, 'egg_id'),
             'pack_id' => empty($data['pack_id']) ? null : $data['pack_id'],
             'startup' => Arr::get($data, 'startup'),
             'image' => Arr::get($data, 'image'),
-            'database_limit' => Arr::get($data, 'database_limit', 0),
-            'allocation_limit' => Arr::get($data, 'allocation_limit', 0),
-            'backup_limit' => Arr::get($data, 'backup_limit', 0),
+            'database_limit' => Arr::get($data, 'database_limit') ?? 0,
+            'allocation_limit' => Arr::get($data, 'allocation_limit') ?? 0,
+            'backup_limit' => Arr::get($data, 'backup_limit') ?? 0,
         ]);
 
         return $model;


### PR DESCRIPTION
This should fix the panel side for issue #2261. Wings will no longer crash because it will receive good data but I still think it shouldn't crash when that's not the case.
I didn't update the CHANGELOG.md since there seems to be no changelog yet for these beta version.