### PR TITLE
Permission for referencing other tables (foreign keys)

### DIFF
--- a/app/Repositories/Eloquent/DatabaseRepository.php
+++ b/app/Repositories/Eloquent/DatabaseRepository.php
@@ -107,7 +107,7 @@ class DatabaseRepository extends EloquentRepository implements DatabaseRepositor
     public function assignUserToDatabase(string $database, string $username, string $remote): bool
     {
         return $this->run(sprintf(
-            'GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, INDEX, LOCK TABLES, CREATE ROUTINE, ALTER ROUTINE, EXECUTE ON `%s`.* TO `%s`@`%s`',
+            'GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, REFERENCES, INDEX, LOCK TABLES, CREATE ROUTINE, ALTER ROUTINE, EXECUTE ON `%s`.* TO `%s`@`%s`',
             $database,
             $username,
             $remote


### PR DESCRIPTION
Add permission to reference other tables so one can use foreign key constraints i.e. FOREIGN KEY(x) REFERENCES tbl(y)