### PR TITLE
Allow MassActionBar div to be clicked through

### DIFF
--- a/resources/scripts/components/server/files/MassActionsBar.tsx
+++ b/resources/scripts/components/server/files/MassActionsBar.tsx
@@ -63,7 +63,7 @@ const MassActionsBar = () => {
 
     return (
         <Fade timeout={75} in={selectedFiles.length > 0} unmountOnExit>
-            <div css={tw`fixed bottom-0 z-50 left-0 right-0 flex justify-center`}>
+            <div css={tw`pointer-events-none fixed bottom-0 z-50 left-0 right-0 flex justify-center`}>
                 <SpinnerOverlay visible={loading} size={'large'} fixed>
                     {loadingMessage}
                 </SpinnerOverlay>
@@ -85,7 +85,7 @@ const MassActionsBar = () => {
                     onDismissed={() => setShowMove(false)}
                 />
                 }
-                <div css={tw`rounded p-4 mb-6`} style={{ background: 'rgba(0, 0, 0, 0.35)' }}>
+                <div css={tw`pointer-events-auto rounded p-4 mb-6`} style={{ background: 'rgba(0, 0, 0, 0.35)' }}>
                     <Button size={'xsmall'} css={tw`mr-4`} onClick={() => setShowMove(true)}>
                         <FontAwesomeIcon icon={faLevelUpAlt} css={tw`mr-2`}/> Move
                     </Button>


### PR DESCRIPTION
Allows users to interact with files that are blocked by the div that renders the MassActionbar

Closes #3355

![2021-05-15_20-05-10](https://user-images.githubusercontent.com/1757840/118381449-e4abb400-b5b8-11eb-83cc-2d18b9a59a8a.gif)
