### PR TITLE
Change ^C to ^^C in egg menus

### DIFF
--- a/resources/views/admin/eggs/new.blade.php
+++ b/resources/views/admin/eggs/new.blade.php
@@ -90,7 +90,7 @@
                             <div class="form-group">
                                 <label for="pConfigStop" class="form-label">Stop Command</label>
                                 <input type="text" id="pConfigStop" name="config_stop" class="form-control" value="{{ old('config_stop') }}" />
-                                <p class="text-muted small">The command that should be sent to server processes to stop them gracefully. If you need to send a <code>SIGINT</code> you should enter <code>^C</code> here.</p>
+                                <p class="text-muted small">The command that should be sent to server processes to stop them gracefully. If you need to send a <code>SIGINT</code> you should enter <code>^^C</code> here.</p>
                             </div>
                             <div class="form-group">
                                 <label for="pConfigLogs" class="form-label">Log Configuration</label>

--- a/resources/views/admin/eggs/view.blade.php
+++ b/resources/views/admin/eggs/view.blade.php
@@ -130,7 +130,7 @@
                             <div class="form-group">
                                 <label for="pConfigStop" class="form-label">Stop Command</label>
                                 <input type="text" id="pConfigStop" name="config_stop" class="form-control" value="{{ $egg->config_stop }}" />
-                                <p class="text-muted small">The command that should be sent to server processes to stop them gracefully. If you need to send a <code>SIGINT</code> you should enter <code>^C</code> here.</p>
+                                <p class="text-muted small">The command that should be sent to server processes to stop them gracefully. If you need to send a <code>SIGINT</code> you should enter <code>^^C</code> here.</p>
                             </div>
                             <div class="form-group">
                                 <label for="pConfigLogs" class="form-label">Log Configuration</label>


### PR DESCRIPTION
For some reason, ^^C actually sends a SIGINT to the server, and ^C does not, so I changed the egg UI to say to add ^^C