### PR TITLE
api(remote): fix inproper reading of boolean for installation status

### DIFF
--- a/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
@@ -56,7 +56,7 @@ class ServerInstallController extends Controller
     {
         $server = $this->repository->getByUuid($uuid);
 
-        $status = $request->input('successful') === '1' ? null : Server::STATUS_INSTALL_FAILED;
+        $status = $request->boolean('successful') ? null : Server::STATUS_INSTALL_FAILED;
         if ($server->status === Server::STATUS_SUSPENDED) {
             $status = Server::STATUS_SUSPENDED;
         }


### PR DESCRIPTION
Wings sends this value as a boolean which is not properly read with the current logic causing a server's status to be set to "install_failed" even if the installation succeeded.