### PR TITLE
Add Json5 and Jsonc extensions to JSON mode

### DIFF
--- a/resources/scripts/modes.ts
+++ b/resources/scripts/modes.ts
@@ -43,9 +43,9 @@ const modes: Mode[] = [
     {
         name: 'JSON',
         mime: 'application/json',
-        mimes: [ 'application/json', 'application/x-json' ],
+        mimes: [ 'application/json', 'application/x-json', 'application/json5' ],
         mode: 'javascript',
-        ext: [ 'json', 'map' ],
+        ext: [ 'json', 'map', 'json5', 'jsonc' ],
         alias: [ 'json5' ],
     },
     { name: 'Lua', mime: 'text/x-lua', mode: 'lua', ext: [ 'lua' ] },


### PR DESCRIPTION
For #3583 

MIME type for Json5 found here https://github.com/json5/json5/issues/80

Could not find MIME type for Json with comments

![image](https://user-images.githubusercontent.com/8514986/131037146-7ea56228-6150-44b8-bb76-7169b853f308.png)
