### PR TITLE
Dont add trailing slash to file manager rows

### DIFF
--- a/resources/scripts/components/server/files/FileObjectRow.tsx
+++ b/resources/scripts/components/server/files/FileObjectRow.tsx
@@ -45,7 +45,7 @@ const Clickable: React.FC<{ file: FileObject }> = memo(({ file, children }) => {
             </div>
             :
             <NavLink
-                to={`${match.url}/${file.isFile ? 'edit/' : ''}#${destination}`}
+                to={`${match.url}${file.isFile ? '/edit' : ''}#${destination}`}
                 css={tw`flex flex-1 text-neutral-300 no-underline p-3 overflow-hidden truncate`}
                 onClick={onRowClick}
             >


### PR DESCRIPTION
closes #2663 

Also removes trailing slash from edit url to keep consistent with the router.