### PR TITLE
make per_schedule_task_limit configurable

### DIFF
--- a/config/pterodactyl.php
+++ b/config/pterodactyl.php
@@ -141,7 +141,7 @@ return [
 
         'schedules' => [
             // The total number of tasks that can exist for any given schedule at once.
-            'per_schedule_task_limit' => 10,
+            'per_schedule_task_limit' => env('PTERODACTYL_PER_SCHEDULE_TASK_LIMIT', 10),
         ],
 
         'allocations' => [


### PR DESCRIPTION
create an env var for `per_schedule_task_limit` called `PTERODACTYL_PER_SCHEDULE_TASK_LIMIT` defualting to the previously hardcoded `10`