### PR TITLE
Go to configuration page instead of allocations after creating a node

### DIFF
--- a/app/Http/Controllers/Admin/NodesController.php
+++ b/app/Http/Controllers/Admin/NodesController.php
@@ -152,7 +152,7 @@ class NodesController extends Controller
         $node = $this->creationService->handle($request->normalize());
         $this->alert->info(trans('admin/node.notices.node_created'))->flash();
 
-        return redirect()->route('admin.nodes.view.allocation', $node->id);
+        return redirect()->route('admin.nodes.view.configuration', $node->id);
     }
 
     /**


### PR DESCRIPTION
When a node is created, you get redirected to the allocations page, but the next thing to do is get the configuration from the configuration tab. This pull request changes it so instead of the allocations page it goes to the configuration page.