### PR TITLE
fix docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yarn install --frozen-lockfile \
 
 # Stage 1:
 # Build the actual container with all of the needed PHP dependencies that will run the application.
-FROM --platform=$TARGETOS/$TARGETARCH php:7.4-fpm-alpine
+FROM --platform=$TARGETOS/$TARGETARCH php:8.1-fpm-alpine
 WORKDIR /app
 COPY . ./
 COPY --from=0 /app/public/assets ./public/assets

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -8,7 +8,7 @@ x-common:
     MYSQL_ROOT_PASSWORD: "CHANGE_ME_TOO"
   panel:
     &panel-environment
-    APP_URL: "https://example.com"
+    APP_URL: "http://example.com"
     # A list of valid timezones can be found here: http://php.net/manual/en/timezones.php
     APP_TIMEZONE: "UTC"
     APP_SERVICE_AUTHOR: "noreply@example.com"


### PR DESCRIPTION
Updates php to 8.1. This may resolve some weird egg import issue we've been seeing.
Resolves the issue when running docker-compose unconfigured redirects to https.