### PR TITLE
Add admin area link to view config

### DIFF
--- a/app/Transformers/Api/Client/ServerTransformer.php
+++ b/app/Transformers/Api/Client/ServerTransformer.php
@@ -46,6 +46,7 @@ class ServerTransformer extends BaseClientTransformer
         return [
             'server_owner' => $this->getKey()->user_id === $server->owner_id,
             'identifier' => $server->uuidShort,
+            'internal_id' => $server->id,
             'uuid' => $server->uuid,
             'name' => $server->name,
             'node' => $server->node->name,

--- a/resources/scripts/api/server/getServer.ts
+++ b/resources/scripts/api/server/getServer.ts
@@ -13,6 +13,7 @@ export interface Allocation {
 
 export interface Server {
     id: string;
+    internalId: number;
     uuid: string;
     name: string;
     node: string;
@@ -43,6 +44,7 @@ export interface Server {
 
 export const rawDataToServerObject = ({ attributes: data }: FractalResponseData): Server => ({
     id: data.identifier,
+    internalId: data.internal_id,
     uuid: data.uuid,
     name: data.name,
     node: data.node,

--- a/resources/scripts/routers/ServerRouter.tsx
+++ b/resources/scripts/routers/ServerRouter.tsx
@@ -29,6 +29,8 @@ import InstallListener from '@/components/server/InstallListener';
 import StartupContainer from '@/components/server/startup/StartupContainer';
 import requireServerPermission from '@/hoc/requireServerPermission';
 import ErrorBoundary from '@/components/elements/ErrorBoundary';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 
 const ServerRouter = ({ match, location }: RouteComponentProps<{ id: string }>) => {
     const rootAdmin = useStoreState(state => state.user.data!.rootAdmin);
@@ -40,6 +42,7 @@ const ServerRouter = ({ match, location }: RouteComponentProps<{ id: string }>) 
     const isInstalling = ServerContext.useStoreState(state => state.server.data?.isInstalling);
     const getServer = ServerContext.useStoreActions(actions => actions.server.getServer);
     const clearServerState = ServerContext.useStoreActions(actions => actions.clearServerState);
+    const serverId = ServerContext.useStoreState(state => state.server.data?.internalId);
 
     useEffect(() => () => {
         clearServerState();
@@ -109,6 +112,11 @@ const ServerRouter = ({ match, location }: RouteComponentProps<{ id: string }>) 
                                 <Can action={[ 'settings.*', 'file.sftp' ]} matchAny>
                                     <NavLink to={`${match.url}/settings`}>Settings</NavLink>
                                 </Can>
+                                {rootAdmin &&
+                                    <a href={'/admin/servers/view/' + serverId} rel="noreferrer" target={'_blank'}>
+                                        <FontAwesomeIcon icon={faExternalLinkAlt}/>
+                                    </a>
+                                }
                             </div>
                         </SubNavigation>
                     </CSSTransition>


### PR DESCRIPTION
Closes #2608 

Adds a link to the admin area for the server to view the config for that specific server like it was on 0.7

![image](https://user-images.githubusercontent.com/1757840/97832315-764c7780-1ca0-11eb-809a-bd4e90c21632.png)
