### PR TITLE
update mumble

### DIFF
--- a/database/Seeders/eggs/voice-servers/egg-mumble-server.json
+++ b/database/Seeders/eggs/voice-servers/egg-mumble-server.json
@@ -10,7 +10,7 @@
     "description": "Mumble is an open source, low-latency, high quality voice chat software primarily intended for use while gaming.",
     "features": null,
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:voice_mumble": "ghcr.io\/parkervcp\/yolks:voice_mumble"
+        "Mumble": "ghcr.io\/parkervcp\/yolks:voice_mumble"
     },
     "file_denylist": [],
     "startup": "mumble-server -fg -ini murmur.ini",

--- a/database/Seeders/eggs/voice-servers/egg-mumble-server.json
+++ b/database/Seeders/eggs/voice-servers/egg-mumble-server.json
@@ -1,28 +1,28 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1",
+        "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2021-06-15T16:54:54-04:00",
+    "exported_at": "2022-10-15T12:38:18+02:00",
     "name": "Mumble Server",
     "author": "support@pterodactyl.io",
     "description": "Mumble is an open source, low-latency, high quality voice chat software primarily intended for use while gaming.",
     "features": null,
-    "images": [
-        "ghcr.io\/pterodactyl\/yolks:alpine"
-    ],
+    "docker_images": {
+        "ghcr.io\/parkervcp\/yolks:voice_mumble": "ghcr.io\/parkervcp\/yolks:voice_mumble"
+    },
     "file_denylist": [],
-    "startup": ".\/murmur.x86 -fg",
+    "startup": "mumble-server -fg -ini murmur.ini",
     "config": {
-        "files": "{\r\n    \"murmur.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"logfile\": \"murmur.log\",\r\n            \"port\": \"{{server.build.default.port}}\",\r\n            \"host\": \"0.0.0.0\",\r\n            \"users\": \"{{server.build.env.MAX_USERS}}\"\r\n        }\r\n    }\r\n}",
+        "files": "{\r\n    \"murmur.ini\": {\r\n        \"parser\": \"ini\",\r\n        \"find\": {\r\n            \"database\": \"\/home\/container\/murmur.sqlite\",\r\n            \"logfile\": \"\/home\/container\/murmur.log\",\r\n            \"port\": \"{{server.build.default.port}}\",\r\n            \"host\": \"0.0.0.0\",\r\n            \"users\": \"{{server.build.env.MAX_USERS}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \"Server listening on\"\r\n}",
-        "logs": "{\r\n    \"custom\": true,\r\n    \"location\": \"logs\/murmur.log\"\r\n}",
+        "logs": "{}",
         "stop": "^C"
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/ash\r\n# Mumble Installation Script\r\n#\r\n# Server Files: \/mnt\/server\r\nGITHUB_PACKAGE=mumble-voip\/mumble\r\nMATCH=murmur-static\r\n\r\nif [ ! -d \/mnt\/server\/ ]; then\r\n    mkdir \/mnt\/server\/\r\nfi\r\n\r\ncd \/mnt\/server\r\n\r\nif [ -z \"${GITHUB_USER}\" ] && [ -z \"${GITHUB_OAUTH_TOKEN}\" ] ; then\r\n    echo -e \"using anon api call\"\r\nelse\r\n    echo -e \"user and oauth token set\"\r\n    alias curl='curl -u ${GITHUB_USER}:${GITHUB_OAUTH_TOKEN} '\r\nfi\r\n\r\n## get release info and download links\r\nLATEST_JSON=$(curl --silent \"https:\/\/api.github.com\/repos\/${GITHUB_PACKAGE}\/releases\/latest\")\r\nRELEASES=$(curl --silent \"https:\/\/api.github.com\/repos\/${GITHUB_PACKAGE}\/releases\")\r\n\r\nif [ -z \"${VERSION}\" ] || [ \"${VERSION}\" == \"latest\" ]; then\r\n    DOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url | grep -m 1 -i ${MATCH})\r\nelse\r\n    VERSION_CHECK=$(echo ${RELEASES} | jq -r --arg VERSION \"${VERSION}\" '.[] | select(.tag_name==$VERSION) | .tag_name')\r\n    if [ \"${VERSION}\" == \"${VERSION_CHECK}\" ]; then\r\n        DOWNLOAD_LINK=$(echo ${RELEASES} | jq -r --arg VERSION \"${VERSION}\" '.[] | select(.tag_name==$VERSION) | .assets[].browser_download_url' | grep -m 1 -i ${MATCH})\r\n    else\r\n        echo -e \"defaulting to latest release\"\r\n        DOWNLOAD_LINK=$(echo ${LATEST_JSON} | jq .assets | jq -r .[].browser_download_url)\r\n    fi\r\nfi\r\n\r\ncurl -L ${DOWNLOAD_LINK} | tar xjv --strip-components=1",
+            "script": "#!\/bin\/ash\r\n\r\nif [ ! -d \/mnt\/server\/ ]; then\r\n    mkdir \/mnt\/server\/\r\nfi\r\n\r\ncd \/mnt\/server\r\n\r\nFILE=\/mnt\/server\/murmur.ini\r\nif [ -f \"$FILE\" ]; then\r\n    echo \"Config file already exists.\"\r\nelse \r\n    echo \"Downloading the config file.\"\r\n    apk add --no-cache murmur\r\n    cp \/etc\/murmur.ini \/mnt\/server\/murmur.ini\r\n    apk del murmur\r\nfi\r\necho \"done\"",
             "container": "ghcr.io\/pterodactyl\/installers:alpine",
             "entrypoint": "ash"
         }
@@ -35,16 +35,8 @@
             "default_value": "100",
             "user_viewable": true,
             "user_editable": false,
-            "rules": "required|numeric|digits_between:1,5"
-        },
-        {
-            "name": "Server Version",
-            "description": "Version of Mumble Server to download and use.",
-            "env_variable": "MUMBLE_VERSION",
-            "default_value": "latest",
-            "user_viewable": true,
-            "user_editable": true,
-            "rules": "required|string"
+            "rules": "required|numeric|digits_between:1,5",
+            "field_type": "text"
         }
     ]
 }


### PR DESCRIPTION
This is a changed mumble egg as the do not provice a static binary anymore for the latest 1.4.x server version.
The current only way to get 1.4 running is you compile the source or run it from the alpine packages mumur what is offical by them.
This egg uses a image that has that mumble packages installed in the docker image
changes:
- The image
- startup cmd as it is now in PATH and does not need a ./ anymore and specify to use murmur.ini config
- File parser to set the sqlite database path to /home/container/murmur.sqlite
- Set the logfile to /home/container/murmur.log but notthing seeems to be writen to it
- remove the version variable as there is no version control as the binary is now in the docker image
- remove the logs part as it is not more used

EDIT
install script:
![afbeelding](https://user-images.githubusercontent.com/67589015/195983759-10946557-416d-41ae-a9cd-186de9da6d2c.png)
