### PR TITLE
Fix Schedule Edit page not working directly by url

### DIFF
--- a/resources/scripts/components/server/schedules/ScheduleContainer.tsx
+++ b/resources/scripts/components/server/schedules/ScheduleContainer.tsx
@@ -58,7 +58,7 @@ export default () => {
                                     css={tw`cursor-pointer mb-2 flex-wrap`}
                                     onClick={(e: any) => {
                                         e.preventDefault();
-                                        history.push(`${match.url}/${schedule.id}`, { schedule });
+                                        history.push(`${match.url}/${schedule.id}`);
                                     }}
                                 >
                                     <ScheduleRow schedule={schedule}/>

--- a/resources/scripts/components/server/schedules/ScheduleEditContainer.tsx
+++ b/resources/scripts/components/server/schedules/ScheduleEditContainer.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useHistory, useLocation, useParams } from 'react-router-dom';
-import { Schedule } from '@/api/server/schedules/getServerSchedules';
+import { useHistory, useParams } from 'react-router-dom';
 import getServerSchedule from '@/api/server/schedules/getServerSchedule';
 import Spinner from '@/components/elements/Spinner';
 import FlashMessageRender from '@/components/FlashMessageRender';
@@ -23,10 +22,6 @@ interface Params {
     id: string;
 }
 
-interface State {
-    schedule?: Schedule;
-}
-
 const CronBox = ({ title, value }: { title: string; value: string }) => (
     <div css={tw`bg-neutral-700 rounded p-3`}>
         <p css={tw`text-neutral-300 text-sm`}>{title}</p>
@@ -47,7 +42,6 @@ const ActivePill = ({ active }: { active: boolean }) => (
 
 export default () => {
     const history = useHistory();
-    const { state } = useLocation<State>();
     const { id: scheduleId } = useParams<Params>();
 
     const id = ServerContext.useStoreState(state => state.server.data!.id);
@@ -57,7 +51,7 @@ export default () => {
     const [ isLoading, setIsLoading ] = useState(true);
     const [ showEditModal, setShowEditModal ] = useState(false);
 
-    const schedule = ServerContext.useStoreState(st => st.schedules.data.find(s => s.id === state.schedule?.id), isEqual);
+    const schedule = ServerContext.useStoreState(st => st.schedules.data.find(s => s.id === Number(scheduleId)), isEqual);
     const appendSchedule = ServerContext.useStoreActions(actions => actions.schedules.appendSchedule);
 
     useEffect(() => {


### PR DESCRIPTION
Fixes: #3473

I am not too sure what is the point of having 2 sources of truth. It tries to get the requested schedule id from react-router state only. And then when accessed by url directly there is no state and fails. I removed react-router state entirely and made so that the schedule ID is always the page url params one.

I am not too sure if react-router state is better then passing id threw url params, but if it's so I could implement it too.