### PR TITLE
Fixed the issue that reCAPTCHA could not be used in some regions

### DIFF
--- a/config/recaptcha.php
+++ b/config/recaptcha.php
@@ -9,7 +9,7 @@ return [
     /*
      * API endpoint for recaptcha checks. You should not edit this.
      */
-    'domain' => 'https://www.google.com/recaptcha/api/siteverify',
+    'domain' => 'https://www.recaptcha.net/recaptcha/api/siteverify',
 
     /*
      * Use a custom secret key, we use our public one by default


### PR DESCRIPTION
For example, in China, the content of google.com cannot be used, and recaptcha.net solves this problem.