### PR TITLE
Fix missing semi, Fixed task row overflow

### DIFF
--- a/resources/scripts/components/server/PowerControls.tsx
+++ b/resources/scripts/components/server/PowerControls.tsx
@@ -49,7 +49,7 @@ const PowerControls = () => {
                 <StopOrKillButton onPress={action => sendPowerCommand(action)}/>
             </Can>
         </div>
-    )
+    );
 };
 
 export default PowerControls;

--- a/resources/scripts/components/server/schedules/ScheduleTaskRow.tsx
+++ b/resources/scripts/components/server/schedules/ScheduleTaskRow.tsx
@@ -81,7 +81,7 @@ export default ({ schedule, task }: Props) => {
                 <div css={tw`md:ml-6 mt-2`}>
                     {task.action === 'backup' &&
                     <p css={tw`text-xs uppercase text-neutral-400 mb-1`}>Ignoring files & folders:</p>}
-                    <div css={tw`font-mono bg-neutral-800 rounded py-1 px-2 text-sm w-auto whitespace-pre inline-block break-all`}>
+                    <div css={tw`font-mono bg-neutral-800 rounded py-1 px-2 text-sm w-auto inline-block whitespace-pre-wrap break-all`}>
                         {task.payload}
                     </div>
                 </div>


### PR DESCRIPTION
Was suppose to be correct in PR https://github.com/pterodactyl/panel/pull/2352 but seems to be picky. 
Should now correctly show a multiline text box and not a long skinny text box when the text overflows.

Also, fixed a missing semicolon. :+1: