### PR TITLE
Add back UptimeDuration for starting containers

### DIFF
--- a/resources/scripts/components/server/console/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/console/ServerDetailsBlock.tsx
@@ -98,7 +98,9 @@ const ServerDetailsBlock = ({ className }: { className?: string }) => {
                 title={'Uptime'}
                 color={getBackgroundColor(status === 'running' ? 0 : status !== 'offline' ? 9 : 10, 10)}
             >
-                {stats.uptime > 0 ? (
+                {status === null ? (
+                    "Offline"
+                ) : stats.uptime > 0 ? (
                     <UptimeDuration uptime={stats.uptime / 1000} />
                 ) : (
                     capitalize(status)

--- a/resources/scripts/components/server/console/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/console/ServerDetailsBlock.tsx
@@ -98,9 +98,7 @@ const ServerDetailsBlock = ({ className }: { className?: string }) => {
                 title={'Uptime'}
                 color={getBackgroundColor(status === 'running' ? 0 : status !== 'offline' ? 9 : 10, 10)}
             >
-                {status === 'starting' || status === 'stopping' ? (
-                    capitalize(status)
-                ) : stats.uptime > 0 ? (
+                {stats.uptime > 0 ? (
                     <UptimeDuration uptime={stats.uptime / 1000} />
                 ) : (
                     'Offline'

--- a/resources/scripts/components/server/console/ServerDetailsBlock.tsx
+++ b/resources/scripts/components/server/console/ServerDetailsBlock.tsx
@@ -101,7 +101,7 @@ const ServerDetailsBlock = ({ className }: { className?: string }) => {
                 {stats.uptime > 0 ? (
                     <UptimeDuration uptime={stats.uptime / 1000} />
                 ) : (
-                    'Offline'
+                    capitalize(status)
                 )}
             </StatBlock>
             <StatBlock icon={faMicrochip} title={'CPU Load'} color={getBackgroundColor(stats.cpu, limits.cpu)}>


### PR DESCRIPTION
Added back UptimeDuration for starting/stopping container. That was removed in v1.9.0