### PR TITLE
Change "Game Port" to "Primary Port"

### DIFF
--- a/resources/views/admin/servers/view/build.blade.php
+++ b/resources/views/admin/servers/view/build.blade.php
@@ -135,7 +135,7 @@
                         </div>
                         <div class="box-body">
                             <div class="form-group">
-                                <label for="pAllocation" class="control-label">Game Port</label>
+                                <label for="pAllocation" class="control-label">Primary Port</label>
                                 <select id="pAllocation" name="allocation_id" class="form-control">
                                     @foreach ($assigned as $assignment)
                                         <option value="{{ $assignment->id }}"


### PR DESCRIPTION
This changes makes the terminology match what's said in the Network tab
And removes the confusing requirement that the Primary Port be the game port even if that port is irrelevant to the server hoster when supplying connection information to users.