### PR TITLE
Fix Old Tailwind Breakpoints

### DIFF
--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -38,17 +38,17 @@ export default () => {
             }
 
             <Container css={[tw`lg:grid lg:grid-cols-3 mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
-                <ContentBox title={'Update Password'} showFlashes={'account:password'}>
+                <ContentBox css={tw`md:w-full`} title={'Update Password'} showFlashes={'account:password'}>
                     <UpdatePasswordForm />
                 </ContentBox>
                 <ContentBox
-                    css={tw`mt-8 md:mt-0 md:ml-8`}
+                    css={tw`mt-8 md:mt-0 md:ml-8 md:w-full`}
                     title={'Update Email Address'}
                     showFlashes={'account:email'}
                 >
                     <UpdateEmailAddressForm />
                 </ContentBox>
-                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
+                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0 md:w-full`} title={'Configure Two Factor'}>
                     <ConfigureTwoFactorForm />
                 </ContentBox>
             </Container>

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -38,17 +38,17 @@ export default () => {
             }
 
             <Container css={[tw`lg:grid lg:grid-cols-3 mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
-                <ContentBox css={tw`md:w-fit`} title={'Update Password'} showFlashes={'account:password'}>
+                <ContentBox css={tw`md:w-max`} title={'Update Password'} showFlashes={'account:password'}>
                     <UpdatePasswordForm />
                 </ContentBox>
                 <ContentBox
-                    css={tw`mt-8 md:mt-0 md:ml-8 md:w-fit`}
+                    css={tw`mt-8 md:mt-0 md:ml-8 md:w-max`}
                     title={'Update Email Address'}
                     showFlashes={'account:email'}
                 >
                     <UpdateEmailAddressForm />
                 </ContentBox>
-                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0 md:w-fit`} title={'Configure Two Factor'}>
+                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0 md:w-max`} title={'Configure Two Factor'}>
                     <ConfigureTwoFactorForm />
                 </ContentBox>
             </Container>

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -16,7 +16,7 @@ const Container = styled.div`
     & > div {
         ${tw`w-full`};
 
-        ${breakpoint('sm')`
+        ${breakpoint('md')`
             width: calc(50% - 1rem);
         `}
 
@@ -38,17 +38,17 @@ export default () => {
             }
 
             <Container css={[tw`lg:grid lg:grid-cols-3 mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
-                <ContentBox css={tw`md:w-max`} title={'Update Password'} showFlashes={'account:password'}>
+                <ContentBox title={'Update Password'} showFlashes={'account:password'}>
                     <UpdatePasswordForm />
                 </ContentBox>
                 <ContentBox
-                    css={tw`mt-8 md:mt-0 md:ml-8 md:w-max`}
+                    css={tw`mt-8 md:mt-0 md:ml-8`}
                     title={'Update Email Address'}
                     showFlashes={'account:email'}
                 >
                     <UpdateEmailAddressForm />
                 </ContentBox>
-                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0 md:w-max`} title={'Configure Two Factor'}>
+                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
                     <ConfigureTwoFactorForm />
                 </ContentBox>
             </Container>

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -16,6 +16,10 @@ const Container = styled.div`
     & > div {
         ${tw`w-full`};
 
+        ${breakpoint('md')`
+            width: calc(50% - 1rem);
+        `}
+
         ${breakpoint('xl')`
             ${tw`w-auto flex-1`};
         `}

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -36,23 +36,23 @@ export default () => {
                     Your account must have two-factor authentication enabled in order to continue.
                 </MessageBox>
             }
-            <div css={tw`lg:grid lg:grid-rows-3`}>
-                <Container css={[tw`mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
-                    <ContentBox title={'Update Password'} showFlashes={'account:password'}>
-                        <UpdatePasswordForm />
-                    </ContentBox>
-                    <ContentBox
-                        css={tw`mt-8 md:mt-0 md:ml-8`}
-                        title={'Update Email Address'}
-                        showFlashes={'account:email'}
-                    >
-                        <UpdateEmailAddressForm />
-                    </ContentBox>
-                    <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
-                        <ConfigureTwoFactorForm />
-                    </ContentBox>
-                </Container>
-            </div>
+
+            <Container css={[tw`lg:grid lg:grid-rows-3 mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
+                <ContentBox title={'Update Password'} showFlashes={'account:password'}>
+                    <UpdatePasswordForm />
+                </ContentBox>
+                <ContentBox
+                    css={tw`mt-8 md:mt-0 md:ml-8`}
+                    title={'Update Email Address'}
+                    showFlashes={'account:email'}
+                >
+                    <UpdateEmailAddressForm />
+                </ContentBox>
+                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
+                    <ConfigureTwoFactorForm />
+                </ContentBox>
+            </Container>
+
 
         </PageContentBlock>
     );

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -11,19 +11,19 @@ import MessageBox from '@/components/MessageBox';
 import { useLocation } from 'react-router-dom';
 
 const Container = styled.div`
-    ${tw`flex flex-wrap`};
+  ${tw`flex flex-wrap`};
 
-    & > div {
-        ${tw`w-full`};
+  & > div {
+    ${tw`w-full`};
 
-        ${breakpoint('sm')`
-            width: calc(50% - 1rem);
-        `}
+    ${breakpoint('sm')`
+      width: calc(50% - 1rem);
+    `}
 
-        ${breakpoint('md')`
-            ${tw`w-auto flex-1`};
-        `}
-    }
+    ${breakpoint('md')`
+      ${tw`w-auto flex-1`};
+    `}
+  }
 `;
 
 export default () => {
@@ -32,27 +32,26 @@ export default () => {
     return (
         <PageContentBlock title={'Account Overview'}>
             {state?.twoFactorRedirect &&
-                <MessageBox title={'2-Factor Required'} type={'error'}>
-                    Your account must have two-factor authentication enabled in order to continue.
-                </MessageBox>
+            <MessageBox title={'2-Factor Required'} type={'error'}>
+                Your account must have two-factor authentication enabled in order to continue.
+            </MessageBox>
             }
 
-            <Container css={[tw`lg:grid lg:grid-cols-3 mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
+            <Container css={[ tw`lg:grid lg:grid-cols-3 mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10` ]}>
                 <ContentBox title={'Update Password'} showFlashes={'account:password'}>
-                    <UpdatePasswordForm />
+                    <UpdatePasswordForm/>
                 </ContentBox>
                 <ContentBox
                     css={tw`mt-8 sm:mt-0 sm:ml-8`}
                     title={'Update Email Address'}
                     showFlashes={'account:email'}
                 >
-                    <UpdateEmailAddressForm />
+                    <UpdateEmailAddressForm/>
                 </ContentBox>
                 <ContentBox css={tw`md:ml-8 mt-8 md:mt-0`} title={'Configure Two Factor'}>
-                    <ConfigureTwoFactorForm />
+                    <ConfigureTwoFactorForm/>
                 </ContentBox>
             </Container>
-
 
         </PageContentBlock>
     );

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -20,7 +20,7 @@ const Container = styled.div`
             width: calc(50% - 1rem);
         `}
 
-        ${breakpoint('xl')`
+        ${breakpoint('md')`
             ${tw`w-auto flex-1`};
         `}
     }

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -32,25 +32,28 @@ export default () => {
     return (
         <PageContentBlock title={'Account Overview'}>
             {state?.twoFactorRedirect &&
-            <MessageBox title={'2-Factor Required'} type={'error'}>
-                Your account must have two-factor authentication enabled in order to continue.
-            </MessageBox>
+                <MessageBox title={'2-Factor Required'} type={'error'}>
+                    Your account must have two-factor authentication enabled in order to continue.
+                </MessageBox>
             }
-            <Container css={[ tw`lg:inline mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10` ]}>
-                <ContentBox title={'Update Password'} showFlashes={'account:password'}>
-                    <UpdatePasswordForm/>
-                </ContentBox>
-                <ContentBox
-                    css={tw`lg:inline mt-8 md:mt-0 md:ml-8`}
-                    title={'Update Email Address'}
-                    showFlashes={'account:email'}
-                >
-                    <UpdateEmailAddressForm/>
-                </ContentBox>
-                <ContentBox css={tw`lg:inline lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
-                    <ConfigureTwoFactorForm/>
-                </ContentBox>
-            </Container>
+            <div css={tw`lg:grid lg:grid-cols-3`}>
+                <Container css={[tw`mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
+                    <ContentBox title={'Update Password'} showFlashes={'account:password'}>
+                        <UpdatePasswordForm />
+                    </ContentBox>
+                    <ContentBox
+                        css={tw`mt-8 md:mt-0 md:ml-8`}
+                        title={'Update Email Address'}
+                        showFlashes={'account:email'}
+                    >
+                        <UpdateEmailAddressForm />
+                    </ContentBox>
+                    <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
+                        <ConfigureTwoFactorForm />
+                    </ContentBox>
+                </Container>
+            </div>
+
         </PageContentBlock>
     );
 };

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -42,7 +42,7 @@ export default () => {
                     <UpdatePasswordForm />
                 </ContentBox>
                 <ContentBox
-                    css={tw`mt-8 md:mt-0 md:ml-8`}
+                    css={tw`mt-8 sm:mt-0 sm:ml-8`}
                     title={'Update Email Address'}
                     showFlashes={'account:email'}
                 >

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -48,7 +48,7 @@ export default () => {
                 >
                     <UpdateEmailAddressForm />
                 </ContentBox>
-                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
+                <ContentBox css={tw`md:ml-8 mt-8 md:mt-0`} title={'Configure Two Factor'}>
                     <ConfigureTwoFactorForm />
                 </ContentBox>
             </Container>

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -36,18 +36,18 @@ export default () => {
                 Your account must have two-factor authentication enabled in order to continue.
             </MessageBox>
             }
-            <Container css={[ tw`mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10` ]}>
+            <Container css={[ tw`lg:inline-block mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10` ]}>
                 <ContentBox title={'Update Password'} showFlashes={'account:password'}>
                     <UpdatePasswordForm/>
                 </ContentBox>
                 <ContentBox
-                    css={tw`mt-8 md:mt-0 md:ml-8`}
+                    css={tw`lg:inline-block mt-8 md:mt-0 md:ml-8`}
                     title={'Update Email Address'}
                     showFlashes={'account:email'}
                 >
                     <UpdateEmailAddressForm/>
                 </ContentBox>
-                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
+                <ContentBox css={tw`lg:inline-block lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
                     <ConfigureTwoFactorForm/>
                 </ContentBox>
             </Container>

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -38,17 +38,17 @@ export default () => {
             }
 
             <Container css={[tw`lg:grid lg:grid-cols-3 mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
-                <ContentBox css={tw`md:w-full`} title={'Update Password'} showFlashes={'account:password'}>
+                <ContentBox css={tw`md:w-fit`} title={'Update Password'} showFlashes={'account:password'}>
                     <UpdatePasswordForm />
                 </ContentBox>
                 <ContentBox
-                    css={tw`mt-8 md:mt-0 md:ml-8 md:w-full`}
+                    css={tw`mt-8 md:mt-0 md:ml-8 md:w-fit`}
                     title={'Update Email Address'}
                     showFlashes={'account:email'}
                 >
                     <UpdateEmailAddressForm />
                 </ContentBox>
-                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0 md:w-full`} title={'Configure Two Factor'}>
+                <ContentBox css={tw`lg:ml-8 mt-8 lg:mt-0 md:w-fit`} title={'Configure Two Factor'}>
                     <ConfigureTwoFactorForm />
                 </ContentBox>
             </Container>

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -36,18 +36,18 @@ export default () => {
                 Your account must have two-factor authentication enabled in order to continue.
             </MessageBox>
             }
-            <Container css={[ tw`lg:inline-block mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10` ]}>
+            <Container css={[ tw`lg:inline mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10` ]}>
                 <ContentBox title={'Update Password'} showFlashes={'account:password'}>
                     <UpdatePasswordForm/>
                 </ContentBox>
                 <ContentBox
-                    css={tw`lg:inline-block mt-8 md:mt-0 md:ml-8`}
+                    css={tw`lg:inline mt-8 md:mt-0 md:ml-8`}
                     title={'Update Email Address'}
                     showFlashes={'account:email'}
                 >
                     <UpdateEmailAddressForm/>
                 </ContentBox>
-                <ContentBox css={tw`lg:inline-block lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
+                <ContentBox css={tw`lg:inline lg:ml-8 mt-8 lg:mt-0`} title={'Configure Two Factor'}>
                     <ConfigureTwoFactorForm/>
                 </ContentBox>
             </Container>

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -16,10 +16,6 @@ const Container = styled.div`
     & > div {
         ${tw`w-full`};
 
-        ${breakpoint('md')`
-            width: calc(50% - 1rem);
-        `}
-
         ${breakpoint('xl')`
             ${tw`w-auto flex-1`};
         `}

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -16,7 +16,7 @@ const Container = styled.div`
     & > div {
         ${tw`w-full`};
 
-        ${breakpoint('md')`
+        ${breakpoint('sm')`
             width: calc(50% - 1rem);
         `}
 

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -37,7 +37,7 @@ export default () => {
                 </MessageBox>
             }
 
-            <Container css={[tw`lg:grid lg:grid-rows-3 mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
+            <Container css={[tw`lg:grid lg:grid-cols-3 mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
                 <ContentBox title={'Update Password'} showFlashes={'account:password'}>
                     <UpdatePasswordForm />
                 </ContentBox>

--- a/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
+++ b/resources/scripts/components/dashboard/AccountOverviewContainer.tsx
@@ -36,7 +36,7 @@ export default () => {
                     Your account must have two-factor authentication enabled in order to continue.
                 </MessageBox>
             }
-            <div css={tw`lg:grid lg:grid-cols-3`}>
+            <div css={tw`lg:grid lg:grid-rows-3`}>
                 <Container css={[tw`mb-10`, state?.twoFactorRedirect ? tw`mt-4` : tw`mt-10`]}>
                     <ContentBox title={'Update Password'} showFlashes={'account:password'}>
                         <UpdatePasswordForm />

--- a/resources/scripts/theme.ts
+++ b/resources/scripts/theme.ts
@@ -3,8 +3,8 @@ import { BreakpointFunction, createBreakpoint } from 'styled-components-breakpoi
 type Breakpoints = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export const breakpoint: BreakpointFunction<Breakpoints> = createBreakpoint<Breakpoints>({
     xs: 0,
-    sm: 576,
+    sm: 640,
     md: 768,
-    lg: 992,
-    xl: 1200,
+    lg: 1024,
+    xl: 1280,
 });


### PR DESCRIPTION
The main issue in https://github.com/pterodactyl/panel/issues/3913 results from old Tailwind breakpoints in https://github.com/pterodactyl/panel/blob/develop/resources/scripts/theme.ts#L4
```ts
export const breakpoint: BreakpointFunction<Breakpoints> = createBreakpoint<Breakpoints>({
    xs: 0,
    sm: 576,
    md: 768,
    lg: 992,
    xl: 1200,
});
```
This PR replaces these with 
```ts
export const breakpoint: BreakpointFunction<Breakpoints> = createBreakpoint<Breakpoints>({
    xs: 0,
    sm: 640,
    md: 768,
    lg: 1024,
    xl: 1280,
});
```
The PR also fixes some margin breaks that are happening early or late.
this closes https://github.com/pterodactyl/panel/issues/3913