### PR TITLE
Allow 0 in first octet of database client IP address Fixes #2779

### DIFF
--- a/resources/scripts/components/server/databases/CreateDatabaseButton.tsx
+++ b/resources/scripts/components/server/databases/CreateDatabaseButton.tsx
@@ -24,7 +24,7 @@ const schema = object().shape({
         .matches(/^[A-Za-z0-9_\-.]{3,48}$/, 'Database name should only contain alphanumeric characters, underscores, dashes, and/or periods.'),
     connectionsFrom: string()
         .required('A connection value must be provided.')
-        .matches(/^([1-9]{1,3}|%)(\.([0-9]{1,3}|%))?(\.([0-9]{1,3}|%))?(\.([0-9]{1,3}|%))?$/, 'A valid connection address must be provided.'),
+        .matches(/^([0-9]{1,3}|%)(\.([0-9]{1,3}|%))?(\.([0-9]{1,3}|%))?(\.([0-9]{1,3}|%))?$/, 'A valid connection address must be provided.'),
 });
 
 export default () => {


### PR DESCRIPTION
Allow user to enter database connection IP address that contains a a 0 in the first octet. Fixes #2779

With the current regex, any IP address that contains a 0 anywhere in the first octet of the IP is rejected by the front end.