### PR TITLE
Allow uuid to be inserted on the user model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -92,6 +92,7 @@ class User extends Model implements
         'totp_authenticated_at',
         'gravatar',
         'root_admin',
+        'uuid',
     ];
 
     /**


### PR DESCRIPTION
Model creation using the create method can't be done if the uuid can't be filled out. User::create();