### PR TITLE
cmd(upgrade):  Attempt to gain users attention during upgrade

### DIFF
--- a/app/Console/Commands/UpgradeCommand.php
+++ b/app/Console/Commands/UpgradeCommand.php
@@ -175,7 +175,7 @@ class UpgradeCommand extends Command
         });
 
         $this->newLine(2);
-        $this->info('Finished running upgrade. Do not forget to update your Wings too!');
+        $this->info('Panel has been successfully upgraded. Please ensure you also update any Wings instances: https://pterodactyl.io/wings/1.0/upgrading.html');
     }
 
     protected function withProgress(ProgressBar $bar, Closure $callback)

--- a/app/Console/Commands/UpgradeCommand.php
+++ b/app/Console/Commands/UpgradeCommand.php
@@ -57,7 +57,7 @@ class UpgradeCommand extends Command
                 $userDetails = posix_getpwuid(fileowner('public'));
                 $user = $userDetails['name'] ?? 'www-data';
 
-                if (!$this->confirm("Your webserver user has been detected as [{$user}]: is this correct?", true)) {
+                if (!$this->confirm("Your webserver user has been detected as <fg=blue>[{$user}]:</> is this correct?", true)) {
                     $user = $this->anticipate(
                         'Please enter the name of the user running your webserver process. This varies from system to system, but is generally "www-data", "nginx", or "apache".',
                         [
@@ -73,7 +73,7 @@ class UpgradeCommand extends Command
                 $groupDetails = posix_getgrgid(filegroup('public'));
                 $group = $groupDetails['name'] ?? 'www-data';
 
-                if (!$this->confirm("Your webserver group has been detected as [{$group}]: is this correct?", true)) {
+                if (!$this->confirm("Your webserver group has been detected as <fg=blue>[{$group}]:</> is this correct?", true)) {
                     $group = $this->anticipate(
                         'Please enter the name of the group running your webserver process. Normally this is the same as your user.',
                         [
@@ -86,6 +86,7 @@ class UpgradeCommand extends Command
             }
 
             if (!$this->confirm('Are you sure you want to run the upgrade process for your Panel?')) {
+                $this->warn('Upgrade process terminated by user.');
                 return;
             }
         }
@@ -173,8 +174,8 @@ class UpgradeCommand extends Command
             $this->call('up');
         });
 
-        $this->newLine();
-        $this->info('Finished running upgrade.');
+        $this->newLine(2);
+        $this->info('Finished running upgrade. Do not forget to update your Wings too!');
     }
 
     protected function withProgress(ProgressBar $bar, Closure $callback)


### PR DESCRIPTION
Changes color of the user and group to gain attention, common issue is having wrong user/group which breaks the panel. Outputs termination message when users spam enter skipping the upgrade wondering why it didn't upgrade.

Reminder to update wings, because users forget it.

![image](https://user-images.githubusercontent.com/10975908/136698764-8d449655-09f7-4aeb-9825-4b130dc48a7e.png)
