### PR TITLE
Display empty lines (linebreaks) in terminal.

### DIFF
--- a/public/themes/pterodactyl/css/terminal.css
+++ b/public/themes/pterodactyl/css/terminal.css
@@ -25,6 +25,7 @@
 }
 
 #terminal > .cmd {
+    height: 14px;
     padding: 1px 0;
     word-wrap: break-word;
 }

--- a/public/themes/pterodactyl/js/frontend/console.js
+++ b/public/themes/pterodactyl/js/frontend/console.js
@@ -203,7 +203,7 @@ function pushToTerminal(string) {
     });
 
     Socket.on('console', function (data) {
-        if(data.line) {
+        if(typeof data.line === "string") {
             data.line.split(/\n/g).forEach(function (item) {
                 TerminalQueue.push(item);
             });


### PR DESCRIPTION
Linebreaks were not visible in live terminal, unless at page-refresh in loaded log.
- Also need to remove whitespace replace in daemon, here is the PR: https://github.com/pterodactyl/daemon/pull/118.

### Images
Before
![Before image](https://i.imgur.com/ajJHEdv.png)
After
![After image](https://i.imgur.com/s1uEAZb.png)

### Example code in NodeJS
```js
setInterval(console.log, 1000, "something\n");
```