### PR TITLE
Allow to find servers by node id (Application API)

### DIFF
--- a/app/Http/Controllers/Api/Application/Servers/ServerController.php
+++ b/app/Http/Controllers/Api/Application/Servers/ServerController.php
@@ -54,7 +54,7 @@ class ServerController extends ApplicationApiController
     public function index(GetServersRequest $request): array
     {
         $servers = QueryBuilder::for(Server::query())
-            ->allowedFilters(['uuid', 'uuidShort', 'name', 'image', 'external_id'])
+            ->allowedFilters(['uuid', 'uuidShort', 'name', 'image', 'external_id', 'node'])
             ->allowedSorts(['id', 'uuid'])
             ->paginate($request->query('per_page') ?? 50);
 


### PR DESCRIPTION
Allow node id to be used as a filter when listing all servers on the application API