### PR TITLE
Change maintenance box color

### DIFF
--- a/resources/views/admin/nodes/view/index.blade.php
+++ b/resources/views/admin/nodes/view/index.blade.php
@@ -98,7 +98,7 @@
                 <div class="row">
                     @if($node->maintenance_mode)
                     <div class="col-sm-12">
-                        <div class="info-box bg-grey">
+                        <div class="info-box bg-orange">
                             <span class="info-box-icon"><i class="ion ion-wrench"></i></span>
                             <div class="info-box-content" style="padding: 23px 10px 0;">
                                 <span class="info-box-text">This node is under</span>


### PR DESCRIPTION
The color of the At-a-Glance for the maintenance box just didn't seem right, so this PR fixes it, with the change shown below.

Before:
![image](https://user-images.githubusercontent.com/63236817/135896395-80680c25-5fc2-4433-a12f-8a0248ff2fd6.png)

After:
![image](https://user-images.githubusercontent.com/63236817/135896448-f4ca5f56-28a7-4a52-b087-3ae41f5ba731.png)
