### PR TITLE
Allow changing the prune age for backups

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -25,11 +25,13 @@ class Kernel extends ConsoleKernel
         // Execute scheduled commands for servers every minute, as if there was a normal cron running.
         $schedule->command('p:schedule:process')->everyMinute()->withoutOverlapping();
 
-        // Every 30 minutes, run the backup pruning command so that any abandoned backups can be removed
-        // from the UI view for the server.
-        $schedule->command('p:maintenance:prune-backups', [
-            '--since-minutes' => '30',
-        ])->everyThirtyMinutes();
+        // Every 30 minutes, run the backup pruning command so that any abandoned backups can be deleted.
+        $pruneAge = config('backups.prune_age', 60);
+        if ($pruneAge > 0) {
+            $schedule->command('p:maintenance:prune-backups', [
+                '--since-minutes' => $pruneAge,
+            ])->everyThirtyMinutes();
+        }
 
         // Every day cleanup any internal backups of service files.
         $schedule->command('p:maintenance:clean-service-backups')->daily();

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -26,7 +26,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('p:schedule:process')->everyMinute()->withoutOverlapping();
 
         // Every 30 minutes, run the backup pruning command so that any abandoned backups can be deleted.
-        $pruneAge = config('backups.prune_age', 60);
+        $pruneAge = config('backups.prune_age', 360); // Defaults to 6 hours (time is in minuteS)
         if ($pruneAge > 0) {
             $schedule->command('p:maintenance:prune-backups', [
                 '--since-minutes' => $pruneAge,

--- a/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
@@ -52,7 +52,7 @@ class BackupRemoteUploadController extends Controller
     public function __invoke(Request $request, string $backup)
     {
         // Get the size query parameter.
-        $size = (int)$request->query('size');
+        $size = (int) $request->query('size');
         if (empty($size)) {
             throw new BadRequestHttpException('A non-empty "size" query parameter must be provided.');
         }

--- a/config/backups.php
+++ b/config/backups.php
@@ -12,6 +12,10 @@ return [
     // uses to upload backups to S3 storage.  Value is in minutes, so this would default to an hour.
     'presigned_url_lifespan' => env('BACKUP_PRESIGNED_URL_LIFESPAN', 60),
 
+    // The time in which to wait before automatically marking a backup as failed.
+    // To disable this feature, set the value to `0`.
+    'prune_age' => env('BACKUP_PRUNE_AGE', 60),
+
     'disks' => [
         // There is no configuration for the local disk for Wings. That configuration
         // is determined by the Daemon configuration, and not the Panel.

--- a/config/backups.php
+++ b/config/backups.php
@@ -12,9 +12,9 @@ return [
     // uses to upload backups to S3 storage.  Value is in minutes, so this would default to an hour.
     'presigned_url_lifespan' => env('BACKUP_PRESIGNED_URL_LIFESPAN', 60),
 
-    // The time in which to wait before automatically marking a backup as failed.
-    // To disable this feature, set the value to `0`.
-    'prune_age' => env('BACKUP_PRUNE_AGE', 60),
+    // The time to wait before automatically failing a backup, time is in minutes and defaults
+    // to 6 hours.  To disable this feature, set the value to `0`.
+    'prune_age' => env('BACKUP_PRUNE_AGE', 360),
 
     'disks' => [
         // There is no configuration for the local disk for Wings. That configuration


### PR DESCRIPTION
Adds the `BACKUP_PRUNE_AGE` environment variable (default value is `60`, value is in minutes).  This value is used for determining if a backup has taken too long and needs to be deleted automatically.