### PR TITLE
Disable telemetry per default as GDPR dictates

### DIFF
--- a/config/pterodactyl.php
+++ b/config/pterodactyl.php
@@ -187,6 +187,6 @@ return [
     */
 
     'telemetry' => [
-        'enabled' => env('PTERODACTYL_TELEMETRY_ENABLED', true),
+        'enabled' => env('PTERODACTYL_TELEMETRY_ENABLED', false),
     ],
 ];


### PR DESCRIPTION
As per GDPR every collection of data, including telemetry data, is Opt In. As an example: There are lawsuits eg. against Microsoft for having an Opt Out. I unfortunately couldn't find the discussion about this, which was mentioned in #4564.

See:
https://gdpr.eu/gdpr-consent-requirements/

Also the project is missing information about what collection is collected where, used for what and for how long it is stored. There's an unresolved Privacy Policy ticket for 4 years now:
https://github.com/pterodactyl/documentation/issues/4