### PR TITLE
Fixed suspension notice not being displayed for admins

### DIFF
--- a/resources/scripts/routers/ServerRouter.tsx
+++ b/resources/scripts/routers/ServerRouter.tsx
@@ -103,7 +103,7 @@ export default () => {
                     <InstallListener />
                     <TransferListener />
                     <WebsocketHandler />
-                    {inConflictState && (!rootAdmin || (rootAdmin && !location.pathname.endsWith(`/server/${id}`))) ? (
+                    {inConflictState ? (
                         <ConflictStateRenderer />
                     ) : (
                         <ErrorBoundary>


### PR DESCRIPTION
Suspension notice would not display for admins only on the console page even though none of the components would work.

closes https://github.com/pterodactyl/panel/issues/4322