### PR TITLE
Update validation rules for remote activity logs

### DIFF
--- a/app/Http/Requests/Api/Remote/ActivityEventRequest.php
+++ b/app/Http/Requests/Api/Remote/ActivityEventRequest.php
@@ -21,7 +21,7 @@ class ActivityEventRequest extends FormRequest
             'data.*.server' => ['required', 'uuid'],
             'data.*.event' => ['required', 'string'],
             'data.*.metadata' => ['present', 'nullable', 'array'],
-            'data.*.ip' => ['present', 'ip'],
+            'data.*.ip' => ['sometimes', 'nullable', 'ip'],
             'data.*.timestamp' => ['required', 'string'],
         ];
     }

--- a/app/Http/Requests/Api/Remote/ActivityEventRequest.php
+++ b/app/Http/Requests/Api/Remote/ActivityEventRequest.php
@@ -17,7 +17,7 @@ class ActivityEventRequest extends FormRequest
         return [
             'data' => ['required', 'array'],
             'data.*' => ['array'],
-            'data.*.user' => ['present', 'uuid'],
+            'data.*.user' => ['sometimes', 'nullable', 'uuid'],
             'data.*.server' => ['required', 'uuid'],
             'data.*.event' => ['required', 'string'],
             'data.*.metadata' => ['present', 'nullable', 'array'],


### PR DESCRIPTION
If it exists, then it must be null or a uuid string. Otherwise, skip validating it.