### PR TITLE
More descriptive error for when backup limit is 0

### DIFF
--- a/resources/scripts/components/server/backups/BackupContainer.tsx
+++ b/resources/scripts/components/server/backups/BackupContainer.tsx
@@ -60,7 +60,7 @@ const BackupContainer = () => {
             </Pagination>
             {backupLimit === 0 &&
             <p css={tw`text-center text-sm text-neutral-300`}>
-                Backups cannot be created for this server when the backup limit is set to 0.
+                Backups cannot be created for this server because the backup limit is set to 0.
             </p>
             }
             <Can action={'backup.create'}>

--- a/resources/scripts/components/server/backups/BackupContainer.tsx
+++ b/resources/scripts/components/server/backups/BackupContainer.tsx
@@ -60,7 +60,7 @@ const BackupContainer = () => {
             </Pagination>
             {backupLimit === 0 &&
             <p css={tw`text-center text-sm text-neutral-300`}>
-                Backups cannot be created for this server.
+                Backups cannot be created for this server when the backup limit is set to 0.
             </p>
             }
             <Can action={'backup.create'}>


### PR DESCRIPTION
At this moment, the error message is confusing and leads to a lot of questions on how to configure backups to work with Pterodactyl