### PR TITLE
server: add configuration for install notifications

### DIFF
--- a/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
@@ -2,6 +2,7 @@
 
 namespace Pterodactyl\Http\Controllers\Api\Remote\Servers;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Pterodactyl\Models\Server;
@@ -69,10 +70,10 @@ class ServerInstallController extends Controller
             $status = Server::STATUS_SUSPENDED;
         }
 
-        $this->repository->update($server->id, ['status' => $status], true, true);
+        $this->repository->update($server->id, ['status' => $status, 'installed_at' => CarbonImmutable::now()], true, true);
 
         // If the server successfully installed, fire installed event.
-        if ($status === null) {
+        if (is_null($server->installed_at) && $status === null) {
             $this->eventDispatcher->dispatch(new ServerInstalled($server));
         }
 

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -38,6 +38,7 @@ use Pterodactyl\Exceptions\Http\Server\ServerStateConflictException;
  * @property int $backup_limit
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $installed_at
  * @property \Illuminate\Database\Eloquent\Collection|\Pterodactyl\Models\ActivityLog[] $activity
  * @property int|null $activity_count
  * @property \Pterodactyl\Models\Allocation|null $allocation
@@ -128,6 +129,7 @@ class Server extends Model
     protected $attributes = [
         'status' => self::STATUS_INSTALLING,
         'oom_disabled' => true,
+        'installed_at' => null,
     ];
 
     /**
@@ -142,14 +144,14 @@ class Server extends Model
      *
      * @var array
      */
-    protected $dates = [self::CREATED_AT, self::UPDATED_AT, 'deleted_at'];
+    protected $dates = [self::CREATED_AT, self::UPDATED_AT, 'deleted_at', 'installed_at'];
 
     /**
      * Fields that are not mass assignable.
      *
      * @var array
      */
-    protected $guarded = ['id', self::CREATED_AT, self::UPDATED_AT, 'deleted_at'];
+    protected $guarded = ['id', self::CREATED_AT, self::UPDATED_AT, 'deleted_at', 'installed_at'];
 
     /**
      * @var array

--- a/config/pterodactyl.php
+++ b/config/pterodactyl.php
@@ -205,4 +205,18 @@ return [
     'assets' => [
         'use_hash' => env('PTERODACTYL_USE_ASSET_HASH', false),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Email Notification Settings
+    |--------------------------------------------------------------------------
+    |
+    | This section controls what notifications are sent to users.
+    */
+    'email' => [
+        // Should an email be sent to a server owner once their server has completed it's first install process?
+        'send_install_notification' => env('PTERODACTYL_SEND_INSTALL_NOTIFICATION', true),
+        // Should an email be sent to a server owner whenever their server is reinstalled?
+        'send_reinstall_notification' => env('PTERODACTYL_SEND_REINSTALL_NOTIFICATION', true),
+    ],
 ];

--- a/database/migrations/2022_08_16_230204_add_installed_at_column_to_servers_table.php
+++ b/database/migrations/2022_08_16_230204_add_installed_at_column_to_servers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddInstalledAtColumnToServersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->timestamp('installed_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->dropColumn('installed_at');
+        });
+    }
+}


### PR DESCRIPTION
Adds two new config options for controlling when install notifications should be sent to a server owner (`PTERODACTYL_SEND_INSTALL_NOTIFICATION` and `PTERODACTYL_SEND_REINSTALL_NOTIFICATION`, both default to `true`).  This PR also adds a new `installed_at` field to servers which tracks the time a server was last "installed", this is primarily used to know if a server is being reinstalled and is not currently mapped in any API responses; this column defaults to `null` rather than setting the current date.