### PR TITLE
Fix support for mailgun API endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ MAIL_USERNAME=
 MAIL_PASSWORD=
 MAIL_ENCRYPTION=tls
 MAIL_FROM=no-reply@example.com
+MAILGUN_ENDPOINT=api.mailgun.net
 # You should set this to your domain to prevent it defaulting to 'localhost', causing
 # mail servers such as Gmail to reject your mail.
 #

--- a/app/Console/Commands/Environment/EmailSettingsCommand.php
+++ b/app/Console/Commands/Environment/EmailSettingsCommand.php
@@ -37,6 +37,7 @@ class EmailSettingsCommand extends Command
                             {--encryption=}
                             {--host=}
                             {--port=}
+                            {--endpoint=}
                             {--username=}
                             {--password=}';
 
@@ -139,6 +140,11 @@ class EmailSettingsCommand extends Command
         $this->variables['MAILGUN_SECRET'] = $this->option('password') ?? $this->ask(
             trans('command/messages.environment.mail.ask_mailgun_secret'),
             $this->config->get('services.mailgun.secret')
+        );
+
+        $this->variables['MAILGUN_ENDPOINT'] = $this->option('endpoint') ?? $this->ask(
+            trans('command/messages.environment.mail.ask_mailgun_endpoint'),
+            $this->config->get('services.mailgun.endpoint')
         );
     }
 

--- a/config/services.php
+++ b/config/services.php
@@ -16,6 +16,7 @@ return [
     'mailgun' => [
         'domain' => env('MAILGUN_DOMAIN'),
         'secret' => env('MAILGUN_SECRET'),
+        'endpoint' => env('MAILGUN_ENDPOINT')
     ],
 
     'mandrill' => [

--- a/resources/lang/en/command/messages.php
+++ b/resources/lang/en/command/messages.php
@@ -53,6 +53,7 @@ return [
             'ask_smtp_username' => 'SMTP Username',
             'ask_smtp_password' => 'SMTP Password',
             'ask_mailgun_domain' => 'Mailgun Domain',
+            'ask_mailgun_endpoint' => 'Mailgun Endpoint',
             'ask_mailgun_secret' => 'Mailgun Secret',
             'ask_mandrill_secret' => 'Mandrill Secret',
             'ask_postmark_username' => 'Postmark API Key',


### PR DESCRIPTION
Because of the update to Laravel 8 (probably), it was impossible to use the european API endpoint of mailgun. This caused all mailgun requests go through the US version, which would cause 401 Unauthorized errors for european domains.

I've defined a default endpoint to the .env.example so people don't get confused when configuring the emails with the laravel command.