### PR TITLE
Change relative docker compose to absolute path docker-compose

### DIFF
--- a/.github/docker/README.md
+++ b/.github/docker/README.md
@@ -2,7 +2,7 @@
 This is a ready to use docker image for the panel.
 
 ## Requirements
-This docker image requires some additional software to function. The software can either be provided in other containers (see the [docker-compose.yml](docker-compose.yml) as an example) or as existing instances.
+This docker image requires some additional software to function. The software can either be provided in other containers (see the [docker-compose.yml](https://github.com/pterodactyl/panel/blob/develop/docker-compose.example.yml) as an example) or as existing instances.
 
 A mysql database is required. We recommend the stock [MariaDB Image](https://hub.docker.com/_/mariadb/) image if you prefer to run it in a docker container. As a non-containerized option we recommend mariadb.
 


### PR DESCRIPTION
The old version was relative and led to a 404 because the compose file is in /panel.