### PR TITLE
ref: set redis as default option for env drivers setup

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -14,7 +14,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_DRIVER', 'file'),
+    'default' => env('CACHE_DRIVER', 'redis'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/queue.php
+++ b/config/queue.php
@@ -14,7 +14,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', env('QUEUE_DRIVER', 'database')),
+    'default' => env('QUEUE_CONNECTION', env('QUEUE_DRIVER', 'redis')),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/session.php
+++ b/config/session.php
@@ -14,7 +14,7 @@ return [
     |
     */
 
-    'driver' => env('SESSION_DRIVER', 'database'),
+    'driver' => env('SESSION_DRIVER', 'redis'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Redis is the recommended value, yet the default options are different, e.g. cache being file. This makes it consistent with what's recommended.

Current default suggested values:
![image](https://user-images.githubusercontent.com/10975908/151022830-5ffc650b-f95b-48c8-873b-471a5d3b9e1e.png)
