### PR TITLE
fixes loading overlay to console only

### DIFF
--- a/resources/scripts/components/server/console/Console.tsx
+++ b/resources/scripts/components/server/console/Console.tsx
@@ -193,7 +193,7 @@ export default () => {
     }, [connected, instance]);
 
     return (
-        <div className={classNames(styles.terminal, "relative")}>
+        <div className={classNames(styles.terminal, 'relative')}>
             <SpinnerOverlay visible={!connected} size={'large'} />
             <div
                 className={classNames(styles.container, styles.overflows_container, { 'rounded-b': !canSendCommands })}

--- a/resources/scripts/components/server/console/Console.tsx
+++ b/resources/scripts/components/server/console/Console.tsx
@@ -193,7 +193,7 @@ export default () => {
     }, [connected, instance]);
 
     return (
-        <div className={styles.terminal}>
+        <div className={classNames(styles.terminal, "relative")}>
             <SpinnerOverlay visible={!connected} size={'large'} />
             <div
                 className={classNames(styles.container, styles.overflows_container, { 'rounded-b': !canSendCommands })}


### PR DESCRIPTION
Is this what is expected as a fix to #4230 ?

It limits the loading to console only.

![chrome_fu7GteMJ4P](https://user-images.githubusercontent.com/45334957/177996582-bf81e9a5-f4dc-4d4c-b034-d506681c1e1d.gif)