### PR TITLE
fix: include oom_disabled in validated

### DIFF
--- a/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
+++ b/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
@@ -102,6 +102,7 @@ class StoreServerRequest extends ApplicationApiRequest
             'database_limit' => array_get($data, 'feature_limits.databases'),
             'allocation_limit' => array_get($data, 'feature_limits.allocations'),
             'backup_limit' => array_get($data, 'feature_limits.backups'),
+            'oom_disabled' => array_get($data, 'oom_disabled'),
         ];
     }
 


### PR DESCRIPTION
The `oom_disabled` property for the store server request was never validated and passed to the server creation service, meaning that servers created via the API always had the OOM killer disabled. This PR fixes that bug, and should also fix updating `oom_disabled` via the update build endpoint.