### PR TITLE
Correct the disproportionate size of the avatar

### DIFF
--- a/resources/scripts/components/NavigationBar.tsx
+++ b/resources/scripts/components/NavigationBar.tsx
@@ -76,7 +76,7 @@ export default () => {
                     <Tooltip placement={'bottom'} content={'Account Settings'}>
                         <NavLink to={'/account'}>
                             <span className={'flex items-center w-5 h-5'}>
-                                <Avatar.User />
+                                <Avatar.User size={22} />
                             </span>
                         </NavLink>
                     </Tooltip>


### PR DESCRIPTION
There is not much to say, it is a very simple fix.

In addition: I think you could make some state for it, so that when it is on the desktop it has one size, and when it is on mobile, it has another size.