### PR TITLE
docker: set errexit in the entrypoint script

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/ash -e
 cd /app
 
 mkdir -p /var/log/panel/logs/ /var/log/supervisord/ /var/log/nginx/ /var/log/php7/ \


### PR DESCRIPTION
Currently container startup will ignore any errors, which will tend
to leave things in a broken state if operations like migrations or
certificate provisioning fail. Prefer to terminate the container
rather than try to limp on.