### PR TITLE
node: lowercase fqdn in letsencrypt path

### DIFF
--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -2,6 +2,7 @@
 
 namespace Pterodactyl\Models;
 
+use Illuminate\Support\Str;
 use Symfony\Component\Yaml\Yaml;
 use Illuminate\Container\Container;
 use Illuminate\Notifications\Notifiable;
@@ -155,8 +156,8 @@ class Node extends Model
                 'port' => $this->daemonListen,
                 'ssl' => [
                     'enabled' => (!$this->behind_proxy && $this->scheme === 'https'),
-                    'cert' => '/etc/letsencrypt/live/' . $this->fqdn . '/fullchain.pem',
-                    'key' => '/etc/letsencrypt/live/' . $this->fqdn . '/privkey.pem',
+                    'cert' => '/etc/letsencrypt/live/' . Str::lower($this->fqdn) . '/fullchain.pem',
+                    'key' => '/etc/letsencrypt/live/' . Str::lower($this->fqdn) . '/privkey.pem',
                 ],
                 'upload_limit' => $this->upload_size,
             ],


### PR DESCRIPTION
LetsEncrypt generates the directory name as lowercase which becomes problematic when someone uses capitals in their FQDN, a change was added to wings to lowercase the SSL path but that affects all paths when the problem is only when using LetsEncrypt.  This PR adds the lowercase conversion to the config on the Panel so if <https://github.com/pterodactyl/wings/pull/114> is merged, people creating new nodes with capitalized FQDNs don't run into this issue.