### PR TITLE
fix: unable to scan 2fa QR code on some devices

### DIFF
--- a/resources/scripts/components/dashboard/forms/SetupTOTPDialog.tsx
+++ b/resources/scripts/components/dashboard/forms/SetupTOTPDialog.tsx
@@ -61,13 +61,11 @@ const ConfigureTwoFactorForm = ({ onTokens }: Props) => {
     return (
         <form id={'enable-totp-form'} onSubmit={submit}>
             <FlashMessageRender byKey={'account:two-step'} className={'mt-4'} />
-            <div
-                className={'flex items-center justify-center w-56 h-56 p-2 bg-gray-800 rounded-lg shadow mx-auto mt-6'}
-            >
+            <div className={'flex items-center justify-center w-56 h-56 p-2 bg-gray-50 shadow mx-auto mt-6'}>
                 {!token ? (
                     <Spinner />
                 ) : (
-                    <QRCode renderAs={'svg'} value={token.image_url_data} css={tw`w-full h-full shadow-none rounded`} />
+                    <QRCode renderAs={'svg'} value={token.image_url_data} css={tw`w-full h-full shadow-none`} />
                 )}
             </div>
             <CopyOnClick text={token?.secret}>


### PR DESCRIPTION
A dark rounded background around the QR code makes it more difficult or impossible to scan on some devices. Replaces it with a white one making it easier to scan.

Old QR image:
![image](https://user-images.githubusercontent.com/10975908/180647745-982d743b-2de3-4e6b-ac95-6f777e2905bf.png)

New QR image:

![image](https://user-images.githubusercontent.com/10975908/180647693-352f711a-d8c5-4234-85a2-431d2346a9bc.png)

Fixes #4277 
