### PR TITLE
Edit page title of SSH keys page

### DIFF
--- a/resources/scripts/components/dashboard/ssh/AccountSSHContainer.tsx
+++ b/resources/scripts/components/dashboard/ssh/AccountSSHContainer.tsx
@@ -25,7 +25,7 @@ export default () => {
     }, [error]);
 
     return (
-        <PageContentBlock title={'Account API'}>
+        <PageContentBlock title={'SSH Keys'}>
             <FlashMessageRender byKey={'account'} />
             <div css={tw`md:flex flex-nowrap my-10`}>
                 <ContentBox title={'Add SSH Key'} css={tw`flex-none w-full md:w-1/2`}>


### PR DESCRIPTION
It seems that the title for the SSH keys page was incorrectly named, which, this pull request resolves that issue.