### PR TITLE
Change SameSite attribute on session cookies to "lax"

### DIFF
--- a/app/Console/Commands/Environment/AppSettingsCommand.php
+++ b/app/Console/Commands/Environment/AppSettingsCommand.php
@@ -144,6 +144,11 @@ class AppSettingsCommand extends Command
             $this->variables['APP_ENVIRONMENT_ONLY'] = $this->confirm(trans('command/messages.environment.app.settings'), true) ? 'false' : 'true';
         }
 
+        // Make sure session cookies are set as "secure" when using HTTPS
+        if (strpos($this->variables['APP_URL'], 'https://') === 0) {
+            $this->variables['SESSION_SECURE_COOKIE'] = 'true';
+        }
+
         $this->checkForRedis();
         $this->writeToEnvironment($this->variables);
 

--- a/config/session.php
+++ b/config/session.php
@@ -188,5 +188,5 @@ return [
     |
     */
 
-    'same_site' => null,
+    'same_site' => env('SESSION_SAMESITE_COOKIE', 'lax'),
 ];


### PR DESCRIPTION
Browsers are in the process of changing their default to "lax", if it has not been set, but developers are still encouraged to set it.

"lax" is the current default in Laravel: https://github.com/laravel/laravel/blob/bec982b0a3962c8a3e1f665e987360bb8c056298/config/session.php#L199

This change also make it possible to change it via an env variable, if you desire.