### PR TITLE
Fix artisan upgrade failing to download

### DIFF
--- a/app/Console/Commands/UpgradeCommand.php
+++ b/app/Console/Commands/UpgradeCommand.php
@@ -79,7 +79,7 @@ class UpgradeCommand extends Command
         if (!$skipDownload) {
             $this->withProgress($bar, function () {
                 $this->line("\$upgrader> curl -L \"{$this->getUrl()}\" | tar -xzv");
-                $process = Process::fromShellCommandline("curl -L \"{$this->getUrl()}\" | tar -xzvf");
+                $process = Process::fromShellCommandline("curl -L \"{$this->getUrl()}\" | tar -xzv");
                 $process->run(function ($type, $buffer) {
                     $this->{$type === Process::ERR ? 'error' : 'line'}($buffer);
                 });


### PR DESCRIPTION
Tar -f flag is not required in this context as no filename is specified. The output is passed to stdout without it and should invoke the unarchiving properly as the artisan upgrade is executed in the webroot directory. I've tested it myself a couple of times and was able to upgrade and downgrade.

Resolves #3159, #3161