### PR TITLE
Fix wings receiving wrong suspended status on sync

### DIFF
--- a/app/Services/Servers/SuspensionService.php
+++ b/app/Services/Servers/SuspensionService.php
@@ -58,15 +58,20 @@ class SuspensionService
             throw new ConflictHttpException('Cannot toggle suspension status on a server that is currently being transferred.');
         }
 
-        $this->connection->transaction(function () use ($action, $server, $isSuspending) {
-            $server->update([
-                'status' => $isSuspending ? Server::STATUS_SUSPENDED : null,
-            ]);
+        // Update the server's suspension status.
+        $server->update([
+            'status' => $isSuspending ? Server::STATUS_SUSPENDED : null,
+        ]);
 
-            // Only trigger a Wings server sync if it is not currently being transferred.
-            if (is_null($server->transfer)) {
-                $this->daemonServerRepository->setServer($server)->sync();
-            }
-        });
+        try {
+            // Tell wings to re-sync the server state.
+            $this->daemonServerRepository->setServer($server)->sync();
+        } catch (\Exception $exception) {
+            // Rollback the server's suspension status if wings fails to sync the server.
+            $server->update([
+                'status' => $isSuspending ? null : Server::STATUS_SUSPENDED,
+            ]);
+            throw $exception;
+        }
     }
 }


### PR DESCRIPTION
Due to wings pulling the server configuration rather than the Panel pushing it,
wings gets the wrong status for a server if both the status update and sync request
are ran in a transaction due to the status not being persisted in the database.

Fixes #3639