### PR TITLE
Fix z-index of the mass confirmation modal

### DIFF
--- a/resources/scripts/components/server/files/MassActionsBar.tsx
+++ b/resources/scripts/components/server/files/MassActionsBar.tsx
@@ -63,7 +63,7 @@ const MassActionsBar = () => {
 
     return (
         <Fade timeout={75} in={selectedFiles.length > 0} unmountOnExit>
-            <div css={tw`pointer-events-none fixed bottom-0 z-50 left-0 right-0 flex justify-center`}>
+            <div css={tw`pointer-events-none fixed bottom-0 z-20 left-0 right-0 flex justify-center`}>
                 <SpinnerOverlay visible={loading} size={'large'} fixed>
                     {loadingMessage}
                 </SpinnerOverlay>


### PR DESCRIPTION
Fixes the order of mass confirmation modal to correctly be displayed prominently on top of all elements.

**Before:**
![image](https://user-images.githubusercontent.com/10975908/125205973-648a8d80-e28d-11eb-92a2-71cad210a51c.png)

**After:**
![image](https://user-images.githubusercontent.com/10975908/125205877-16758a00-e28d-11eb-8a78-40a7c1fe7c44.png)
