### PR TITLE
Arrange cron times in proper order to match

### DIFF
--- a/resources/scripts/components/server/schedules/EditScheduleModal.tsx
+++ b/resources/scripts/components/server/schedules/EditScheduleModal.tsx
@@ -40,16 +40,16 @@ const EditScheduleModal = ({ schedule, ...props }: Omit<Props, 'onScheduleUpdate
                 />
                 <div css={tw`flex mt-6`}>
                     <div css={tw`flex-1 mr-4`}>
-                        <Field name={'dayOfWeek'} label={'Day of week'}/>
-                    </div>
-                    <div css={tw`flex-1 mr-4`}>
-                        <Field name={'dayOfMonth'} label={'Day of month'}/>
+                        <Field name={'minute'} label={'Minute'}/>
                     </div>
                     <div css={tw`flex-1 mr-4`}>
                         <Field name={'hour'} label={'Hour'}/>
                     </div>
+                    <div css={tw`flex-1 mr-4`}>
+                        <Field name={'dayOfMonth'} label={'Day of month'}/>
+                    </div>
                     <div css={tw`flex-1`}>
-                        <Field name={'minute'} label={'Minute'}/>
+                        <Field name={'dayOfWeek'} label={'Day of week'}/>
                     </div>
                 </div>
                 <p css={tw`text-neutral-400 text-xs mt-2`}>


### PR DESCRIPTION
Moves the rendering of the time boxes to proper locations to match the view on the main schedules page and to match cron syntax