### PR TITLE
Change Rust RCON Password input rule

### DIFF
--- a/database/Seeders/eggs/rust/egg-rust.json
+++ b/database/Seeders/eggs/rust/egg-rust.json
@@ -121,7 +121,7 @@
             "default_value": "CHANGEME",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|regex:\/^[a-zA-Z0-9_.-]*$\/|max:64"
+            "rules": "required|regex:/^[\w.-]*$/|max:64"
         },
         {
             "name": "Save Interval",

--- a/database/Seeders/eggs/rust/egg-rust.json
+++ b/database/Seeders/eggs/rust/egg-rust.json
@@ -121,7 +121,7 @@
             "default_value": "CHANGEME",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:64"
+            "rules": "required|regex:\/^[a-zA-Z0-9_.-]*$\/|max:64"
         },
         {
             "name": "Save Interval",


### PR DESCRIPTION
RCON will fail to connect if the password contains special characters such as á,ö,ä, /%¤&. This input rule resolves that issue by only accepting alphanumeric letters, dots, underscores, and dashes.