### PR TITLE
Fixed incorrect filename in activity log

### DIFF
--- a/resources/scripts/components/server/files/FileEditContainer.tsx
+++ b/resources/scripts/components/server/files/FileEditContainer.tsx
@@ -66,7 +66,7 @@ export default () => {
             .then((content) => saveFileContents(uuid, name || hashToPath(hash), content))
             .then(() => {
                 if (name) {
-                    history.push(`/server/${id}/files/edit#/${encodePathSegments(name)}`);
+                    history.push(`/server/${id}/files/edit#${encodePathSegments(name)}`);
                     return;
                 }
 


### PR DESCRIPTION
This PR fixes the wrong filename in the activity log when a new file is created

closes https://github.com/pterodactyl/panel/issues/4311