### PR TITLE
Add clickable URLs in console

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "xterm-addon-fit": "^0.4.0",
         "xterm-addon-search": "^0.7.0",
         "xterm-addon-search-bar": "^0.2.0",
+        "xterm-addon-web-links": "^0.4.0",
         "yup": "^0.29.1"
     },
     "devDependencies": {

--- a/resources/scripts/components/server/Console.tsx
+++ b/resources/scripts/components/server/Console.tsx
@@ -3,6 +3,7 @@ import { ITerminalOptions, Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { SearchAddon } from 'xterm-addon-search';
 import { SearchBarAddon } from 'xterm-addon-search-bar';
+import { WebLinksAddon } from 'xterm-addon-web-links';
 import SpinnerOverlay from '@/components/elements/SpinnerOverlay';
 import { ServerContext } from '@/state/server';
 import styled from 'styled-components/macro';
@@ -62,6 +63,7 @@ export default () => {
     const fitAddon = new FitAddon();
     const searchAddon = new SearchAddon();
     const searchBar = new SearchBarAddon({ searchAddon });
+    const webLinksAddon = new WebLinksAddon();
     const { connected, instance } = ServerContext.useStoreState(state => state.socket);
     const [ canSendCommands ] = usePermissions([ 'control.console' ]);
     const serverId = ServerContext.useStoreState(state => state.server.data!.id);
@@ -115,6 +117,7 @@ export default () => {
             terminal.loadAddon(fitAddon);
             terminal.loadAddon(searchAddon);
             terminal.loadAddon(searchBar);
+            terminal.loadAddon(webLinksAddon);
             fitAddon.fit();
 
             // Add support for capturing keys

--- a/yarn.lock
+++ b/yarn.lock
@@ -7621,6 +7621,11 @@ xterm-addon-search@^0.7.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-search/-/xterm-addon-search-0.7.0.tgz#c929d3e5cbb335e82bff72f158ea82936d9cd4ef"
   integrity sha512-6060evmJJ+tZcjnx33FXaeEHLpuXEa7l9UzUsYfMlCKbu88AbE+5LJocTKCHYd71cwCwb9pjmv/G1o9Rf9Zbcg==
 
+xterm-addon-web-links@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.4.0.tgz#265cbf8221b9b315d0a748e1323bee331cd5da03"
+  integrity sha512-xv8GeiINmx0zENO9hf5k+5bnkaE8mRzF+OBAr9WeFq2eLaQSudioQSiT34M1ofKbzcdjSsKiZm19Rw3i4eXamg==
+
 xterm@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/xterm/-/xterm-4.9.0.tgz#7a4c097a433d565339b5533b468bbc60c6c87969"


### PR DESCRIPTION
Adds an xterm addon to enable clicking on URLs in console.
Closes https://github.com/pterodactyl/panel/issues/2736