### PR TITLE
fix(docker): handle cases where DB_PORT is not defined

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -55,6 +55,11 @@ else
   rm -rf /etc/nginx/http.d/default.conf
 fi
 
+if [[ -z $DB_PORT ]]; then
+  echo -e "DB_PORT not specified, defaulting to 3306"
+  DB_PORT=3306
+fi
+
 ## check for DB up before starting the panel
 echo "Checking database status."
 until nc -z -v -w30 $DB_HOST $DB_PORT


### PR DESCRIPTION
Related to and discussed in #3796.

This PR adds a check if the DB_PORT environmental variable is defined, and in case it's not defined, it defaults to the port 3306.

This allows for backward compatibility for users that have older Docker setups without the environmental variable defined. (As of now, the panel will fail to boot if the DB_PORT variable is missing.)