### PR TITLE
Update ARK Survival Evolved egg for fix some mistakes

### DIFF
--- a/database/Seeders/eggs/source-engine/egg-ark--survival-evolved.json
+++ b/database/Seeders/eggs/source-engine/egg-ark--survival-evolved.json
@@ -15,12 +15,12 @@
         "quay.io\/parkervcp\/pterodactyl-images:debian_source"
     ],
     "file_denylist": [],
-    "startup": "rmv() { echo -e \"stopping server\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} -c saveworld && rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} -c DoExit; }; trap rmv 15; cd ShooterGame\/Binaries\/Linux && .\/ShooterGameServer {{SERVER_MAP}}?listen?SessionName=\"{{SESSION_NAME}}\"?ServerPassword={{ARK_PASSWORD}}?ServerAdminPassword={{ARK_ADMIN_PASSWORD}}?Port={{SERVER_PORT}}?RCONPort={{RCON_PORT}}?QueryPort={{QUERY_PORT}}?RCONEnabled=True$( [ \"$BATTLE_EYE\" == \"1\" ] || printf %s ' -NoBattlEye' ) -server {{ARGS}} -log & until echo \"waiting for rcon connection...\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD}; do sleep 5; done",
+    "startup": "cd ShooterGame\/Binaries\/Linux && .\/ShooterGameServer {{SERVER_MAP}}?listen?SessionName=\"{{SESSION_NAME}}\"?ServerPassword={{ARK_PASSWORD}}?ServerAdminPassword={{ARK_ADMIN_PASSWORD}}?Port={{SERVER_PORT}}?RCONPort={{RCON_PORT}}?QueryPort={{QUERY_PORT}}?RCONEnabled=True$( [ \"$BATTLE_EYE\" == \"1\" ] || printf %s ' -NoBattlEye' ) -server {{ARGS}} -log & until echo \"waiting for rcon connection...\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD}; do sleep 5; done; echo -e \"stopping server\"; rcon -t rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} saveworld && rcon -a 127.0.0.1:${RCON_PORT} -p ${ARK_ADMIN_PASSWORD} DoExit",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"Waiting commands for 127.0.0.1:\"\r\n}",
         "logs": "{}",
-        "stop": "^C"
+        "stop": ":q"
     },
     "scripts": {
         "installation": {


### PR DESCRIPTION
Fixed rcon command syntax for `saveworld` and `doExit` commands,  option '-c' not exists, from rcon help:
```
   To run single mode type commands after options flags. Example:
   rcon -a 127.0.0.1:16260 -p password command1 command2

   To run terminal mode just do not specify commands to execute. Example:
   rcon -a 127.0.0.1:16260 -p password
```

Do not send to rcon ^C on exit, use :q to exit with exit code 0 for correct exit from `until` cycle.  
Do not use trap command, on correct exit from cycle, command placed behind it will work.