### PR TITLE
Fixed an error when trying to install dependencies without a .env file

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -45,7 +45,7 @@ return [
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => env('DB_PREFIX', ''),
             'strict' => env('DB_STRICT_MODE', false),
-            'timezone' => env('DB_TIMEZONE', Time::getMySQLTimezoneOffset(env('APP_TIMEZONE')))
+            'timezone' => env('DB_TIMEZONE', Time::getMySQLTimezoneOffset(env('APP_TIMEZONE', 'UTC')))
         ],
 
         /*
@@ -68,7 +68,7 @@ return [
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
             'strict' => false,
-            'timezone' => env('DB_TIMEZONE', Time::getMySQLTimezoneOffset(env('APP_TIMEZONE')))
+            'timezone' => env('DB_TIMEZONE', Time::getMySQLTimezoneOffset(env('APP_TIMEZONE', 'UTC')))
         ],
     ],
 


### PR DESCRIPTION
We need to set a default value for this, because we don't have any message suggesting that the user has not configured .env
![image](https://user-images.githubusercontent.com/28255085/100143998-33e51780-2ea7-11eb-9750-459d0d3f4e46.png)
