### PR TITLE
Enable standards mode in React app

### DIFF
--- a/resources/views/templates/wrapper.blade.php
+++ b/resources/views/templates/wrapper.blade.php
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <title>{{ config('app.name', 'Pterodactyl') }}</title>


### PR DESCRIPTION
Adds `<!DOCTYPE html>` to the template that renders the React app to enable the standards mode (quirks mode makes a warning in the console):
https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode
This doesn't seem to change the layout in any way.