### PR TITLE
Add Redis UNIX socket support besides to TCP

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -96,6 +96,8 @@ return [
         'client' => 'predis',
 
         'default' => [
+            'scheme' => env('REDIS_SCHEME', 'tcp'),
+            'path' => env('REDIS_PATH', '/run/redis/redis.sock'),
             'host' => env('REDIS_HOST', 'localhost'),
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),
@@ -103,6 +105,8 @@ return [
         ],
 
         'sessions' => [
+            'scheme' => env('REDIS_SCHEME', 'tcp'),
+            'path' => env('REDIS_PATH', '/run/redis/redis.sock'),
             'host' => env('REDIS_HOST', 'localhost'),
             'password' => env('REDIS_PASSWORD', null),
             'port' => env('REDIS_PORT', 6379),


### PR DESCRIPTION
Hi,

I'm currently in a scenario where I'm forced to connect to my Redis instance with an UNIX socket. As this is currently supported by Predis (as seen [here](https://github.com/predis/predis/wiki/Connection-Parameters)), it wasn't directly supported in Pterodacyl. So I've added it as configuration options during installation. Of course `TCP` stays the default to be backward compatible.

If there's something that I missed, I am looking forward to your comments. 😃