### PR TITLE
Add possibility to sort on some columns in the server administration 

### DIFF
--- a/app/Http/Controllers/Admin/Servers/ServerController.php
+++ b/app/Http/Controllers/Admin/Servers/ServerController.php
@@ -4,14 +4,14 @@ namespace Pterodactyl\Http\Controllers\Admin\Servers;
 
 use Illuminate\Http\Request;
 use Pterodactyl\Models\Server;
-use Pterodactyl\Models\Sorters\AdminServerSorter;
-use Pterodactyl\Models\Sorters\NodeServerSorter;
 use Spatie\QueryBuilder\AllowedSort;
 use Spatie\QueryBuilder\QueryBuilder;
 use Illuminate\Contracts\View\Factory;
 use Spatie\QueryBuilder\AllowedFilter;
 use Pterodactyl\Http\Controllers\Controller;
+use Pterodactyl\Models\Sorters\NodeServerSorter;
 use Pterodactyl\Models\Filters\AdminServerFilter;
+use Pterodactyl\Models\Sorters\AdminServerSorter;
 use Pterodactyl\Repositories\Eloquent\ServerRepository;
 
 class ServerController extends Controller
@@ -32,8 +32,7 @@ class ServerController extends Controller
     public function __construct(
         Factory $view,
         ServerRepository $repository
-    )
-    {
+    ) {
         $this->view = $view;
         $this->repository = $repository;
     }

--- a/app/Http/Controllers/Admin/Servers/ServerController.php
+++ b/app/Http/Controllers/Admin/Servers/ServerController.php
@@ -4,6 +4,9 @@ namespace Pterodactyl\Http\Controllers\Admin\Servers;
 
 use Illuminate\Http\Request;
 use Pterodactyl\Models\Server;
+use Pterodactyl\Models\Sorters\AdminServerSorter;
+use Pterodactyl\Models\Sorters\NodeServerSorter;
+use Spatie\QueryBuilder\AllowedSort;
 use Spatie\QueryBuilder\QueryBuilder;
 use Illuminate\Contracts\View\Factory;
 use Spatie\QueryBuilder\AllowedFilter;
@@ -29,7 +32,8 @@ class ServerController extends Controller
     public function __construct(
         Factory $view,
         ServerRepository $repository
-    ) {
+    )
+    {
         $this->view = $view;
         $this->repository = $repository;
     }
@@ -46,6 +50,11 @@ class ServerController extends Controller
             ->allowedFilters([
                 AllowedFilter::exact('owner_id'),
                 AllowedFilter::custom('*', new AdminServerFilter()),
+            ])
+            ->allowedSorts([
+                'name',
+                AllowedSort::custom('owner', new AdminServerSorter()),
+                AllowedSort::custom('node', new NodeServerSorter()),
             ])
             ->paginate(config()->get('pterodactyl.paginate.admin.servers'));
 

--- a/app/Models/Sorters/AdminServerSorter.php
+++ b/app/Models/Sorters/AdminServerSorter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Pterodactyl\Models\Sorters;
+
+
+use BadMethodCallException;
+use Spatie\QueryBuilder\Sorts\Sort;
+use Illuminate\Database\Eloquent\Builder;
+
+class AdminServerSorter implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        if ($query->getQuery()->from !== 'servers') {
+            throw new BadMethodCallException('Cannot use the AdminServerSorter against a non-server model.');
+        }
+
+        $query->join('users', 'users.id', '=', 'servers.owner_id')->orderBy('users.username', $descending ? 'DESC' : 'ASC');
+    }
+}

--- a/app/Models/Sorters/AdminServerSorter.php
+++ b/app/Models/Sorters/AdminServerSorter.php
@@ -15,6 +15,6 @@ class AdminServerSorter implements Sort
             throw new BadMethodCallException('Cannot use the AdminServerSorter against a non-server model.');
         }
 
-        $query->join('users', 'users.id', '=', 'servers.owner_id')->orderBy('users.username', $descending ? 'DESC' : 'ASC');
+        $query->join('users as us', 'us.id', '=', 'servers.owner_id')->orderBy('us.username', $descending ? 'DESC' : 'ASC');
     }
 }

--- a/app/Models/Sorters/NodeServerSorter.php
+++ b/app/Models/Sorters/NodeServerSorter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Pterodactyl\Models\Sorters;
+
+
+use BadMethodCallException;
+use Spatie\QueryBuilder\Sorts\Sort;
+use Illuminate\Database\Eloquent\Builder;
+
+class NodeServerSorter implements Sort
+{
+    public function __invoke(Builder $query, bool $descending, string $property)
+    {
+        if ($query->getQuery()->from !== 'servers') {
+            throw new BadMethodCallException('Cannot use the NodeServerSorter against a non-server model.');
+        }
+
+        $query->join('nodes', 'nodes.id', '=', 'servers.node_id')->orderBy('nodes.name', $descending ? 'DESC' : 'ASC');
+    }
+}

--- a/app/Models/Sorters/NodeServerSorter.php
+++ b/app/Models/Sorters/NodeServerSorter.php
@@ -15,6 +15,6 @@ class NodeServerSorter implements Sort
             throw new BadMethodCallException('Cannot use the NodeServerSorter against a non-server model.');
         }
 
-        $query->join('nodes', 'nodes.id', '=', 'servers.node_id')->orderBy('nodes.name', $descending ? 'DESC' : 'ASC');
+        $query->join('nodes as ns', 'ns.id', '=', 'servers.node_id')->orderBy('ns.name', $descending ? 'DESC' : 'ASC');
     }
 }

--- a/resources/views/admin/servers/index.blade.php
+++ b/resources/views/admin/servers/index.blade.php
@@ -39,10 +39,16 @@
                 <table class="table table-hover">
                     <tbody>
                         <tr>
-                            <th>Server Name</th>
+                            <th>
+                                @include('admin.servers.partials.sortable_column', ['name' => 'Server Name', 'column' => 'name'])
+                            </th>
                             <th>UUID</th>
-                            <th>Owner</th>
-                            <th>Node</th>
+                            <th>
+                                @include('admin.servers.partials.sortable_column', ['name' => 'Owner', 'column' => 'owner'])
+                            </th>
+                            <th>
+                                @include('admin.servers.partials.sortable_column', ['name' => 'Node', 'column' => 'node'])
+                            </th>
                             <th>Connection</th>
                             <th></th>
                             <th></th>

--- a/resources/views/admin/servers/index.blade.php
+++ b/resources/views/admin/servers/index.blade.php
@@ -26,6 +26,7 @@
                 <div class="box-tools search01">
                     <form action="{{ route('admin.servers') }}" method="GET">
                         <div class="input-group input-group-sm">
+                            <input type="hidden" name="sort" value="{{ request()->get('sort') }}">
                             <input type="text" name="filter[*]" class="form-control pull-right" value="{{ request()->input()['filter']['*'] ?? '' }}" placeholder="Search Servers">
                             <div class="input-group-btn">
                                 <button type="submit" class="btn btn-default"><i class="fa fa-search"></i></button>

--- a/resources/views/admin/servers/partials/sortable_column.blade.php
+++ b/resources/views/admin/servers/partials/sortable_column.blade.php
@@ -1,0 +1,12 @@
+@if(request()->get('sort') === $column)
+    @php ($dir = '▲')
+    @php ($params = array_merge(request()->query(), ['sort' => '-' . $column]))
+@elseif(request()->get('sort') === '-' . $column)
+    @php ($dir = '▼')
+    @php ($params = request()->except(['sort']))
+@else
+    @php ($dir = '')
+    @php ($params = array_merge(request()->query(), ['sort' => $column]))
+@endif
+
+<a href="{{ route('admin.servers', $params) }}">{{ $dir }} {{ $name }}</a>


### PR DESCRIPTION
This PR addresses partially #498 by allowing the user to sort on:

* Server Name
* Owner
* Node

I also made sure that if the user was doing a keyword search, those features adds up.

![image](https://user-images.githubusercontent.com/785518/116612306-3df2c280-a8ec-11eb-9487-db547c287be6.png)

To address the rest of #498 I can also work on a category system, I didn't want to mix those two distinct features in one PR.