### PR TITLE
fix: lowercase pid modal error array element

### DIFF
--- a/resources/scripts/components/server/features/PIDLimitModalFeature.tsx
+++ b/resources/scripts/components/server/features/PIDLimitModalFeature.tsx
@@ -24,7 +24,7 @@ const PIDLimitModalFeature = () => {
 
         const errors = [
             'pthread_create failed',
-            'Exception in thread "Craft Async Scheduler Management Thread"',
+            'exception in thread "craft async scheduler management thread"',
             'unable to create new native thread',
             'unable to create native thread',
         ];


### PR DESCRIPTION
The listener converts lines to lowercase, while the array elements could be uppercase, such as in this case.

We could lowercase the elements too `includes(p.toLowerCase())))` for future-proofing, but this should fix it for now. This affects all existing egg features, but their array elements are already in lowercase.