### PR TITLE
Network info added to details + ClickToCopy

### DIFF
--- a/resources/scripts/components/server/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/ServerDetailsBlock.tsx
@@ -7,6 +7,7 @@ import TitledGreyBox from '@/components/elements/TitledGreyBox';
 import { ServerContext } from '@/state/server';
 import CopyOnClick from '@/components/elements/CopyOnClick';
 import Can from '@/components/elements/Can';
+
 interface Stats {
     memory: number;
     cpu: number;

--- a/resources/scripts/components/server/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/ServerDetailsBlock.tsx
@@ -6,8 +6,7 @@ import { bytesToHuman, megabytesToHuman } from '@/helpers';
 import TitledGreyBox from '@/components/elements/TitledGreyBox';
 import { ServerContext } from '@/state/server';
 import CopyOnClick from '@/components/elements/CopyOnClick';
-import Can from '@/elements/Can';
-
+import Can from '@/components/elements/Can';
 interface Stats {
     memory: number;
     cpu: number;

--- a/resources/scripts/components/server/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/ServerDetailsBlock.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import tw from 'twin.macro';
-import { faCircle, faHdd, faMemory, faMicrochip, faServer } from '@fortawesome/free-solid-svg-icons';
+import { faCircle, faEthernet, faHdd, faMemory, faMicrochip, faServer } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { bytesToHuman, megabytesToHuman } from '@/helpers';
 import TitledGreyBox from '@/components/elements/TitledGreyBox';
 import { ServerContext } from '@/state/server';
+import CopyOnClick from '@/components/elements/CopyOnClick';
 
 interface Stats {
     memory: number;
@@ -49,6 +50,9 @@ const ServerDetailsBlock = () => {
 
     const name = ServerContext.useStoreState(state => state.server.data!.name);
     const limits = ServerContext.useStoreState(state => state.server.data!.limits);
+    const primaryAllocation = ServerContext.useStoreState(state => state.server.data!.allocations.filter(alloc => alloc.isDefault).map(
+        allocation => allocation.alias + ':' + allocation.port || allocation.ip + ':' + allocation.port
+    )).toString();
 
     const disklimit = limits.disk ? megabytesToHuman(limits.disk) : 'Unlimited';
     const memorylimit = limits.memory ? megabytesToHuman(limits.memory) : 'Unlimited';
@@ -66,6 +70,12 @@ const ServerDetailsBlock = () => {
                 />
                 &nbsp;{!status ? 'Connecting...' : status}
             </p>
+            <CopyOnClick text={primaryAllocation}>
+                <p css={tw`text-xs mt-2`}>
+                    <FontAwesomeIcon icon={faEthernet} fixedWidth css={tw`mr-1`}/>
+                    <code css={tw`ml-1`}>{primaryAllocation}</code>
+                </p>
+            </CopyOnClick>
             <p css={tw`text-xs mt-2`}>
                 <FontAwesomeIcon icon={faMicrochip} fixedWidth css={tw`mr-1`}/> {stats.cpu.toFixed(2)}%
             </p>

--- a/resources/scripts/components/server/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/ServerDetailsBlock.tsx
@@ -6,7 +6,6 @@ import { bytesToHuman, megabytesToHuman } from '@/helpers';
 import TitledGreyBox from '@/components/elements/TitledGreyBox';
 import { ServerContext } from '@/state/server';
 import CopyOnClick from '@/components/elements/CopyOnClick';
-import Can from '@/components/elements/Can';
 
 interface Stats {
     memory: number;
@@ -71,14 +70,12 @@ const ServerDetailsBlock = () => {
                 />
                 &nbsp;{!status ? 'Connecting...' : status}
             </p>
-            <Can action={'allocation.read'}>
-                <CopyOnClick text={primaryAllocation}>
-                    <p css={tw`text-xs mt-2`}>
-                        <FontAwesomeIcon icon={faEthernet} fixedWidth css={tw`mr-1`}/>
-                        <code css={tw`ml-1`}>{primaryAllocation}</code>
-                    </p>
-                </CopyOnClick>
-            </Can>
+            <CopyOnClick text={primaryAllocation}>
+                <p css={tw`text-xs mt-2`}>
+                    <FontAwesomeIcon icon={faEthernet} fixedWidth css={tw`mr-1`}/>
+                    <code css={tw`ml-1`}>{primaryAllocation}</code>
+                </p>
+            </CopyOnClick>
             <p css={tw`text-xs mt-2`}>
                 <FontAwesomeIcon icon={faMicrochip} fixedWidth css={tw`mr-1`}/> {stats.cpu.toFixed(2)}%
             </p>

--- a/resources/scripts/components/server/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/ServerDetailsBlock.tsx
@@ -6,6 +6,7 @@ import { bytesToHuman, megabytesToHuman } from '@/helpers';
 import TitledGreyBox from '@/components/elements/TitledGreyBox';
 import { ServerContext } from '@/state/server';
 import CopyOnClick from '@/components/elements/CopyOnClick';
+import Can from '@/elements/Can';
 
 interface Stats {
     memory: number;
@@ -70,12 +71,14 @@ const ServerDetailsBlock = () => {
                 />
                 &nbsp;{!status ? 'Connecting...' : status}
             </p>
-            <CopyOnClick text={primaryAllocation}>
-                <p css={tw`text-xs mt-2`}>
-                    <FontAwesomeIcon icon={faEthernet} fixedWidth css={tw`mr-1`}/>
-                    <code css={tw`ml-1`}>{primaryAllocation}</code>
-                </p>
-            </CopyOnClick>
+            <Can action={'allocation.read'}>
+                <CopyOnClick text={primaryAllocation}>
+                    <p css={tw`text-xs mt-2`}>
+                        <FontAwesomeIcon icon={faEthernet} fixedWidth css={tw`mr-1`}/>
+                        <code css={tw`ml-1`}>{primaryAllocation}</code>
+                    </p>
+                </CopyOnClick>
+            </Can>
             <p css={tw`text-xs mt-2`}>
                 <FontAwesomeIcon icon={faMicrochip} fixedWidth css={tw`mr-1`}/> {stats.cpu.toFixed(2)}%
             </p>

--- a/resources/scripts/components/server/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/ServerDetailsBlock.tsx
@@ -51,7 +51,7 @@ const ServerDetailsBlock = () => {
     const name = ServerContext.useStoreState(state => state.server.data!.name);
     const limits = ServerContext.useStoreState(state => state.server.data!.limits);
     const primaryAllocation = ServerContext.useStoreState(state => state.server.data!.allocations.filter(alloc => alloc.isDefault).map(
-        allocation => allocation.alias + ':' + allocation.port || allocation.ip + ':' + allocation.port
+        allocation => (allocation.alias || allocation.ip) + ':' + allocation.port
     )).toString();
 
     const disklimit = limits.disk ? megabytesToHuman(limits.disk) : 'Unlimited';

--- a/resources/scripts/routers/ServerRouter.tsx
+++ b/resources/scripts/routers/ServerRouter.tsx
@@ -100,7 +100,7 @@ const ServerRouter = ({ match, location }: RouteComponentProps<{ id: string }>) 
                                 <Can action={'backup.*'}>
                                     <NavLink to={`${match.url}/backups`}>Backups</NavLink>
                                 </Can>
-                                <Can action={'allocations.*'}>
+                                <Can action={'allocation.*'}>
                                     <NavLink to={`${match.url}/network`}>Network</NavLink>
                                 </Can>
                                 <Can action={'startup.*'}>


### PR DESCRIPTION
Adds network info to the server details section, Also copies to the clipboard when clicked.

Closes https://github.com/pterodactyl/panel/issues/2585

![image](https://user-images.githubusercontent.com/1757840/97797786-eb12a980-1bed-11eb-8d82-63785381ba5c.png)
![image](https://user-images.githubusercontent.com/1757840/97797819-24e3b000-1bee-11eb-991a-4949d88723a6.png)
