### PR TITLE
Change to actual function names to support MariaDB

### DIFF
--- a/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
@@ -111,7 +111,7 @@ class ServerDetailsController extends Controller
         /** @var \Pterodactyl\Models\Server[] $servers */
         $servers = Server::query()
             ->select('servers.*')
-            ->selectRaw('started.metadata->>"$.backup_uuid" as backup_uuid')
+            ->selectRaw('JSON_UNQUOTE(JSON_EXTRACT(started.metadata, "$.backup_uuid")) as backup_uuid')
             ->leftJoinSub(function (Builder $builder) {
                 $builder->select('*')->from('audit_logs')
                     ->where('action', AuditLog::SERVER__BACKUP_RESTORE_STARTED)


### PR DESCRIPTION
Haven't tested it, but the arrow ->> is just syntactic sugar for: `JSON_UNQUOTE(JSON_EXTRACT())` according to: https://dev.mysql.com/doc/refman/5.7/en/json-function-reference.html