### PR TITLE
cmd(upgrade): fix force and seed flags being ignored

### DIFF
--- a/app/Console/Commands/UpgradeCommand.php
+++ b/app/Console/Commands/UpgradeCommand.php
@@ -68,7 +68,7 @@ class UpgradeCommand extends Command
                     );
                 }
             }
-            
+
             if (is_null($this->option('group'))) {
                 $groupDetails = posix_getgrgid(filegroup('public'));
                 $group = $groupDetails['name'] ?? 'www-data';
@@ -150,8 +150,8 @@ class UpgradeCommand extends Command
         });
 
         $this->withProgress($bar, function () {
-            $this->line('$upgrader> php artisan migrate --seed --force');
-            $this->call('migrate', ['--seed' => '', '--force' => '']);
+            $this->line('$upgrader> php artisan migrate --force --seed');
+            $this->call('migrate', ['--force' => true, '--seed' => true]);
         });
 
         $this->withProgress($bar, function () use ($user, $group) {


### PR DESCRIPTION
From Laravel's code.  Boolean flags require being specified with `true` or `false`, not `''`

![Ni26rKF8Bf05RgwO](https://user-images.githubusercontent.com/26559841/128080742-8aac2568-0e4f-4e41-8439-98404a5f6566.png)
