### PR TITLE
Set CSGO Steam Account Token to nullable

### DIFF
--- a/database/Seeders/eggs/source-engine/egg-counter--strike--global-offensive.json
+++ b/database/Seeders/eggs/source-engine/egg-counter--strike--global-offensive.json
@@ -39,7 +39,7 @@
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|alpha_num|size:32"
+            "rules": "nullable|string|alpha_num|size:32"
         },
         {
             "name": "Source AppID",


### PR DESCRIPTION
Set the Steam Account Token to nullable so it's not required, makes it work out of the box for the WHMCS module.