### PR TITLE
fix(forge): validate only input and not length

### DIFF
--- a/database/Seeders/eggs/minecraft/egg-forge-minecraft.json
+++ b/database/Seeders/eggs/minecraft/egg-forge-minecraft.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-06-17T08:11:14+03:00",
+    "exported_at": "2022-11-06T06:33:01-05:00",
     "name": "Forge Minecraft",
     "author": "support@pterodactyl.io",
     "description": "Minecraft Forge Server. Minecraft Forge is a modding API (Application Programming Interface), which makes it easier to create mods, and also make sure mods are compatible with each other.",
@@ -67,12 +67,12 @@
         },
         {
             "name": "Forge Version",
-            "description": "Gets an exact version.\r\n\r\nEx. 1.15.2-31.2.4\r\n\r\nOverrides MC_VERSION and BUILD_TYPE. If it fails to download the server files it will fail to install.",
+            "description": "The full exact version.\r\n\r\nEx. 1.15.2-31.2.4\r\n\r\nOverrides MC_VERSION and BUILD_TYPE. If it fails to download the server files it will fail to install.",
             "env_variable": "FORGE_VERSION",
             "default_value": "",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "nullable|string|max:25",
+            "rules": "nullable|regex:\/^[0-9\\.\\-]+$\/",
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
Only allows digits, dots and dashes in the input, which is what Forge versions consists of. Removes arbitrary char limit.

fixes #4449