### PR TITLE
Run panel scheduled tasks via cron in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache --update ca-certificates dcron curl git supervisor tar un
 
 RUN rm /usr/local/etc/php-fpm.conf \
     && echo "* * * * * /usr/local/bin/php /app/artisan schedule:run >> /dev/null 2>&1" >> /var/spool/cron/crontabs/root \
+    && echo "* * * * * /usr/local/bin/php /app/artisan p:schedule:process >> /dev/null 2>&1" >> /var/spool/cron/crontabs/root \
     && echo "0 23 * * * certbot renew --nginx --quiet" >> /var/spool/cron/crontabs/root \
     && sed -i s/ssl_session_cache/#ssl_session_cache/g /etc/nginx/nginx.conf \
     && mkdir -p /var/run/php /var/run/nginx


### PR DESCRIPTION
Previously, scheduled tasks created in the panel would not run in docker. There's already a cron mechanism in place, we just specifically need to run the right command.