### PR TITLE
Fix: Max Ram usage showing wrong while hovering over Memory

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -9,7 +9,7 @@ return [
     | change this value if you are not maintaining your own internal versions.
     */
 
-    'version' => 'canary',
+    'version' => '1.9.0',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The multiplyer for the calculation from MB to GB is wrong. The Panel Calculates 1GB = 1000MB and Not 1GB = 1024MB.
If i set the Max Ram usage to 24.000MB the Panel shows Max 24GB but if i set it to 24.576MB the Panel shows 24,57GB as max.

![Ptero Bug](https://user-images.githubusercontent.com/76449174/175933684-8776458b-b385-47da-afa2-b789123e463d.png)
![Ptero Bug2](https://user-images.githubusercontent.com/76449174/175933688-d19480fc-eaf2-4910-9ac1-a1f573cb2d3e.png)

