### PR TITLE
Remove target="blank" from /admin link

### DIFF
--- a/resources/scripts/components/NavigationBar.tsx
+++ b/resources/scripts/components/NavigationBar.tsx
@@ -63,7 +63,7 @@ export default () => {
                         <FontAwesomeIcon icon={faUserCircle}/>
                     </NavLink>
                     {rootAdmin &&
-                    <a href={'/admin'} target={'_blank'} rel={'noreferrer'}>
+                    <a href={'/admin'} rel={'noreferrer'}>
                         <FontAwesomeIcon icon={faCogs}/>
                     </a>
                     }


### PR DESCRIPTION
This should be changed to make it consistent with the admin panel, where the link back to the user panel does not open in a new tab.