### PR TITLE
Increase task action delay limit to 3600 seconds

### DIFF
--- a/app/Http/Requests/Api/Client/Servers/Schedules/StoreTaskRequest.php
+++ b/app/Http/Requests/Api/Client/Servers/Schedules/StoreTaskRequest.php
@@ -21,7 +21,7 @@ class StoreTaskRequest extends ViewScheduleRequest
         return [
             'action' => 'required|in:command,power,backup',
             'payload' => 'required_unless:action,backup|string|nullable',
-            'time_offset' => 'required|numeric|min:0|max:900',
+            'time_offset' => 'required|numeric|min:0|max:3600',
             'sequence_id' => 'sometimes|required|numeric|min:1',
         ];
     }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -100,7 +100,7 @@ class Task extends Model
         'sequence_id' => 'required|numeric|min:1',
         'action' => 'required|string',
         'payload' => 'required_unless:action,backup|string',
-        'time_offset' => 'required|numeric|between:0,900',
+        'time_offset' => 'required|numeric|between:0,3600',
         'is_queued' => 'boolean',
         'continue_on_failure' => 'boolean',
     ];

--- a/resources/scripts/components/server/schedules/TaskDetailsModal.tsx
+++ b/resources/scripts/components/server/schedules/TaskDetailsModal.tsx
@@ -41,10 +41,10 @@ const schema = object().shape({
     }),
     continueOnFailure: boolean(),
     timeOffset: number()
-        .typeError('The time offset must be a valid number between 0 and 900.')
+        .typeError('The time offset must be a valid number between 0 and 3600.')
         .required('A time offset value must be provided.')
         .min(0, 'The time offset must be at least 0 seconds.')
-        .max(900, 'The time offset must be less than 900 seconds.'),
+        .max(3600, 'The time offset must be less than or equal to 3600 seconds.'),
 });
 
 const ActionListener = () => {


### PR DESCRIPTION
This pull request raises the maximum delay between tasks from 900 seconds to 3600 seconds, and corrects a grammatical error in the message for having a delay that is too long.