### PR TITLE
Increase Rust server name length

### DIFF
--- a/database/Seeders/eggs/rust/egg-rust.json
+++ b/database/Seeders/eggs/rust/egg-rust.json
@@ -31,7 +31,7 @@
             "default_value": "A Rust Server",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:40"
+            "rules": "required|string|max:60"
         },
         {
             "name": "OxideMod",


### PR DESCRIPTION
The current length of 40 is too short