### PR TITLE
Added translation for AutoAllocationNotEnabledException

### DIFF
--- a/app/Exceptions/Service/Allocation/AutoAllocationNotEnabledException.php
+++ b/app/Exceptions/Service/Allocation/AutoAllocationNotEnabledException.php
@@ -11,8 +11,6 @@ class AutoAllocationNotEnabledException extends DisplayException
      */
     public function __construct()
     {
-        parent::__construct(
-            'Server auto-allocation is not enabled for this instance.'
-        );
+        parent::__construct(trans('exceptions.allocations.autoallocation_not_enabled'));
     }
 }

--- a/resources/lang/en/exceptions.php
+++ b/resources/lang/en/exceptions.php
@@ -12,6 +12,7 @@ return [
         'invalid_mapping' => 'The mapping provided for :port was invalid and could not be processed.',
         'cidr_out_of_range' => 'CIDR notation only allows masks between /25 and /32.',
         'port_out_of_range' => 'Ports in an allocation must be greater than 1024 and less than or equal to 65535.',
+        'autoallocation_not_enabled' => 'Server auto-allocation is not enabled for this instance.',
     ],
     'nest' => [
         'delete_has_servers' => 'A Nest with active servers attached to it cannot be deleted from the Panel.',


### PR DESCRIPTION
The exception was in plain text, so I added a translation for it.