### PR TITLE
Updated formatting for the docker compose file to fix a error.

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -61,8 +61,7 @@ services:
       - "/srv/pterodactyl/certs/:/etc/letsencrypt/"
       - "/srv/pterodactyl/logs/:/app/storage/logs"
     environment:
-      <<: *panel-environment
-      <<: *mail-environment
+      <<: [*panel-environment, *mail-environment]
       DB_PASSWORD: *db-password
       APP_ENV: "production"
       APP_ENVIRONMENT_ONLY: "false"


### PR DESCRIPTION
This fixes the error message "There is an error in the yaml syntax: YAMLSemanticError: Map keys must be unique; "<<" is repeated" which is received if trying to deploy the docker compose using portainer it will not even allow you to click the button because of the formatting error. This is a page showing a example of what I did "http://yaml.org/type/merge.html" Instead of 2 merge requests docker/portainer only allows 1 merge request in this situation so they had to be combined into 1 line instead of 2.