### PR TITLE
fix: enable editing paper and spongeforge version variable input

### DIFF
--- a/database/Seeders/eggs/minecraft/egg-paper.json
+++ b/database/Seeders/eggs/minecraft/egg-paper.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-07-24T11:38:02+03:00",
+    "exported_at": "2021-08-01T03:54:45+03:00",
     "name": "Paper",
     "author": "parker@pterodactyl.io",
     "description": "High performance Spigot fork that aims to fix gameplay and mechanics inconsistencies.",
@@ -38,7 +38,7 @@
             "env_variable": "MINECRAFT_VERSION",
             "default_value": "latest",
             "user_viewable": true,
-            "user_editable": false,
+            "user_editable": true,
             "rules": "nullable|string|max:20"
         },
         {
@@ -65,7 +65,7 @@
             "env_variable": "BUILD_NUMBER",
             "default_value": "latest",
             "user_viewable": true,
-            "user_editable": false,
+            "user_editable": true,
             "rules": "required|string|max:20"
         }
     ]

--- a/database/Seeders/eggs/minecraft/egg-sponge--sponge-vanilla.json
+++ b/database/Seeders/eggs/minecraft/egg-sponge--sponge-vanilla.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v1",
         "update_url": null
     },
-    "exported_at": "2021-07-04T19:19:11-04:00",
+    "exported_at": "2021-08-01T03:55:24+03:00",
     "name": "Sponge (SpongeVanilla)",
     "author": "support@pterodactyl.io",
     "description": "SpongeVanilla is the SpongeAPI implementation for Vanilla Minecraft.",
@@ -21,7 +21,7 @@
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \")! For help, type \"\r\n}",
-        "logs": "{\r\n    \"custom\": false,\r\n    \"location\": \"logs\/latest.log\"\r\n}",
+        "logs": "{}",
         "stop": "stop"
     },
     "scripts": {
@@ -38,7 +38,7 @@
             "env_variable": "SPONGE_VERSION",
             "default_value": "1.12.2-7.3.0",
             "user_viewable": true,
-            "user_editable": false,
+            "user_editable": true,
             "rules": "required|regex:\/^([a-zA-Z0-9.\\-_]+)$\/"
         },
         {


### PR DESCRIPTION
Changes the paper and spongeforge version variable to be editable by users on the client view. There is no reason to have it as read-only. Other eggs have this value as editable