### PR TITLE
update docker-compose.example.yml to avoid #4330

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -71,14 +71,14 @@ services:
       REDIS_HOST: "cache"
       DB_HOST: "database"
       DB_PORT: "3306"
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
 volumes:
   database:
   var:
   nginx:
   certs:
   logs:
-networks:
-  default:
-    ipam:
-      config:
-        - subnet: 172.20.0.0/16

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -38,7 +38,7 @@ services:
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     volumes:
-      - "/srv/pterodactyl/database:/var/lib/mysql"
+      - database:/var/lib/mysql
     environment:
       <<: *db-environment
       MYSQL_DATABASE: "panel"

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -56,10 +56,10 @@ services:
       - database
       - cache
     volumes:
-      - "/srv/pterodactyl/var/:/app/var/"
-      - "/srv/pterodactyl/nginx/:/etc/nginx/http.d/"
-      - "/srv/pterodactyl/certs/:/etc/letsencrypt/"
-      - "/srv/pterodactyl/logs/:/app/storage/logs"
+      - var:/app/var
+      - nginx:/etc/nginx/http.d
+      - certs:/etc/letsencrypt
+      - logs:/app/storage/logs
     environment:
       <<: [*panel-environment, *mail-environment]
       DB_PASSWORD: *db-password
@@ -71,6 +71,12 @@ services:
       REDIS_HOST: "cache"
       DB_HOST: "database"
       DB_PORT: "3306"
+volumes:
+  database:
+  var:
+  nginx:
+  certs:
+  logs:
 networks:
   default:
     ipam:


### PR DESCRIPTION
Update the docker-compose.example.yml to use named volumes instead of bind volumes. 
This should avoid users that use this file as a starting point to run into issue #4330.
Technically, this is only required for the volume mounted into /app/storage/logs but it is better practice anyway.