### PR TITLE
Fix server mounts

### DIFF
--- a/app/Http/Controllers/Admin/ServersController.php
+++ b/app/Http/Controllers/Admin/ServersController.php
@@ -14,6 +14,7 @@ use Illuminate\Http\Request;
 use Pterodactyl\Models\User;
 use Pterodactyl\Models\Mount;
 use Pterodactyl\Models\Server;
+use Pterodactyl\Models\MountServer;
 use Prologue\Alerts\AlertsMessageBag;
 use GuzzleHttp\Exception\RequestException;
 use Pterodactyl\Exceptions\DisplayException;
@@ -419,17 +420,21 @@ class ServersController extends Controller
      *
      * @param Server $server
      * @param \Pterodactyl\Models\Mount $mount
-     * @return \Illuminate\Http\RedirectResponse
      *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     * @throws \Pterodactyl\Exceptions\Repository\RecordNotFoundException
+     * @return \Illuminate\Http\RedirectResponse
+     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException|\Throwable
      */
     public function addMount(Server $server, Mount $mount)
     {
-        $server->mounts()->updateOrCreate([
+        /*$server->mounts()->updateOrCreate([
             'mount_id' => $mount->id,
             'server_id' => $server->id,
-        ]);
+        ]);*/
+
+        $mountServer = new MountServer;
+        $mountServer->mount_id = $mount->id;
+        $mountServer->server_id = $server->id;
+        $mountServer->saveOrFail();
 
         $data = $this->serverConfigurationStructureService->handle($server);
 
@@ -458,10 +463,7 @@ class ServersController extends Controller
      */
     public function deleteMount(Server $server, Mount $mount)
     {
-        $server->mounts()
-            ->where('mount_id', $mount->id)
-            ->where('server_id', $server->id)
-            ->delete();
+        MountServer::where('mount_id', $mount->id)->where('server_id', $server->id)->delete();
 
         $data = $this->serverConfigurationStructureService->handle($server);
 

--- a/app/Http/Controllers/Admin/ServersController.php
+++ b/app/Http/Controllers/Admin/ServersController.php
@@ -426,11 +426,6 @@ class ServersController extends Controller
      */
     public function addMount(Server $server, Mount $mount)
     {
-        /*$server->mounts()->updateOrCreate([
-            'mount_id' => $mount->id,
-            'server_id' => $server->id,
-        ]);*/
-
         $mountServer = new MountServer;
         $mountServer->mount_id = $mount->id;
         $mountServer->server_id = $server->id;

--- a/app/Models/MountServer.php
+++ b/app/Models/MountServer.php
@@ -12,6 +12,11 @@ class MountServer extends Model
     protected $table = 'mount_server';
 
     /**
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
      * @var null
      */
     protected $primaryKey = null;


### PR DESCRIPTION
Resolves #2493 

Once the 500 error when mounting a mount was fixed I noticed that unmounting the mount would delete the actual mount instead of the relation in the `mount_server` table, this was fixed as well.