### PR TITLE
fix file manager transition animations

### DIFF
--- a/resources/scripts/TransitionRouter.tsx
+++ b/resources/scripts/TransitionRouter.tsx
@@ -15,13 +15,11 @@ const StyledSwitchTransition = styled(SwitchTransition)`
 `;
 
 const TransitionRouter: React.FC = ({ children }) => {
-    const uuid = useRef(v4()).current;
-
     return (
         <Route
             render={({ location }) => (
                 <StyledSwitchTransition>
-                    <Fade timeout={150} key={location.key || uuid} in appear unmountOnExit>
+                    <Fade timeout={150} key={location.pathname + location.search} in appear unmountOnExit>
                         <section>
                             {children}
                         </section>

--- a/resources/scripts/components/elements/PageContentBlock.tsx
+++ b/resources/scripts/components/elements/PageContentBlock.tsx
@@ -18,29 +18,27 @@ const PageContentBlock: React.FC<PageContentBlockProps> = ({ title, showFlashKey
     }, [ title ]);
 
     return (
-        <CSSTransition timeout={150} classNames={'fade'} appear in>
-            <>
-                <ContentContainer css={tw`my-4 sm:my-10`} className={className}>
-                    {showFlashKey &&
-                    <FlashMessageRender byKey={showFlashKey} css={tw`mb-4`}/>
-                    }
-                    {children}
-                </ContentContainer>
-                <ContentContainer css={tw`mb-4`}>
-                    <p css={tw`text-center text-neutral-500 text-xs`}>
-                        &copy; 2015 - 2020&nbsp;
-                        <a
-                            rel={'noopener nofollow noreferrer'}
-                            href={'https://pterodactyl.io'}
-                            target={'_blank'}
-                            css={tw`no-underline text-neutral-500 hover:text-neutral-300`}
-                        >
-                            Pterodactyl Software
-                        </a>
-                    </p>
-                </ContentContainer>
-            </>
-        </CSSTransition>
+        <>
+            <ContentContainer css={tw`my-4 sm:my-10`} className={className}>
+                {showFlashKey &&
+                <FlashMessageRender byKey={showFlashKey} css={tw`mb-4`}/>
+                }
+                {children}
+            </ContentContainer>
+            <ContentContainer css={tw`mb-4`}>
+                <p css={tw`text-center text-neutral-500 text-xs`}>
+                    &copy; 2015 - 2020&nbsp;
+                    <a
+                        rel={'noopener nofollow noreferrer'}
+                        href={'https://pterodactyl.io'}
+                        target={'_blank'}
+                        css={tw`no-underline text-neutral-500 hover:text-neutral-300`}
+                    >
+                        Pterodactyl Software
+                    </a>
+                </p>
+            </ContentContainer>
+        </>
     );
 };
 


### PR DESCRIPTION
There seem to be CSSTransitions all over the place, some of which are either not needed, or should be applied somewhere else (at least in my opinion).

Removing the transition from the PageContentBlock and using the pathname and search of the location as the TransitionRouter key does not seem to break any animations, but doing both fixes the file manager reloading entirely on each click.

Maybe I'm also missing something though.