### PR TITLE
fix: paper server jar input rule

### DIFF
--- a/database/Seeders/eggs/minecraft/egg-paper.json
+++ b/database/Seeders/eggs/minecraft/egg-paper.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-07-04T19:19:42-04:00",
+    "exported_at": "2021-07-24T11:38:02+03:00",
     "name": "Paper",
     "author": "parker@pterodactyl.io",
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",
@@ -48,7 +48,7 @@
             "default_value": "server.jar",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:20"
+            "rules": "required|regex:\/^([\\w\\d._-]+)(\\.jar)$\/"
         },
         {
             "name": "Download Path",


### PR DESCRIPTION
Changes Paper egg server jar variable input rule to match the other Minecraft eggs. Matches `a-zA-Z0-9_` and `.jar` at the end instead of hard-coded length value of 20.

Fixes #3492