### PR TITLE
Drop explicit transaction from store_node_tokens_as_encrypted_value

### DIFF
--- a/database/migrations/2020_04_10_141024_store_node_tokens_as_encrypted_value.php
+++ b/database/migrations/2020_04_10_141024_store_node_tokens_as_encrypted_value.php
@@ -33,19 +33,17 @@ class StoreNodeTokensAsEncryptedValue extends Migration
             $table->text('daemon_token')->change();
         });
 
-        DB::transaction(function () {
-            /** @var \Illuminate\Contracts\Encryption\Encrypter $encrypter */
-            $encrypter = Container::getInstance()->make(Encrypter::class);
+        /** @var \Illuminate\Contracts\Encryption\Encrypter $encrypter */
+        $encrypter = Container::getInstance()->make(Encrypter::class);
 
-            foreach (DB::select('SELECT id, daemon_token FROM nodes') as $datum) {
-                DB::update('UPDATE nodes SET uuid = ?, daemon_token_id = ?, daemon_token = ? WHERE id = ?', [
-                    Uuid::uuid4()->toString(),
-                    substr($datum->daemon_token, 0, 16),
-                    $encrypter->encrypt(substr($datum->daemon_token, 16)),
-                    $datum->id,
-                ]);
-            }
-        });
+        foreach (DB::select('SELECT id, daemon_token FROM nodes') as $datum) {
+            DB::update('UPDATE nodes SET uuid = ?, daemon_token_id = ?, daemon_token = ? WHERE id = ?', [
+                Uuid::uuid4()->toString(),
+                substr($datum->daemon_token, 0, 16),
+                $encrypter->encrypt(substr($datum->daemon_token, 16)),
+                $datum->id,
+            ]);
+        }
 
         Schema::table('nodes', function (Blueprint $table) {
             $table->unique(['uuid']);


### PR DESCRIPTION
Migrations are executed in transactions anyway, and creating a savepoint can cause
spurious failures on databases that don't support transactional DDL (like
MySQL and MariaDB) when it attempts to commit a savepoint that was silently
not created because there wasn't an active transaction after some DDL was
executed.

While a better solution might involve splitting this migration into several so each
one is only DDL or only data manipulation, I don't think that can be done very
easily while maintaining compatibility with existing deployments.

Fixes #3229.