### PR TITLE
#BlameDane (fix backup pruning)

### DIFF
--- a/app/Console/Commands/Maintenance/PruneOrphanedBackupsCommand.php
+++ b/app/Console/Commands/Maintenance/PruneOrphanedBackupsCommand.php
@@ -28,7 +28,7 @@ class PruneOrphanedBackupsCommand extends Command
 
         $query = $repository->getBuilder()
             ->whereNull('completed_at')
-            ->whereDate('created_at', '<=', CarbonImmutable::now()->subMinutes($since));
+            ->where('created_at', '<=', CarbonImmutable::now()->subMinutes($since)->toDateTimeString());
 
         $count = $query->count();
         if (!$count) {


### PR DESCRIPTION
Previously running the prune backups command would prune any backups that are currently running (unless they were already completed), because the `created_at` where in the query was not functioning properly.