### PR TITLE
New rules for user password validation, close #2750

### DIFF
--- a/app/Http/Requests/Api/Client/Account/UpdatePasswordRequest.php
+++ b/app/Http/Requests/Api/Client/Account/UpdatePasswordRequest.php
@@ -32,7 +32,7 @@ class UpdatePasswordRequest extends ClientApiRequest
      */
     public function rules(): array
     {
-        $rules = User::getRulesForUpdate($this->user());
+        $rules = User::getRules();
 
         return ['password' => array_merge($rules['password'], ['confirmed'])];
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -142,7 +142,7 @@ class User extends Model implements
         'username' => 'required|between:1,191|unique:users,username',
         'name_first' => 'required|string|between:1,191',
         'name_last' => 'required|string|between:1,191',
-        'password' => 'sometimes|nullable|string',
+        'password' => 'required|string',
         'root_admin' => 'boolean',
         'language' => 'string',
         'use_totp' => 'boolean',
@@ -159,6 +159,21 @@ class User extends Model implements
 
         $rules['language'][] = new In(array_keys((new self)->getAvailableLanguages()));
         $rules['username'][] = new Username;
+
+        return $rules;
+    }
+        
+    public static function getRulesForUpdate($id, string $primaryKey = 'id')
+    {
+        $rules = parent::getRulesForUpdate($id, $primaryKey);
+
+        foreach ($rules['password'] as $key => $rule) {
+            if ($rule === 'required') {
+                unset($rules['password'][$key]);
+            }
+        }
+
+        $rules['password'] = array_merge($rules['password'], ['sometimes', 'nullable']);
 
         return $rules;
     }

--- a/tests/Integration/Api/Application/Users/UserControllerTest.php
+++ b/tests/Integration/Api/Application/Users/UserControllerTest.php
@@ -223,6 +223,7 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
             'email' => 'test@example.com',
             'first_name' => 'Test',
             'last_name' => 'User',
+            'password' => 'password',
         ]);
 
         $response->assertStatus(Response::HTTP_CREATED);


### PR DESCRIPTION
I imagine that the password should always be mandatory, we can't leave this field empty under any circumstances. When updating data, we should keep the other conditions of the validating, removing the must requirement of a password. This may not be an ideal method for replacing rules, but I would be happy if you would consider it.