### PR TITLE
Textarea can't be resized horizontally

### DIFF
--- a/public/themes/pterodactyl/css/pterodactyl.css
+++ b/public/themes/pterodactyl/css/pterodactyl.css
@@ -684,6 +684,9 @@ textarea.form-control {
     box-shadow: none;
     -webkit-transition: border .15s linear,box-shaodw .15s ease-in;
     transition: border .15s linear,box-shaodw .15s ease-in;
+    min-width: 100%;
+    width : 100%;
+    max-width: 100%;
 }
 
 .input-group .input-group-addon {


### PR DESCRIPTION
I noticed on pages such as the node add page where you have the description textarea it's able to be resized horizontally but it doesn't make sense to have that since it would then be bigger than it's container, see here:

[![](https://i.imgur.com/OsaMtML.gif)](https://i.imgur.com/OsaMtML.gif)

With this change you can now only resize it vertically:

[![](https://i.imgur.com/t104IaC.gif)](https://i.imgur.com/t104IaC.gif)