### PR TITLE
Delete backups on server deletion

### DIFF
--- a/app/Jobs/Backup/DeleteBackupJob.php
+++ b/app/Jobs/Backup/DeleteBackupJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pterodactyl\Jobs\Backup;
+
+use Pterodactyl\Jobs\Job;
+use Pterodactyl\Models\Backup;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Pterodactyl\Services\Backups\DeleteBackupService;
+
+class DeleteBackupJob extends Job implements ShouldQueue
+{
+    use DispatchesJobs;
+    use InteractsWithQueue;
+    use SerializesModels;
+
+    /**
+     * @var \Pterodactyl\Models\Backup
+     */
+    public Backup $backup;
+
+    /**
+     * DeleteBackupJob constructor.
+     */
+    public function __construct(Backup $backup)
+    {
+        $this->queue = config('pterodactyl.queues.standard');
+        $this->backup = $backup;
+    }
+
+    /**
+     * Delete the backup.
+     *
+     * @throws \Throwable
+     */
+    public function handle(DeleteBackupService $deleteBackupService)
+    {
+        $deleteBackupService->handle($this->backup);
+    }
+}

--- a/app/Jobs/Server/DeleteServerJob.php
+++ b/app/Jobs/Server/DeleteServerJob.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Pterodactyl\Jobs\Server;
+
+use Pterodactyl\Jobs\Job;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Pterodactyl\Models\Server;
+use Pterodactyl\Repositories\Wings\DaemonServerRepository;
+
+class DeleteServerJob extends Job implements ShouldQueue
+{
+    use DispatchesJobs;
+    use InteractsWithQueue;
+    use SerializesModels;
+
+    /**
+     * @var \Pterodactyl\Models\Server
+     */
+    public Server $server;
+
+    /**
+     * DeleteServerJob constructor.
+     */
+    public function __construct(Server $server)
+    {
+        $this->queue = config('pterodactyl.queues.standard');
+        $this->server = $server;
+    }
+
+    /**
+     * Delete the server.
+     *
+     * @throws \Throwable
+     */
+    public function handle(DaemonServerRepository $daemonServerRepository)
+    {
+        $daemonServerRepository->setServer($this->server)->delete();
+        $this->server->delete();
+    }
+}

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -111,6 +111,7 @@ class Server extends Model
     public const STATUS_INSTALL_FAILED = 'install_failed';
     public const STATUS_SUSPENDED = 'suspended';
     public const STATUS_RESTORING_BACKUP = 'restoring_backup';
+    public const STATUS_DELETING = 'deleting';
 
     /**
      * The table associated with the model.
@@ -220,6 +221,11 @@ class Server extends Model
     public function isSuspended(): bool
     {
         return $this->status === self::STATUS_SUSPENDED;
+    }
+
+    public function isDeleting(): bool
+    {
+        return $this->status === self::STATUS_DELETING;
     }
 
     /**

--- a/app/Services/Servers/ServerDeletionService.php
+++ b/app/Services/Servers/ServerDeletionService.php
@@ -117,7 +117,7 @@ class ServerDeletionService
                 $backup->update(['is_locked' => false]);
                 try {
                     $job = new DeleteBackupJob($backup);
-                    $this->dispatcher->dispatchNow($job);
+                    $this->dispatcher->dispatch($job);
                 } catch (Exception $exception) {
                     if (!$this->force) {
                         throw $exception;

--- a/resources/lang/en/admin/server.php
+++ b/resources/lang/en/admin/server.php
@@ -17,7 +17,7 @@ return [
     ],
     'alerts' => [
         'startup_changed' => 'The startup configuration for this server has been updated. If this server\'s nest or egg was changed a reinstall will be occurring now.',
-        'server_deleted' => 'Server has successfully been deleted from the system.',
+        'server_deleted' => 'This server has been queued for deletion beginning now.',
         'server_created' => 'Server was successfully created on the panel. Please allow the daemon a few minutes to completely install this server.',
         'build_updated' => 'The build details for this server have been updated. Some changes may require a restart to take effect.',
         'suspension_toggled' => 'Server suspension status has been changed to :status.',

--- a/resources/views/admin/servers/index.blade.php
+++ b/resources/views/admin/servers/index.blade.php
@@ -61,6 +61,8 @@
                                         <span class="label bg-maroon">Suspended</span>
                                     @elseif(! $server->isInstalled())
                                         <span class="label label-warning">Installing</span>
+                                    @elseif($server->isDeleting())
+                                        <span class="label label-danger">Deleting</span>
                                     @else
                                         <span class="label label-success">Active</span>
                                     @endif

--- a/resources/views/admin/servers/partials/navigation.blade.php
+++ b/resources/views/admin/servers/partials/navigation.blade.php
@@ -8,32 +8,34 @@
             <ul class="nav nav-tabs">
                 <li class="{{ $router->currentRouteNamed('admin.servers.view') ? 'active' : '' }}">
                     <a href="{{ route('admin.servers.view', $server->id) }}">About</a></li>
-                @if($server->isInstalled())
-                    <li class="{{ $router->currentRouteNamed('admin.servers.view.details') ? 'active' : '' }}">
-                        <a href="{{ route('admin.servers.view.details', $server->id) }}">Details</a>
+                @if(!$server->isDeleting())
+                    @if($server->isInstalled())
+                        <li class="{{ $router->currentRouteNamed('admin.servers.view.details') ? 'active' : '' }}">
+                            <a href="{{ route('admin.servers.view.details', $server->id) }}">Details</a>
+                        </li>
+                        <li class="{{ $router->currentRouteNamed('admin.servers.view.build') ? 'active' : '' }}">
+                            <a href="{{ route('admin.servers.view.build', $server->id) }}">Build Configuration</a>
+                        </li>
+                        <li class="{{ $router->currentRouteNamed('admin.servers.view.startup') ? 'active' : '' }}">
+                            <a href="{{ route('admin.servers.view.startup', $server->id) }}">Startup</a>
+                        </li>
+                        <li class="{{ $router->currentRouteNamed('admin.servers.view.database') ? 'active' : '' }}">
+                            <a href="{{ route('admin.servers.view.database', $server->id) }}">Database</a>
+                        </li>
+                        <li class="{{ $router->currentRouteNamed('admin.servers.view.mounts') ? 'active' : '' }}">
+                            <a href="{{ route('admin.servers.view.mounts', $server->id) }}">Mounts</a>
+                        </li>
+                    @endif
+                    <li class="{{ $router->currentRouteNamed('admin.servers.view.manage') ? 'active' : '' }}">
+                        <a href="{{ route('admin.servers.view.manage', $server->id) }}">Manage</a>
                     </li>
-                    <li class="{{ $router->currentRouteNamed('admin.servers.view.build') ? 'active' : '' }}">
-                        <a href="{{ route('admin.servers.view.build', $server->id) }}">Build Configuration</a>
+                    <li class="tab-danger {{ $router->currentRouteNamed('admin.servers.view.delete') ? 'active' : '' }}">
+                        <a href="{{ route('admin.servers.view.delete', $server->id) }}">Delete</a>
                     </li>
-                    <li class="{{ $router->currentRouteNamed('admin.servers.view.startup') ? 'active' : '' }}">
-                        <a href="{{ route('admin.servers.view.startup', $server->id) }}">Startup</a>
-                    </li>
-                    <li class="{{ $router->currentRouteNamed('admin.servers.view.database') ? 'active' : '' }}">
-                        <a href="{{ route('admin.servers.view.database', $server->id) }}">Database</a>
-                    </li>
-                    <li class="{{ $router->currentRouteNamed('admin.servers.view.mounts') ? 'active' : '' }}">
-                        <a href="{{ route('admin.servers.view.mounts', $server->id) }}">Mounts</a>
+                    <li class="tab-success">
+                        <a href="/server/{{ $server->uuidShort }}" target="_blank"><i class="fa fa-external-link"></i></a>
                     </li>
                 @endif
-                <li class="{{ $router->currentRouteNamed('admin.servers.view.manage') ? 'active' : '' }}">
-                    <a href="{{ route('admin.servers.view.manage', $server->id) }}">Manage</a>
-                </li>
-                <li class="tab-danger {{ $router->currentRouteNamed('admin.servers.view.delete') ? 'active' : '' }}">
-                    <a href="{{ route('admin.servers.view.delete', $server->id) }}">Delete</a>
-                </li>
-                <li class="tab-success">
-                    <a href="/server/{{ $server->uuidShort }}" target="_blank"><i class="fa fa-external-link"></i></a>
-                </li>
             </ul>
         </div>
     </div>

--- a/resources/views/admin/servers/view/index.blade.php
+++ b/resources/views/admin/servers/view/index.blade.php
@@ -142,6 +142,15 @@
                             </div>
                         </div>
                     @endif
+                        @if($server->isDeleting())
+                            <div class="col-sm-12">
+                                <div class="small-box bg-yellow">
+                                    <div class="inner">
+                                        <h3 class="no-margin">Deleting</h3>
+                                    </div>
+                                </div>
+                            </div>
+                        @endif
                     @if(!$server->isInstalled())
                         <div class="col-sm-12">
                             <div class="small-box {{ (! $server->isInstalled()) ? 'bg-blue' : 'bg-maroon' }}">

--- a/tests/Integration/Services/Servers/ServerDeletionServiceTest.php
+++ b/tests/Integration/Services/Servers/ServerDeletionServiceTest.php
@@ -121,7 +121,6 @@ class ServerDeletionServiceTest extends IntegrationTestCase
 
         $server->refresh();
 
-        $this->daemonServerRepository->expects('setServer->delete')->withNoArgs()->andReturnUndefined();
         $this->databaseManagementService->expects('delete')->with(Mockery::on(function ($value) use ($db) {
             return $value instanceof Database && $value->id === $db->id;
         }))->andThrows(new Exception());


### PR DESCRIPTION
Based on #3902, but deletion is handled via a job.

~Current problem is that wings doesn't delete the backups because the server doesn't exist anymore when the job runs. Probably a wings edit is needed? (a wings-sided job or something?) Ideas are welcome, as I'm clueless atm.~
Solved this by making the server deletion itself a job too.

This will close #2564.