### PR TITLE
Fix file uploading not working from download popup

### DIFF
--- a/resources/scripts/components/server/files/UploadButton.tsx
+++ b/resources/scripts/components/server/files/UploadButton.tsx
@@ -49,9 +49,7 @@ export default ({ className }: WithClassname) => {
     useEventListener(
         'dragenter',
         (e) => {
-            if (!isFileOrDirectory(e)) {
-                return;
-            }
+            e.preventDefault();
             e.stopPropagation();
             setVisible(true);
         },


### PR DESCRIPTION
This pull request fixes file uploading in firefox, when dragging from the "downloads" pupup after #4219.