### PR TITLE
fix: remove ./ before wings for auto-configuration

### DIFF
--- a/resources/views/admin/nodes/view/configuration.blade.php
+++ b/resources/views/admin/nodes/view/configuration.blade.php
@@ -74,7 +74,7 @@
             swal({
                 type: 'success',
                 title: 'Token created.',
-                text: '<p>To auto-configure your node run the following command:<br /><small><pre>cd /etc/pterodactyl && sudo ./wings configure --panel-url {{ config('app.url') }} --token ' + data.token + ' --node ' + data.node + '{{ config('app.debug') ? ' --allow-insecure' : '' }}</pre></small></p>',
+                text: '<p>To auto-configure your node run the following command:<br /><small><pre>cd /etc/pterodactyl && sudo wings configure --panel-url {{ config('app.url') }} --token ' + data.token + ' --node ' + data.node + '{{ config('app.debug') ? ' --allow-insecure' : '' }}</pre></small></p>',
                 html: true
             })
         }).fail(function () {


### PR DESCRIPTION
on the docs, you're downloading it to /usr/local/bin so it's easier like this