### PR TITLE
Auto Mounts Feature

### DIFF
--- a/app/Listeners/RemoveMountsAfterInstall.php
+++ b/app/Listeners/RemoveMountsAfterInstall.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Pterodactyl\Listeners;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Pterodactyl\Models\Mount;
+use Pterodactyl\Models\MountServer;
+
+class RemoveMountsAfterInstall
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        $mounts = Mount::where('mount_on_install', '=', true)->get();
+        foreach ($mounts as $mount) {
+            MountServer::where('mount_id', $mount->id)->where('server_id', $event->server->id)->delete();
+        }
+    }
+}

--- a/app/Listeners/RemoveMountsAfterInstall.php
+++ b/app/Listeners/RemoveMountsAfterInstall.php
@@ -2,23 +2,11 @@
 
 namespace Pterodactyl\Listeners;
 
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
 use Pterodactyl\Models\Mount;
 use Pterodactyl\Models\MountServer;
 
 class RemoveMountsAfterInstall
 {
-    /**
-     * Create the event listener.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
     /**
      * Handle the event.
      *

--- a/app/Models/Mount.php
+++ b/app/Models/Mount.php
@@ -48,6 +48,8 @@ class Mount extends Model
         'id' => 'int',
         'read_only' => 'bool',
         'user_mountable' => 'bool',
+        'mount_on_install' => 'bool',
+        'auto_mount' => 'bool',
     ];
 
     /**
@@ -62,6 +64,8 @@ class Mount extends Model
         'target' => 'required|string',
         'read_only' => 'sometimes|boolean',
         'user_mountable' => 'sometimes|boolean',
+        'mount_on_install' => 'sometimes|boolean',
+        'auto_mount' => 'sometimes|boolean',
     ];
 
     /**
@@ -103,6 +107,8 @@ class Mount extends Model
      */
     public static $invalidTargetPaths = [
         '/home/container',
+        '/mnt/server',
+        '/mnt/install',
     ];
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -16,6 +16,7 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         ServerInstalledEvent::class => [
             ServerInstalledNotification::class,
+            RemoveMountsAfterInstall::class,
         ],
     ];
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Pterodactyl\Providers;
 
 use Pterodactyl\Events\Server\Installed as ServerInstalledEvent;
+use Pterodactyl\Listeners\RemoveMountsAfterInstall;
 use Pterodactyl\Notifications\ServerInstalled as ServerInstalledNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 

--- a/app/Services/Servers/ServerCreationService.php
+++ b/app/Services/Servers/ServerCreationService.php
@@ -156,7 +156,7 @@ class ServerCreationService
             // Create the server and assign any additional allocations to it.
             $server = $this->createModel($data);
 
-            $this->storeMounts($server);
+            $this->storeActiveMounts($server);
             $this->storeAssignedAllocations($server, $data);
             $this->storeEggVariables($server, $eggVariableData);
 

--- a/database/migrations/2022_04_03_151827_add_auto_mount_to_mounts_table.php
+++ b/database/migrations/2022_04_03_151827_add_auto_mount_to_mounts_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAutoMountToMountsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mounts', function (Blueprint $table) {
+            $table->boolean("mount_on_install")->after("user_mountable")->default(false);
+            $table->boolean("auto_mount")->after("mount_on_install")->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mounts', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/resources/views/admin/mounts/view.blade.php
+++ b/resources/views/admin/mounts/view.blade.php
@@ -89,6 +89,40 @@
                                 </div>
                             </div>
                         </div>
+
+                        <div class="row">
+                            <div class="form-group col-md-6">
+                                <label class="form-label">Mount on Install</label>
+
+                                <div>
+                                    <div class="radio radio-success radio-inline">
+                                        <input type="radio" id="pMountOnInstallFalse" name="mount_on_install" value="0" @if(!$mount->mount_on_install) checked @endif>
+                                        <label for="pMountOnInstallFalse">False</label>
+                                    </div>
+
+                                    <div class="radio radio-warning radio-inline">
+                                        <input type="radio" id="pMountOnInstall" name="mount_on_install" value="1" @if($mount->mount_on_install) checked @endif>
+                                        <label for="pMountOnInstall">True</label>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-group col-md-6">
+                                <label class="form-label">Auto Mount</label>
+
+                                <div>
+                                    <div class="radio radio-success radio-inline">
+                                        <input type="radio" id="pAutoMountFalse" name="auto_mount" value="0" @if(!$mount->auto_mount) checked @endif>
+                                        <label for="pAutoMountFalse">False</label>
+                                    </div>
+
+                                    <div class="radio radio-warning radio-inline">
+                                        <input type="radio" id="pAutoMount" name="auto_mount" value="1" @if($mount->auto_mount) checked @endif>
+                                        <label for="pAutoMount">True</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="box-footer">


### PR DESCRIPTION
This PR adds mounts to the installation script on Panel.
People will be able to activate the option from mounts page.
This feature enable people with low bandwidth to create a mount where will contain all the binaries required
for server installation. The feature will save time on installation & network bandwidth.
Right now the database has two new boolean values (mount_on_install, auto_mount).
The mount for installation script is deleted after server installation event.
Auto mount boolean column should be used to auto mount on server creation and remain available until the server is deleted.