### PR TITLE
Added SERVER_NAME environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,11 @@ MAIL_USERNAME=
 MAIL_PASSWORD=
 MAIL_ENCRYPTION=tls
 MAIL_FROM=no-reply@example.com
-#SERVER_NAME=panel.yourdomain.com # You should set this to your domain to prevent it defaulting to 'localhost', causing mail servers such as Gmail to reject your mail. PR: https://github.com/pterodactyl/panel/pull/3110
+# You should set this to your domain to prevent it defaulting to 'localhost', causing
+# mail servers such as Gmail to reject your mail.
+#
+# @see: https://github.com/pterodactyl/panel/pull/3110
+# SERVER_NAME=panel.yourdomain.com
 
 QUEUE_HIGH=high
 QUEUE_STANDARD=standard

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ MAIL_USERNAME=
 MAIL_PASSWORD=
 MAIL_ENCRYPTION=tls
 MAIL_FROM=no-reply@example.com
-SERVER_NAME=panel.yourdomain.com
+#SERVER_NAME=panel.yourdomain.com # PR: https://github.com/pterodactyl/panel/pull/3110
 
 QUEUE_HIGH=high
 QUEUE_STANDARD=standard

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ MAIL_USERNAME=
 MAIL_PASSWORD=
 MAIL_ENCRYPTION=tls
 MAIL_FROM=no-reply@example.com
+SERVER_NAME=panel.yourdomain.com
 
 QUEUE_HIGH=high
 QUEUE_STANDARD=standard

--- a/.env.example
+++ b/.env.example
@@ -25,7 +25,7 @@ MAIL_USERNAME=
 MAIL_PASSWORD=
 MAIL_ENCRYPTION=tls
 MAIL_FROM=no-reply@example.com
-#SERVER_NAME=panel.yourdomain.com # PR: https://github.com/pterodactyl/panel/pull/3110
+#SERVER_NAME=panel.yourdomain.com # You should set this to your domain to prevent it defaulting to 'localhost', causing mail servers such as Gmail to reject your mail. PR: https://github.com/pterodactyl/panel/pull/3110
 
 QUEUE_HIGH=high
 QUEUE_STANDARD=standard


### PR DESCRIPTION
Added SERVER_NAME environment variable to stop laravel framework server name defaulting to localhost, causing mail relays such as Gmail to stop silently dropping emails due to sender name being localhost.