### PR TITLE
fix: use POST for admin logout route

### DIFF
--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -195,9 +195,17 @@
                             cancelButtonColor: '#d33',
                             confirmButtonText: 'Log out'
                         }, function () {
-                            window.location = $(that).attr('href');
+                             $.ajax({
+                                type: 'POST',
+                                url: '{{ route('auth.logout') }}',
+                                data: {
+                                    _token: '{{ csrf_token() }}'
+                                },complete: function () {
+                                    window.location.href = '{{route('auth.login')}}';
+                                }
                         });
                     });
+                });
                 </script>
             @endif
 


### PR DESCRIPTION
Quick dirty fix for logging out from the admin panel as the auth route was changed from GET to POST.