### PR TITLE
Remove console logging

### DIFF
--- a/resources/scripts/api/swr/getServerStartup.ts
+++ b/resources/scripts/api/swr/getServerStartup.ts
@@ -9,7 +9,6 @@ interface Response {
 }
 
 export default (uuid: string, initialData?: Response) => useSWR([ uuid, '/startup' ], async (): Promise<Response> => {
-    console.log('firing getServerStartup');
     const { data } = await http.get(`/api/client/servers/${uuid}/startup`);
 
     const variables = ((data as FractalResponseList).data || []).map(rawDataToServerEggVariable);


### PR DESCRIPTION
Remove console logging, as its not an error being logged i see no reason for this to be printed when the startup page is viewed.