### PR TITLE
Remove validation of type in fails for upload

### DIFF
--- a/resources/scripts/components/server/files/UploadButton.tsx
+++ b/resources/scripts/components/server/files/UploadButton.tsx
@@ -67,7 +67,7 @@ export default ({ className }: WithClassname) => {
     const onFileSubmission = (files: FileList) => {
         clearAndAddHttpError();
         const list = Array.from(files);
-        if (list.some((file) => !file.type && file.size % 4096 === 0)) {
+        if (list.some((file) => file.size % 4096 === 0)) {
             return addError('Folder uploads are not supported at this time.', 'Error');
         }
 


### PR DESCRIPTION
This close #4280 by removing the validation of file type.

Based in a [note ](https://developer.mozilla.org/en-US/docs/Web/API/File/type) about File.type this property only work for a few files like normal text or images, for the rest of files (like .db, .jar) this return empty then its a valid form to check a file in the upload process.

i dont know fully the system for try to suggest a better form for validation but can suggest this little fix.