### PR TITLE
Allow copy on click for SFTP information

### DIFF
--- a/resources/scripts/components/server/settings/SettingsContainer.tsx
+++ b/resources/scripts/components/server/settings/SettingsContainer.tsx
@@ -30,19 +30,23 @@ export default () => {
                         <TitledGreyBox title={'SFTP Details'} css={tw`mb-6 md:mb-10`}>
                             <div>
                                 <Label>Server Address</Label>
-                                <Input
-                                    type={'text'}
-                                    value={`sftp://${sftp.ip}:${sftp.port}`}
-                                    readOnly
-                                />
+                                <CopyOnClick text={`sftp://${sftp.ip}:${sftp.port}`}>
+                                    <Input
+                                        type={'text'}
+                                        value={`sftp://${sftp.ip}:${sftp.port}`}
+                                        readOnly
+                                    />
+                                </CopyOnClick>
                             </div>
                             <div css={tw`mt-6`}>
                                 <Label>Username</Label>
-                                <Input
-                                    type={'text'}
-                                    value={`${username}.${id}`}
-                                    readOnly
-                                />
+                                <CopyOnClick text={`${username}.${id}`}>
+                                    <Input
+                                        type={'text'}
+                                        value={`${username}.${id}`}
+                                        readOnly
+                                    />
+                                </CopyOnClick>
                             </div>
                             <div css={tw`mt-6 flex items-center`}>
                                 <div css={tw`flex-1`}>


### PR DESCRIPTION
Allows the end-user to click the sftp address and username to copy it to the clipboard.

Duplicate of https://github.com/pterodactyl/panel/pull/2920 ... just without the un-needed 5 commits