### PR TITLE
Rename duplicated input id

### DIFF
--- a/resources/scripts/components/dashboard/forms/UpdatePasswordForm.tsx
+++ b/resources/scripts/components/dashboard/forms/UpdatePasswordForm.tsx
@@ -77,7 +77,7 @@ export default () => {
                                 </div>
                                 <div css={tw`mt-6`}>
                                     <Field
-                                        id={'confirm_password'}
+                                        id={'confirm_new_password'}
                                         type={'password'}
                                         name={'confirmPassword'}
                                         label={'Confirm New Password'}


### PR DESCRIPTION
Renames the field id so its unique and chrome doesn't complain <3

Closes https://github.com/pterodactyl/panel/issues/2710