### PR TITLE
server: fix build modification not being persisted

### DIFF
--- a/app/Services/Servers/BuildModificationService.php
+++ b/app/Services/Servers/BuildModificationService.php
@@ -56,8 +56,6 @@ class BuildModificationService
      */
     public function handle(Server $server, array $data)
     {
-        $this->connection->beginTransaction();
-
         /** @var \Pterodactyl\Models\Server $server */
         $server = $this->connection->transaction(function() use ($server, $data) {
             $this->processAllocations($server, $data);
@@ -87,7 +85,7 @@ class BuildModificationService
 
         // Because Wings always fetches an updated configuration from the Panel when booting
         // a server this type of exception can be safely "ignored" and just written to the logs.
-        // Ideally this request succeedes so we can apply resource modifications on the fly, but
+        // Ideally this request succeeds, so we can apply resource modifications on the fly, but
         // if it fails we can just continue on as normal.
         if (!empty($updateData['build'])) {
             try {


### PR DESCRIPTION
Pretty self-explainatory, removes a loose `beginTransaction` that should've been removed by [`d8d1eac`](https://github.com/pterodactyl/panel/commit/d8d1eacb42019228032e798c417a89ca53cc89f4#diff-12658b98d0a8cc9aa4712a24c0db0973f56cf08d132ece8d0ac5fd734364b15eL97-L98)