### PR TITLE
Filter allocations by assigned in application api.

### DIFF
--- a/app/Http/Controllers/Api/Application/Nodes/AllocationController.php
+++ b/app/Http/Controllers/Api/Application/Nodes/AllocationController.php
@@ -4,6 +4,7 @@ namespace Pterodactyl\Http\Controllers\Api\Application\Nodes;
 
 use Pterodactyl\Models\Node;
 use Illuminate\Http\JsonResponse;
+use Spatie\QueryBuilder\QueryBuilder;
 use Pterodactyl\Models\Allocation;
 use Pterodactyl\Services\Allocations\AssignmentService;
 use Pterodactyl\Services\Allocations\AllocationDeletionService;
@@ -43,7 +44,9 @@ class AllocationController extends ApplicationApiController
      */
     public function index(GetAllocationsRequest $request, Node $node): array
     {
-        $allocations = $node->allocations()->paginate($request->query('per_page') ?? 50);
+        $allocations = QueryBuilder::for($node->allocations())
+            ->allowedFilters(['assigned_to'])
+            ->paginate($request->query('per_page') ?? 50);
 
         return $this->fractal->collection($allocations)
             ->transformWith($this->getTransformer(AllocationTransformer::class))


### PR DESCRIPTION
I have ran into this issue when I was creating a website that was using the panel's application api. When creating a new server the data must include a default allocation for the server to use, but most of the time i just need any random non-assigned allocation which is easy at the start but once you have over 50 or 100 servers you either have to make the per_page bigger or search through pages for unassigned one. Now can just set assigned_to to null to get those ones.