### PR TITLE
fix modals z-index overlapping

### DIFF
--- a/resources/scripts/components/elements/Modal.tsx
+++ b/resources/scripts/components/elements/Modal.tsx
@@ -21,7 +21,8 @@ export interface ModalProps extends RequiredModalProps {
 }
 
 export const ModalMask = styled.div`
-    ${tw`fixed z-50 overflow-auto flex w-full inset-0`};
+    ${tw`fixed overflow-auto flex w-full inset-0`};
+    z-index: 10000;
     background: rgba(0, 0, 0, 0.70);
 `;
 


### PR DESCRIPTION
Fixes: #3428 

Tested on most pages, works fine. Other solution would have been to lower the SpinnerOverlay zIndex, but as I am not that familiar with this codebase I went with this solution.