### PR TITLE
Fix 'Launch SFTP' button

### DIFF
--- a/resources/scripts/components/server/settings/SettingsContainer.tsx
+++ b/resources/scripts/components/server/settings/SettingsContainer.tsx
@@ -50,7 +50,7 @@ export default () => {
                                     </div>
                                 </div>
                                 <div css={tw`ml-4`}>
-                                    <a href={`sftp://${username}.${id}@${ip(sftp.ip)}:${sftp.port}`}>
+                                    <a href={`sftp://${username}.${id}@${ip(sftp.ip)}:${sftp.port}/home/container/`}>
                                         <Button.Text variant={Button.Variants.Secondary}>Launch SFTP</Button.Text>
                                     </a>
                                 </div>


### PR DESCRIPTION
This tiny commit fixes the 'Launch SFTP' button in the settings tab of a server
The issue in question:
![image](https://user-images.githubusercontent.com/60919292/200082205-c2b70763-0552-440d-8801-4cbaeb7c9e7e.png)

Basically, just making sftp open the /home/container/ folder instead of opening the / that it would open by default.