### PR TITLE
Fix activity logs and prevent them from removing text

### DIFF
--- a/resources/scripts/components/elements/activity/ActivityLogEntry.tsx
+++ b/resources/scripts/components/elements/activity/ActivityLogEntry.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 function wrapProperties(value: unknown): any {
     if (value === null || typeof value === 'string' || typeof value === 'number') {
-        return `<strong>${String(value)}</strong>`;
+        return `${String(value)}`;
     }
 
     if (isObject(value)) {


### PR DESCRIPTION
The correct way to fix this is to update the i18n package from React and utilize this new behavior: https://github.com/i18next/react-i18next/issues/1323

Resolves #4370

Basically the translation is removing the tags completely instead of escaping them. By default the strong tag is allowed though which is why it still works.