### PR TITLE
Fix 'other servers' toggle being persisted across non-admin accounts

### DIFF
--- a/resources/scripts/components/dashboard/DashboardContainer.tsx
+++ b/resources/scripts/components/dashboard/DashboardContainer.tsx
@@ -20,8 +20,8 @@ export default () => {
     const [ showOnlyAdmin, setShowOnlyAdmin ] = usePersistedState('show_all_servers', false);
 
     const { data: servers, error } = useSWR<PaginatedResult<Server>>(
-        [ '/api/client/servers', showOnlyAdmin, page ],
-        () => getServers({ page, type: showOnlyAdmin ? 'admin' : undefined }),
+        [ '/api/client/servers', rootAdmin && showOnlyAdmin, page ],
+        () => getServers({ page, type: rootAdmin && showOnlyAdmin ? 'admin' : undefined }),
     );
 
     useEffect(() => {


### PR DESCRIPTION
The toggle only available to admins on the landing page of the panel is persisted using local storage but if you logout of an admin account, then login with a regular user account, the state is still persisted which can hide your own servers from view.