### PR TITLE
Add new audit log types

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/BackupController.php
+++ b/app/Http/Controllers/Api/Client/Servers/BackupController.php
@@ -92,7 +92,7 @@ class BackupController extends ClientApiController
 
             $backup = $action->handle($server, $request->input('name'));
 
-            $audit->metadata = ['backup_name' => $backup->name];
+            $audit->metadata = ['backup_uuid' => $backup->uuid, 'backup_name' => $backup->name];
 
             return $backup;
         });
@@ -116,7 +116,7 @@ class BackupController extends ClientApiController
 
         $action = $backup->is_locked ? AuditLog::SERVER__BACKUP_UNLOCK : AuditLog::SERVER__BACKUP_LOCK;
         $server->audit($action, function (AuditLog $audit) use ($backup) {
-            $audit->metadata = ['backup_name' => $backup->name];
+            $audit->metadata = ['backup_uuid' => $backup->uuid, 'backup_name' => $backup->name];
 
             $backup->update(['is_locked' => !$backup->is_locked]);
         });
@@ -157,7 +157,7 @@ class BackupController extends ClientApiController
         }
 
         $server->audit(AuditLog::SERVER__BACKUP_DELETE, function (AuditLog $audit) use ($backup) {
-            $audit->metadata = ['backup_name' => $backup->name];
+            $audit->metadata = ['backup_uuid' => $backup->uuid, 'backup_name' => $backup->name];
 
             $this->deleteBackupService->handle($backup);
         });
@@ -185,7 +185,7 @@ class BackupController extends ClientApiController
 
         $url = $this->downloadLinkService->handle($backup, $request->user());
         $server->audit(AuditLog::SERVER__BACKUP_DOWNLOAD, function (AuditLog $audit) use ($backup) {
-            $audit->metadata = ['backup_name' => $backup->name];
+            $audit->metadata = ['backup_uuid' => $backup->uuid, 'backup_name' => $backup->name];
         });
 
         return new JsonResponse([
@@ -222,7 +222,7 @@ class BackupController extends ClientApiController
         }
 
         $server->audit(AuditLog::SERVER__BACKUP_RESTORE_START, function (AuditLog $audit, Server $server) use ($backup, $request) {
-            $audit->metadata = ['backup_name' => $backup->name];
+            $audit->metadata = ['backup_uuid' => $backup->uuid, 'backup_name' => $backup->name];
 
             // If the backup is for an S3 file we need to generate a unique Download link for
             // it that will allow Wings to actually access the file.

--- a/app/Http/Controllers/Api/Client/Servers/ScheduleTaskController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ScheduleTaskController.php
@@ -59,7 +59,7 @@ class ScheduleTaskController extends ClientApiController
         $lastTask = $schedule->tasks()->orderByDesc('sequence_id')->first();
 
         /** @var \Pterodactyl\Models\Task $task */
-        $task = $server->audit(AuditLog::SERVER__SCHEDULE_TASK_CREATE, function (AuditLog $audit, Server $server) use ($request, $schedule) {
+        $task = $server->audit(AuditLog::SERVER__SCHEDULE_TASK_CREATE, function (AuditLog $audit, Server $server) use ($request, $schedule, $lastTask) {
             $task = $this->repository->create([
                 'schedule_id' => $schedule->id,
                 'sequence_id' => ($lastTask->sequence_id ?? 0) + 1,

--- a/app/Http/Controllers/Api/Client/Servers/SubuserController.php
+++ b/app/Http/Controllers/Api/Client/Servers/SubuserController.php
@@ -89,7 +89,7 @@ class SubuserController extends ClientApiController
      */
     public function store(StoreSubuserRequest $request, Server $server)
     {
-        $response = $server->audit(AuditLog::SERVER__SUBUSER_CREATED, function (AuditLog $audit, Server $server) use ($request) {
+        $response = $server->audit(AuditLog::SERVER__SUBUSER_CREATE, function (AuditLog $audit, Server $server) use ($request) {
             $response = $this->creationService->handle(
                 $server,
                 $request->input('email'),

--- a/app/Http/Controllers/Api/Client/Servers/SubuserController.php
+++ b/app/Http/Controllers/Api/Client/Servers/SubuserController.php
@@ -4,6 +4,7 @@ namespace Pterodactyl\Http\Controllers\Api\Client\Servers;
 
 use Illuminate\Http\Request;
 use Pterodactyl\Models\Server;
+use Pterodactyl\Models\AuditLog;
 use Illuminate\Http\JsonResponse;
 use Pterodactyl\Models\Permission;
 use Illuminate\Support\Facades\Log;
@@ -88,11 +89,15 @@ class SubuserController extends ClientApiController
      */
     public function store(StoreSubuserRequest $request, Server $server)
     {
-        $response = $this->creationService->handle(
-            $server,
-            $request->input('email'),
-            $this->getDefaultPermissions($request)
-        );
+        $response = $server->audit(AuditLog::SERVER__SUBUSER_CREATED, function (AuditLog $audit, Server $server) use ($request) {
+            $response = $this->creationService->handle(
+                $server,
+                $request->input('email'),
+                $this->getDefaultPermissions($request)
+            );
+            $audit->metadata = ['user' => $request->input('email')];
+            return $response;
+        });
 
         return $this->fractal->item($response)
             ->transformWith($this->getTransformer(SubuserTransformer::class))
@@ -119,9 +124,12 @@ class SubuserController extends ClientApiController
         // Only update the database and hit up the Wings instance to invalidate JTI's if the permissions
         // have actually changed for the user.
         if ($permissions !== $current) {
-            $this->repository->update($subuser->id, [
-                'permissions' => $this->getDefaultPermissions($request),
-            ]);
+            $server->audit(AuditLog::SERVER__SUBUSER_UPDATE, function (AuditLog $audit) use ($subuser, $request) {
+                $audit->metadata = ['user' => $subuser->user->email];
+                $this->repository->update($subuser->id, [
+                    'permissions' => $this->getDefaultPermissions($request),
+                ]);
+            });
 
             try {
                 $this->serverRepository->setServer($server)->revokeUserJTI($subuser->user_id);
@@ -147,7 +155,10 @@ class SubuserController extends ClientApiController
         /** @var \Pterodactyl\Models\Subuser $subuser */
         $subuser = $request->attributes->get('subuser');
 
-        $this->repository->delete($subuser->id);
+        $server->audit(AuditLog::SERVER__SUBUSER_DELETE, function (AuditLog $audit) use ($subuser) {
+            $audit->metadata = ['user' => $subuser->user->email];
+            $this->repository->delete($subuser->id);
+        });
 
         try {
             $this->serverRepository->setServer($server)->revokeUserJTI($subuser->user_id);

--- a/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
@@ -47,12 +47,12 @@ class BackupStatusController extends Controller
         }
 
         $action = $request->input('successful')
-            ? AuditLog::SERVER__BACKUP_COMPELTED
-            : AuditLog::SERVER__BACKUP_FAILED;
+            ? AuditLog::SERVER__BACKUP_COMPLETE
+            : AuditLog::SERVER__BACKUP_FAIL;
 
         $model->server->audit($action, function (AuditLog $audit) use ($model, $request) {
             $audit->is_system = true;
-            $audit->metadata = ['backup_uuid' => $model->uuid];
+            $audit->metadata = ['backup_name' => $model->name];
 
             $successful = $request->boolean('successful');
             $model->fill([
@@ -94,14 +94,14 @@ class BackupStatusController extends Controller
         /** @var \Pterodactyl\Models\Backup $model */
         $model = Backup::query()->where('uuid', $backup)->firstOrFail();
         $action = $request->get('successful')
-            ? AuditLog::SERVER__BACKUP_RESTORE_COMPLETED
-            : AuditLog::SERVER__BACKUP_RESTORE_FAILED;
+            ? AuditLog::SERVER__BACKUP_RESTORE_COMPLETE
+            : AuditLog::SERVER__BACKUP_RESTORE_FAIL;
 
         // Just create a new audit entry for this event and update the server state
         // so that power actions, file management, and backups can resume as normal.
-        $model->server->audit($action, function (AuditLog $audit, Server $server) use ($backup) {
+        $model->server->audit($action, function (AuditLog $audit, Server $server) use ($model, $backup) {
             $audit->is_system = true;
-            $audit->metadata = ['backup_uuid' => $backup];
+            $audit->metadata = ['backup_name' => $model->name];
             $server->update(['status' => null]);
         });
 

--- a/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
@@ -52,7 +52,7 @@ class BackupStatusController extends Controller
 
         $model->server->audit($action, function (AuditLog $audit) use ($model, $request) {
             $audit->is_system = true;
-            $audit->metadata = ['backup_name' => $model->name];
+            $audit->metadata = ['backup_uuid' => $model->uuid, 'backup_name' => $model->name];
 
             $successful = $request->boolean('successful');
             $model->fill([
@@ -101,7 +101,7 @@ class BackupStatusController extends Controller
         // so that power actions, file management, and backups can resume as normal.
         $model->server->audit($action, function (AuditLog $audit, Server $server) use ($model, $backup) {
             $audit->is_system = true;
-            $audit->metadata = ['backup_name' => $model->name];
+            $audit->metadata = ['backup_uuid' => $model->uuid, 'backup_name' => $model->name];
             $server->update(['status' => null]);
         });
 

--- a/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
@@ -110,7 +110,7 @@ class ServerDetailsController extends Controller
         /** @var \Pterodactyl\Models\Server[] $servers */
         $servers = Server::query()
             ->select('servers.*')
-            ->selectRaw('JSON_UNQUOTE(JSON_EXTRACT(started.metadata, "$.backup_name")) as backup_name')
+            ->selectRaw('JSON_UNQUOTE(JSON_EXTRACT(started.metadata, "$.backup_uuid")) as backup_uuid')
             ->leftJoinSub(function (Builder $builder) {
                 $builder->select('*')->from('audit_logs')
                     ->where('action', AuditLog::SERVER__BACKUP_RESTORE_START)
@@ -135,7 +135,7 @@ class ServerDetailsController extends Controller
             // so that power actions, file management, and backups can resume as normal.
             $server->audit(AuditLog::SERVER__BACKUP_RESTORE_FAIL, function (AuditLog $audit, Server $server) {
                 $audit->is_system = true;
-                $audit->metadata = ['backup_name' => $server->getAttribute('backup_name')];
+                $audit->metadata = ['backup_uuid' => $server->getAttribute('backup_uuid'), 'backup_name' => $server->getAttribute('backup_name')];
                 $server->update(['status' => null]);
             });
         }

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -24,6 +24,21 @@ class AuditLog extends Model
 {
     public const UPDATED_AT = null;
 
+    public const SERVER__BACKUP_START = 'server:backup.start';
+    public const SERVER__BACKUP_FAIL = 'server:backup.fail';
+    public const SERVER__BACKUP_COMPLETE = 'server:backup.complete';
+    public const SERVER__BACKUP_DELETE = 'server:backup.delete';
+    public const SERVER__BACKUP_DOWNLOAD = 'server:backup.download';
+    public const SERVER__BACKUP_LOCK = 'server:backup.lock';
+    public const SERVER__BACKUP_UNLOCK = 'server:backup.unlock';
+    public const SERVER__BACKUP_RESTORE_START = 'server:backup.restore.start';
+    public const SERVER__BACKUP_RESTORE_COMPLET = 'server:backup.restore.complete';
+    public const SERVER__BACKUP_RESTORE_FAIL = 'server:backup.restore.fail';
+
+    public const SERVER__DATABASE_CREATE = 'server:database.create';
+    public const SERVER__DATABASE_PASSWORD_ROTATE = 'server:database.password.rotate';
+    public const SERVER__DATABASE_DELETE = 'server:database.delete';
+
     public const SERVER__FILESYSTEM_DOWNLOAD = 'server:filesystem.download';
     public const SERVER__FILESYSTEM_WRITE = 'server:filesystem.write';
     public const SERVER__FILESYSTEM_DELETE = 'server:filesystem.delete';
@@ -31,16 +46,26 @@ class AuditLog extends Model
     public const SERVER__FILESYSTEM_COMPRESS = 'server:filesystem.compress';
     public const SERVER__FILESYSTEM_DECOMPRESS = 'server:filesystem.decompress';
     public const SERVER__FILESYSTEM_PULL = 'server:filesystem.pull';
-    public const SERVER__BACKUP_STARTED = 'server:backup.started';
-    public const SERVER__BACKUP_FAILED = 'server:backup.failed';
-    public const SERVER__BACKUP_COMPELTED = 'server:backup.completed';
-    public const SERVER__BACKUP_DELETED = 'server:backup.deleted';
-    public const SERVER__BACKUP_DOWNLOADED = 'server:backup.downloaded';
-    public const SERVER__BACKUP_LOCKED = 'server:backup.locked';
-    public const SERVER__BACKUP_UNLOCKED = 'server:backup.unlocked';
-    public const SERVER__BACKUP_RESTORE_STARTED = 'server:backup.restore.started';
-    public const SERVER__BACKUP_RESTORE_COMPLETED = 'server:backup.restore.completed';
-    public const SERVER__BACKUP_RESTORE_FAILED = 'server:backup.restore.failed';
+
+    public const SERVER__ALLOCATION_SET_PRIMARY = 'server:allocation.set.primary';
+    public const SERVER__ALLOCATION_DELETE = 'server:allocation.delete';
+    public const SERVER__ALLOCATION_CREATE = 'server:allocation.create';
+
+    public const SERVER__SCHEDULE_CREATE = 'server:schedule.create';
+    public const SERVER__SCHEDULE_UPDATE = 'server:schedule.update';
+    public const SERVER__SCHEDULE_DELETE = 'server:schedule.delete';
+    public const SERVER__SCHEDULE_RUN = 'server:schedule.run';
+    public const SERVER__SCHEDULE_TASK_CREATE = 'server:schedule.task.create';
+    public const SERVER__SCHEDULE_TASK_UPDATE = 'server:schedule.task.update';
+    public const SERVER__SCHEDULE_TASK_DELETE = 'server:schedule.task.delete';
+
+    public const SERVER__SETTINGS_NAME = 'server:settings.name.update';
+    public const SERVER__SETTINGS_REINSTALL = 'server:settings.reinstall';
+    public const SERVER__SETTINGS_IMAGE = 'server:settings.image.update';
+
+    public const SERVER__SUBUSER_CREATED = 'server:subuser.create';
+    public const SERVER__SUBUSER_UPDATE = 'server:subuser.update';
+    public const SERVER__SUBUSER_DELETE = 'server:subuser.delete';
 
     /**
      * @var string[]

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -63,7 +63,7 @@ class AuditLog extends Model
     public const SERVER__SETTINGS_REINSTALL = 'server:settings.reinstall';
     public const SERVER__SETTINGS_IMAGE = 'server:settings.image.update';
 
-    public const SERVER__SUBUSER_CREATED = 'server:subuser.create';
+    public const SERVER__SUBUSER_CREATE = 'server:subuser.create';
     public const SERVER__SUBUSER_UPDATE = 'server:subuser.update';
     public const SERVER__SUBUSER_DELETE = 'server:subuser.delete';
 

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -32,7 +32,7 @@ class AuditLog extends Model
     public const SERVER__BACKUP_LOCK = 'server:backup.lock';
     public const SERVER__BACKUP_UNLOCK = 'server:backup.unlock';
     public const SERVER__BACKUP_RESTORE_START = 'server:backup.restore.start';
-    public const SERVER__BACKUP_RESTORE_COMPLET = 'server:backup.restore.complete';
+    public const SERVER__BACKUP_RESTORE_COMPLETE = 'server:backup.restore.complete';
     public const SERVER__BACKUP_RESTORE_FAIL = 'server:backup.restore.fail';
 
     public const SERVER__DATABASE_CREATE = 'server:database.create';

--- a/app/Models/Backup.php
+++ b/app/Models/Backup.php
@@ -105,8 +105,8 @@ class Backup extends Model
      */
     public function audits()
     {
-        return $this->hasMany(AuditLog::class, 'metadata->backup_uuid', 'uuid')
+        return $this->hasMany(AuditLog::class, 'metadata->backup_name', 'name')
             ->where('action', 'LIKE', 'server:backup.%');
-        // ->where('metadata->backup_uuid', $this->uuid);
+        // ->where('metadata->backup_name', $this->name);
     }
 }

--- a/app/Models/Backup.php
+++ b/app/Models/Backup.php
@@ -105,8 +105,8 @@ class Backup extends Model
      */
     public function audits()
     {
-        return $this->hasMany(AuditLog::class, 'metadata->backup_name', 'name')
+        return $this->hasMany(AuditLog::class, 'metadata->backup_uuid', 'uuid')
             ->where('action', 'LIKE', 'server:backup.%');
-        // ->where('metadata->backup_name', $this->name);
+        // ->where('metadata->backup_uuid', $this->uuid);
     }
 }

--- a/database/migrations/2022_01_06_065926_update_old_auditlogs_to_new_auditlogs.php
+++ b/database/migrations/2022_01_06_065926_update_old_auditlogs_to_new_auditlogs.php
@@ -28,7 +28,7 @@ class UpdateOldAuditlogsToNewAuditlogs extends Migration
         foreach ($logs as $record) {
             $record_metadata = json_decode($record->metadata);
             $backup = DB::table('backups')->where('uuid', '=', $record_metadata->backup_uuid)->first();
-            $record_metadata = ['backup_name' => $backup->name];
+            $record_metadata = ['backup_uuid' => $backup->uuid, 'backup_name' => $backup->name];
             DB::table('audit_logs')->where('id', '=', $record->id)->update(['metadata' => $record_metadata]);
 
             if($record->action == "server:backup.started"){
@@ -77,13 +77,7 @@ class UpdateOldAuditlogsToNewAuditlogs extends Migration
 
         foreach ($logs as $record) {
             $record_metadata = json_decode($record->metadata);
-            $backup = DB::table('backups')
-            ->where([
-                ['name', '=', $record_metadata->backup_name],
-                ['server_id', '=', $record->server_id]
-            ])
-            ->first();
-            $record_metadata = ['backup_uuid' => $backup->uuid];
+            $record_metadata = ['backup_uuid' => $record_metadata->backup_uuid];
             DB::table('audit_logs')->where('id', '=', $record->id)->update(['metadata' => $record_metadata]);
 
             if($record->action == "server:backup.start"){

--- a/database/migrations/2022_01_06_065926_update_old_auditlogs_to_new_auditlogs.php
+++ b/database/migrations/2022_01_06_065926_update_old_auditlogs_to_new_auditlogs.php
@@ -1,0 +1,112 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateOldAuditlogsToNewAuditlogs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $logs = DB::table('audit_logs')
+        ->where('action', '=', 'server:backup.started')
+        ->orWhere('action', '=', 'server:backup.failed')
+        ->orWhere('action', '=', 'server:backup.completed')
+        ->orWhere('action', '=', 'server:backup.deleted')
+        ->orWhere('action', '=', 'server:backup.downloaded')
+        ->orWhere('action', '=', 'server:backup.locked')
+        ->orWhere('action', '=', 'server:backup.unlocked')
+        ->orWhere('action', '=', 'server:backup.restore.started')
+        ->orWhere('action', '=', 'server:backup.restore.completed')
+        ->orWhere('action', '=', 'server:backup.restore.failed')
+        ->get();
+
+        foreach ($logs as $record) {
+            $record_metadata = json_decode($record->metadata);
+            $backup = DB::table('backups')->where('uuid', '=', $record_metadata->backup_uuid)->first();
+            $record_metadata = ['backup_name' => $backup->name];
+            DB::table('audit_logs')->where('id', '=', $record->id)->update(['metadata' => $record_metadata]);
+
+            if($record->action == "server:backup.started"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.start"]);
+            }else if($record->action == "server:backup.failed"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.fail"]);
+            }else if($record->action == "server:backup.completed"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.complete"]);
+            }else if($record->action == "server:backup.deleted"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.delete"]);
+            }else if($record->action == "server:backup.downloaded"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.download"]);
+            }else if($record->action == "server:backup.locked"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.lock"]);
+            }else if($record->action == "server:backup.unlocked"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.unlock"]);
+            }else if($record->action == "server:backup.restore.started"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.restore.start"]);
+            }else if($record->action == "server:backup.restore.completed"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.restore.complete"]);
+            }else if($record->action == "server:backup.restore.failed"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.restore.fail"]);
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $logs = DB::table('audit_logs')
+        ->where('action', '=', 'server:backup.start')
+        ->orWhere('action', '=', 'server:backup.fail')
+        ->orWhere('action', '=', 'server:backup.complete')
+        ->orWhere('action', '=', 'server:backup.delete')
+        ->orWhere('action', '=', 'server:backup.download')
+        ->orWhere('action', '=', 'server:backup.lock')
+        ->orWhere('action', '=', 'server:backup.unlock')
+        ->orWhere('action', '=', 'server:backup.restore.start')
+        ->orWhere('action', '=', 'server:backup.restore.complete')
+        ->orWhere('action', '=', 'server:backup.restore.fail')
+        ->get();
+
+        foreach ($logs as $record) {
+            $record_metadata = json_decode($record->metadata);
+            $backup = DB::table('backups')
+            ->where([
+                ['name', '=', $record_metadata->backup_name],
+                ['server_id', '=', $record->server_id]
+            ])
+            ->first();
+            $record_metadata = ['backup_uuid' => $backup->uuid];
+            DB::table('audit_logs')->where('id', '=', $record->id)->update(['metadata' => $record_metadata]);
+
+            if($record->action == "server:backup.start"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.started"]);
+            }else if($record->action == "server:backup.fail"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.failed"]);
+            }else if($record->action == "server:backup.complete"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.completed"]);
+            }else if($record->action == "server:backup.delete"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.deleted"]);
+            }else if($record->action == "server:backup.download"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.downloaded"]);
+            }else if($record->action == "server:backup.lock"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.locked"]);
+            }else if($record->action == "server:backup.unlock"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.unlocked"]);
+            }else if($record->action == "server:backup.restore.start"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.restore.started"]);
+            }else if($record->action == "server:backup.restore.complete"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.restore.completed"]);
+            }else if($record->action == "server:backup.restore.fail"){
+                DB::table('audit_logs')->where('id', '=', $record->id)->update(['action' => "server:backup.restore.failed"]);
+            }
+        }
+    }
+}

--- a/tests/Integration/Api/Client/Server/Backup/DeleteBackupTest.php
+++ b/tests/Integration/Api/Client/Server/Backup/DeleteBackupTest.php
@@ -55,7 +55,7 @@ class DeleteBackupTest extends ClientApiIntegrationTestCase
 
         $this->actingAs($user)->deleteJson($this->link($backup))->assertStatus(Response::HTTP_NOT_FOUND);
 
-        $event = $backup->audits()->where('action', AuditLog::SERVER__BACKUP_DELETED)->latest()->first();
+        $event = $backup->audits()->where('action', AuditLog::SERVER__BACKUP_DELETE)->latest()->first();
 
         $this->assertNotNull($event);
         $this->assertFalse($event->is_system);


### PR DESCRIPTION
I added new logging types to cover almost all server actions.
I changed the way the old logging worked by migrating the backup uuid to backup name so the user UI can be constructed with more ease, without having to execute hundreds or possibly thousands of databases query's. With this comes a nice, completely functional, database migration file.