### PR TITLE
Use app key from environment

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,10 +20,15 @@ else
   touch /app/var/.env
 
   ## manually generate a key because key generate --force fails
-  echo -e "Generating key."
-  APP_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
-  echo -e "Generated app key: $APP_KEY"
-  echo -e "APP_KEY=$APP_KEY" > /app/var/.env
+  if [ -z "$APP_KEY" ]; then
+      echo -e "Generating key."
+      APP_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+      echo -e "Generated app key: $APP_KEY"
+      echo -e "APP_KEY=$APP_KEY" > /app/var/.env
+  else
+    echo -e "APP_KEY exists in environment, using that."
+    echo -e "APP_KEY=$APP_KEY" > /app/var/.env
+  fi
 
   ln -s /app/var/.env /app/
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,11 +20,11 @@ else
   touch /app/var/.env
 
   ## manually generate a key because key generate --force fails
-  if [ -z "$APP_KEY" ]; then
-      echo -e "Generating key."
-      APP_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
-      echo -e "Generated app key: $APP_KEY"
-      echo -e "APP_KEY=$APP_KEY" > /app/var/.env
+  if [ -z $APP_KEY ]; then
+     echo -e "Generating key."
+     APP_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+     echo -e "Generated app key: $APP_KEY"
+     echo -e "APP_KEY=$APP_KEY" > /app/var/.env
   else
     echo -e "APP_KEY exists in environment, using that."
     echo -e "APP_KEY=$APP_KEY" > /app/var/.env


### PR DESCRIPTION
The entry point for docker generates its own APP_KEY even if their is one in scope.

The entrypoint now checks if there is an APP_KEY in scope and will use that instead of overwriting it.