### PR TITLE
Fix grammatical error

### DIFF
--- a/database/Seeders/eggs/source-engine/egg-garrys-mod.json
+++ b/database/Seeders/eggs/source-engine/egg-garrys-mod.json
@@ -87,7 +87,7 @@
         },
         {
             "name": "Tickrate",
-            "description": "The tickrate defines how fast the server will update each entities location.",
+            "description": "The tickrate defines how fast the server will update each entity's location.",
             "env_variable": "TICKRATE",
             "default_value": "22",
             "user_viewable": true,

--- a/database/Seeders/eggs/source-engine/egg-garrys-mod.json
+++ b/database/Seeders/eggs/source-engine/egg-garrys-mod.json
@@ -87,7 +87,7 @@
         },
         {
             "name": "Tickrate",
-            "description": "The tickrate defines how fast the server will update each entity\'s location.",
+            "description": "The tickrate defines how fast the server will update each entity's location.",
             "env_variable": "TICKRATE",
             "default_value": "22",
             "user_viewable": true,

--- a/database/Seeders/eggs/source-engine/egg-garrys-mod.json
+++ b/database/Seeders/eggs/source-engine/egg-garrys-mod.json
@@ -87,7 +87,7 @@
         },
         {
             "name": "Tickrate",
-            "description": "The tickrate defines how fast the server will update each entity's location.",
+            "description": "The tickrate defines how fast the server will update each entity\'s location.",
             "env_variable": "TICKRATE",
             "default_value": "22",
             "user_viewable": true,


### PR DESCRIPTION
Changed "... each entities location" to "... each entity's location"; the statement is intended to convey that each entity has a location, so the possessive form should be used.