### PR TITLE
change display format of the container uptime

### DIFF
--- a/resources/scripts/components/server/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/ServerDetailsBlock.tsx
@@ -92,7 +92,7 @@ const ServerDetailsBlock = () => {
                 />
                 &nbsp;{!status ? 'Connecting...' : (isInstalling ? 'Installing' : (isTransferring) ? 'Transferring' : status)}
                 {stats.uptime > 0 &&
-                <span css={tw`ml-2`}>
+                <span css={tw`ml-2 lowercase`}>
                     (<UptimeDuration uptime={stats.uptime / 1000}/>)
                 </span>
                 }

--- a/resources/scripts/components/server/UptimeDuration.tsx
+++ b/resources/scripts/components/server/UptimeDuration.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
 
 export default ({ uptime }: { uptime: number }) => {
-    const hours = Math.floor(Math.floor(uptime) / 60 / 60);
+    const days = Math.floor(uptime / (24 * 60 * 60));
+    const hours = Math.floor(Math.floor(uptime) / 60 / 60 % 24);
     const remainder = Math.floor(uptime - (hours * 60 * 60));
-    const minutes = Math.floor(remainder / 60);
+    const minutes = Math.floor(remainder / 60 % 60);
     const seconds = remainder % 60;
 
     return (
         <>
-            {hours.toString().padStart(2, '0')}:{minutes.toString().padStart(2, '0')}:{seconds.toString().padStart(2, '0')}
+            {days > 0 ? (
+                <>
+                    {days}d {hours}h {minutes}m
+                </>
+            ) : (
+                <>
+                    {hours}h {minutes}m {seconds}s
+                </>
+            )}
         </>
     );
 };

--- a/resources/scripts/components/server/UptimeDuration.tsx
+++ b/resources/scripts/components/server/UptimeDuration.tsx
@@ -7,17 +7,9 @@ export default ({ uptime }: { uptime: number }) => {
     const minutes = Math.floor(remainder / 60 % 60);
     const seconds = remainder % 60;
 
-    return (
-        <>
-            {days > 0 ? (
-                <>
-                    {days}d {hours}h {minutes}m
-                </>
-            ) : (
-                <>
-                    {hours}h {minutes}m {seconds}s
-                </>
-            )}
-        </>
-    );
+    if (days > 0) {
+        return <>{days}d {hours}h {minutes}m</>;
+    }
+
+    return <>{hours}h {minutes}m {seconds}s</>;
 };


### PR DESCRIPTION
Display `day, hour, min` if days is more than 0, otherwise default to existing `hour, min, sec`. Removes pads to make it cleaner in this new format. There are probably better ways to do this especially with the frags.

![image](https://user-images.githubusercontent.com/10975908/138597540-197a7e37-7456-40aa-a583-38c2328a9029.png)


![image](https://user-images.githubusercontent.com/10975908/138597534-6983d0bf-312b-4cb7-9af3-d4d079955797.png)
