### PR TITLE
Lookup both A and AAAA records for node FQDNs

### DIFF
--- a/app/Console/Commands/Node/MakeNodeCommand.php
+++ b/app/Console/Commands/Node/MakeNodeCommand.php
@@ -59,7 +59,13 @@ class MakeNodeCommand extends Command
         $data['description'] = $this->option('description') ?? $this->ask('Enter a description to identify the node');
         $data['location_id'] = $this->option('locationId') ?? $this->ask('Enter a valid location id');
         $data['fqdn'] = $this->option('fqdn') ?? $this->ask('Enter a domain name (e.g node.example.com) to be used for connecting to the daemon. An IP address may only be used if you are not using SSL for this node');
-        if (!filter_var(gethostbyname($data['fqdn']), FILTER_VALIDATE_IP)) {
+
+        // Note, this function will also resolve CNAMEs for us automatically,
+        // there is no need to manually resolve them here.
+        //
+        // Using @ as workaround to fix https://bugs.php.net/bug.php?id=73149
+        $records = @dns_get_record($data['fqdn'], DNS_A + DNS_AAAA);
+        if (empty($records)) {
             $this->error('The FQDN or IP address provided does not resolve to a valid IP address.');
 
             return;

--- a/app/Http/Requests/Admin/Node/NodeFormRequest.php
+++ b/app/Http/Requests/Admin/Node/NodeFormRequest.php
@@ -34,8 +34,12 @@ class NodeFormRequest extends AdminFormRequest
     public function withValidator($validator)
     {
         $validator->after(function ($validator) {
-            // Check that the FQDN is a valid IP address.
-            if (!filter_var(gethostbyname($this->input('fqdn')), FILTER_VALIDATE_IP)) {
+            // Note, this function will also resolve CNAMEs for us automatically,
+            // there is no need to manually resolve them here.
+            //
+            // Using @ as workaround to fix https://bugs.php.net/bug.php?id=73149
+            $records = @dns_get_record($this->input('fqdn'), DNS_A + DNS_AAAA);
+            if (empty($records)) {
                 $validator->errors()->add('fqdn', trans('admin/node.validation.fqdn_not_resolvable'));
             }
 

--- a/app/Services/Allocations/AssignmentService.php
+++ b/app/Services/Allocations/AssignmentService.php
@@ -60,6 +60,10 @@ class AssignmentService
         }
 
         try {
+            // TODO: how should we approach supporting IPv6 with this?
+            // gethostbyname only supports IPv4, but the alternative (dns_get_record) returns
+            // an array of records, which is not ideal for this use case, we need a SINGLE
+            // IP to use, not multiple.
             $underlying = gethostbyname($data['allocation_ip']);
             $parsed = Network::parse($underlying);
         } catch (Exception $exception) {


### PR DESCRIPTION
Allows IPv6 addresses to be used, instead of IPv4 being required.

Closes <https://github.com/pterodactyl/panel/issues/4011>