### PR TITLE
Store S3 upload_id in the database for backups

### DIFF
--- a/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
@@ -47,6 +47,7 @@ class BackupRemoteUploadController extends Controller
      * @return \Illuminate\Http\JsonResponse
      *
      * @throws \Exception
+     * @throws \Throwable
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
     public function __invoke(Request $request, string $backup)
@@ -101,8 +102,12 @@ class BackupRemoteUploadController extends Controller
             )->getUri()->__toString();
         }
 
-        return new JsonResponse([
+        // Set the upload_id on the backup in the database.
+        $backup->forceFill([
             'upload_id' => $params['UploadId'],
+        ])->saveOrFail();
+
+        return new JsonResponse([
             'parts' => $parts,
             'part_size' => self::PART_SIZE,
         ]);

--- a/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
@@ -78,7 +78,7 @@ class BackupStatusController extends Controller
             $params = [
                 'Bucket' => $adapter->getBucket(),
                 'Key' => sprintf('%s/%s.tar.gz', $backup->server->uuid, $backup->uuid),
-                'UploadId' => $request->input('upload_id'),
+                'UploadId' => $backup->upload_id,
             ];
 
             // If the backup was not successful, send an AbortMultipartUpload request.

--- a/app/Models/Backup.php
+++ b/app/Models/Backup.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $disk
  * @property string|null $checksum
  * @property int $bytes
+ * @property string|null $upload_id
  * @property \Carbon\CarbonImmutable|null $completed_at
  * @property \Carbon\CarbonImmutable $created_at
  * @property \Carbon\CarbonImmutable $updated_at
@@ -46,8 +47,8 @@ class Backup extends Model
     protected $casts = [
         'id' => 'int',
         'is_successful' => 'bool',
-        'bytes' => 'int',
         'ignored_files' => 'array',
+        'bytes' => 'int',
     ];
 
     /**
@@ -64,6 +65,7 @@ class Backup extends Model
         'is_successful' => true,
         'checksum' => null,
         'bytes' => 0,
+        'upload_id' => null,
     ];
 
     /**
@@ -78,6 +80,7 @@ class Backup extends Model
         'disk' => 'required|string',
         'checksum' => 'nullable|string',
         'bytes' => 'numeric',
+        'upload_id' => 'nullable|uuid',
     ];
 
     /**

--- a/database/migrations/2020_12_26_184914_add_upload_id_column_to_backups_table.php
+++ b/database/migrations/2020_12_26_184914_add_upload_id_column_to_backups_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUploadIdColumnToBackupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('backups', function (Blueprint $table) {
+            $table->char('upload_id', 36)->nullable()->after('bytes');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('backups', function (Blueprint $table) {
+            $table->dropColumn('upload_id');
+        });
+    }
+}


### PR DESCRIPTION
Instead of relying on wings to pass the `upload_id` back and fourth for S3 backups, this PR stores the upload_id in the database alongside backups which is probably a way better idea, this also avoids the potential for wings to no longer have the upload_id stored, causing the backup to fail.