### PR TITLE
Allow database users to create/alter/drop routines

### DIFF
--- a/app/Repositories/Eloquent/DatabaseRepository.php
+++ b/app/Repositories/Eloquent/DatabaseRepository.php
@@ -107,7 +107,7 @@ class DatabaseRepository extends EloquentRepository implements DatabaseRepositor
     public function assignUserToDatabase(string $database, string $username, string $remote): bool
     {
         return $this->run(sprintf(
-            'GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, INDEX, LOCK TABLES, EXECUTE ON `%s`.* TO `%s`@`%s`',
+            'GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, INDEX, LOCK TABLES, CREATE ROUTINE, ALTER ROUTINE, EXECUTE ON `%s`.* TO `%s`@`%s`',
             $database,
             $username,
             $remote


### PR DESCRIPTION
Database users may wish to create/alter/drop routines on their databases in order to use extra MySQL functionality such as `IF` statements.