### PR TITLE
Fix SSL config docker

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -30,7 +30,7 @@ else
 fi
 
 echo "Checking if https is required."
-if [ -f /etc/nginx/conf.d/default.conf ]; then
+if [ -f /etc/nginx/http.d/default.conf ]; then
   echo "Using nginx config already in place."
   if [ $LE_EMAIL ]; then
     echo "Checking for cert update"
@@ -42,12 +42,12 @@ else
   echo "Checking if letsencrypt email is set."
   if [ -z $LE_EMAIL ]; then
     echo "No letsencrypt email is set using http config."
-    cp .github/docker/default.conf /etc/nginx/conf.d/default.conf
+    cp .github/docker/default.conf /etc/nginx/http.d/default.conf
   else
     echo "writing ssl config"
-    cp .github/docker/default_ssl.conf /etc/nginx/conf.d/default.conf
+    cp .github/docker/default_ssl.conf /etc/nginx/http.d/default.conf
     echo "updating ssl config for domain"
-    sed -i "s|<domain>|$(echo $APP_URL | sed 's~http[s]*://~~g')|g" /etc/nginx/conf.d/default.conf
+    sed -i "s|<domain>|$(echo $APP_URL | sed 's~http[s]*://~~g')|g" /etc/nginx/http.d/default.conf
     echo "generating certs"
     certbot certonly -d $(echo $APP_URL | sed 's~http[s]*://~~g')  --standalone -m $LE_EMAIL --agree-tos -n
   fi

--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -30,7 +30,7 @@ else
 fi
 
 echo "Checking if https is required."
-if [ -f /etc/nginx/http.d/default.conf ]; then
+if [ -f /etc/nginx/http.d/panel.conf ]; then
   echo "Using nginx config already in place."
   if [ $LE_EMAIL ]; then
     echo "Checking for cert update"
@@ -42,15 +42,17 @@ else
   echo "Checking if letsencrypt email is set."
   if [ -z $LE_EMAIL ]; then
     echo "No letsencrypt email is set using http config."
-    cp .github/docker/default.conf /etc/nginx/http.d/default.conf
+    cp .github/docker/default.conf /etc/nginx/http.d/panel.conf
   else
     echo "writing ssl config"
-    cp .github/docker/default_ssl.conf /etc/nginx/http.d/default.conf
+    cp .github/docker/default_ssl.conf /etc/nginx/http.d/panel.conf
     echo "updating ssl config for domain"
-    sed -i "s|<domain>|$(echo $APP_URL | sed 's~http[s]*://~~g')|g" /etc/nginx/http.d/default.conf
+    sed -i "s|<domain>|$(echo $APP_URL | sed 's~http[s]*://~~g')|g" /etc/nginx/http.d/panel.conf
     echo "generating certs"
     certbot certonly -d $(echo $APP_URL | sed 's~http[s]*://~~g')  --standalone -m $LE_EMAIL --agree-tos -n
   fi
+  echo "Removing the default nginx config"
+  rm -rf /etc/nginx/http.d/default.conf
 fi
 
 ## check for DB up before starting the panel

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ RUN rm /usr/local/etc/php-fpm.conf \
     && sed -i s/ssl_session_cache/#ssl_session_cache/g /etc/nginx/nginx.conf \
     && mkdir -p /var/run/php /var/run/nginx
 
-COPY .github/docker/default.conf /etc/nginx/http.d/default.conf
 COPY .github/docker/www.conf /usr/local/etc/php-fpm.conf
 COPY .github/docker/supervisord.conf /etc/supervisord.conf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN rm /usr/local/etc/php-fpm.conf \
     && sed -i s/ssl_session_cache/#ssl_session_cache/g /etc/nginx/nginx.conf \
     && mkdir -p /var/run/php /var/run/nginx
 
+COPY .github/docker/default.conf /etc/nginx/http.d/default.conf
 COPY .github/docker/www.conf /usr/local/etc/php-fpm.conf
 COPY .github/docker/supervisord.conf /etc/supervisord.conf
 


### PR DESCRIPTION
By default nginx in alpine has the following include statement: `include /etc/nginx/http.d/*.conf`. Normal HTTP configuration was working because it was being copied over to the image at build time. I've removed that. Now the entrypoint decides which config to use and that gets picked up by nginx properly. Tested with the latest version of docker-compose and docker