### PR TITLE
Additional allocations with port ranges

### DIFF
--- a/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
+++ b/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
@@ -68,6 +68,8 @@ class StoreServerRequest extends ApplicationApiRequest
             'deploy.dedicated_ip' => 'required_with:deploy,boolean',
             'deploy.port_range' => 'array',
             'deploy.port_range.*' => 'string',
+            'deploy.additional_ports_ranges' => 'array',
+            'deploy.additional_ports_ranges.*' => 'string',
 
             'start_on_completion' => 'sometimes|boolean',
         ];
@@ -156,6 +158,7 @@ class StoreServerRequest extends ApplicationApiRequest
         $object->setDedicated($this->input('deploy.dedicated_ip', false));
         $object->setLocations($this->input('deploy.locations', []));
         $object->setPorts($this->input('deploy.port_range', []));
+        $object->setAdditionalPorts($this->input('deploy.additional_ports_ranges', []));
 
         return $object;
     }

--- a/app/Models/Objects/DeploymentObject.php
+++ b/app/Models/Objects/DeploymentObject.php
@@ -20,6 +20,11 @@ class DeploymentObject
     private $ports = [];
 
     /**
+     * @var array
+     */
+    private $additionalPorts = [];
+
+    /**
      * @return bool
      */
     public function isDedicated(): bool
@@ -72,6 +77,25 @@ class DeploymentObject
     public function setPorts(array $ports)
     {
         $this->ports = $ports;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdditionalPorts(): array
+    {
+        return $this->additionalPorts;
+    }
+
+    /**
+     * @param array $ports
+     * @return $this
+     */
+    public function setAdditionalPorts(array $additionalPorts)
+    {
+        $this->additionalPorts = $additionalPorts;
 
         return $this;
     }


### PR DESCRIPTION
This PR adds a field called 'additional_ports_ranges' to the server create API. It allows users to automatically add multiple allocations to servers without having to make API calls to retrieve allocation IDs first.

'additional_ports_ranges' should be an array of strings (each a port range), it will add a port for every string in the array.