### PR TITLE
Use correct default value for JavaVersionModal

### DIFF
--- a/resources/scripts/components/server/features/JavaVersionModalFeature.tsx
+++ b/resources/scripts/components/server/features/JavaVersionModalFeature.tsx
@@ -37,7 +37,7 @@ const JavaVersionModalFeature = () => {
         if (!visible) return;
 
         mutate().then((value) => {
-            setSelectedVersion(Object.keys(value?.dockerImages || [])[0] || '');
+            setSelectedVersion(Object.values(value?.dockerImages || [])[0] || '');
         });
     }, [visible]);
 


### PR DESCRIPTION
Just confirming the Java Version modal (without switching the image) currently throws the following error because the default value of the selected version is wrong:
![image](https://user-images.githubusercontent.com/8203120/176667396-800a6fff-1440-4867-9ef9-bd10997ad706.png)

The current default is the image's display name (`Java 17`) and not the actual image (`ghcr.io/pterodactyl/yolks:java_17`). This PR fixes that.