### PR TITLE
Fix mail settings not saving

### DIFF
--- a/app/Http/Controllers/Admin/Settings/MailController.php
+++ b/app/Http/Controllers/Admin/Settings/MailController.php
@@ -57,8 +57,8 @@ class MailController extends Controller
         }
 
         $values = $request->normalize();
-        if (array_get($values, 'mail:password') === '!e') {
-            $values['mail:password'] = '';
+        if (array_get($values, 'mail:mailers:smtp:password') === '!e') {
+            $values['mail:mailers:smtp:password'] = '';
         }
 
         foreach ($values as $key => $value) {

--- a/app/Http/Requests/Admin/Settings/MailSettingsFormRequest.php
+++ b/app/Http/Requests/Admin/Settings/MailSettingsFormRequest.php
@@ -13,11 +13,11 @@ class MailSettingsFormRequest extends AdminFormRequest
     public function rules(): array
     {
         return [
-            'mail:host' => 'required|string',
-            'mail:port' => 'required|integer|between:1,65535',
-            'mail:encryption' => ['present', Rule::in([null, 'tls', 'ssl'])],
-            'mail:username' => 'nullable|string|max:191',
-            'mail:password' => 'nullable|string|max:191',
+            'mail:mailers:smtp:host' => 'required|string',
+            'mail:mailers:smtp:port' => 'required|integer|between:1,65535',
+            'mail:mailers:smtp:encryption' => ['present', Rule::in([null, 'tls', 'ssl'])],
+            'mail:mailers:smtp:username' => 'nullable|string|max:191',
+            'mail:mailers:smtp:password' => 'nullable|string|max:191',
             'mail:from:address' => 'required|string|email',
             'mail:from:name' => 'nullable|string|max:191',
         ];
@@ -31,8 +31,8 @@ class MailSettingsFormRequest extends AdminFormRequest
     {
         $keys = array_flip(array_keys($this->rules()));
 
-        if (empty($this->input('mail:password'))) {
-            unset($keys['mail:password']);
+        if (empty($this->input('mail:mailers:smtp:password'))) {
+            unset($keys['mail:mailers:smtp:password']);
         }
 
         return $this->only(array_flip($keys));

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -37,13 +37,13 @@ class SettingsServiceProvider extends ServiceProvider
      * when using the SMTP driver.
      */
     protected array $emailKeys = [
-        'mail:host',
-        'mail:port',
+        'mail:mailers:smtp:host',
+        'mail:mailers:smtp:port',
         'mail:from:address',
         'mail:from:name',
-        'mail:encryption',
-        'mail:username',
-        'mail:password',
+        'mail:mailers:smtp:encryption',
+        'mail:mailers:smtp:username',
+        'mail:mailers:smtp:password',
     ];
 
     /**
@@ -51,7 +51,7 @@ class SettingsServiceProvider extends ServiceProvider
      * configuration array.
      */
     protected static array $encrypted = [
-        'mail:password',
+        'mail:mailers:smtp:password',
     ];
 
     /**

--- a/resources/views/admin/settings/mail.blade.php
+++ b/resources/views/admin/settings/mail.blade.php
@@ -38,14 +38,14 @@
                                 <div class="form-group col-md-6">
                                     <label class="control-label">SMTP Host</label>
                                     <div>
-                                        <input required type="text" class="form-control" name="mail:host" value="{{ old('mail:host', config('mail.mailers.smtp.host')) }}" />
+                                        <input required type="text" class="form-control" name="mail:mailers:smtp:host" value="{{ old('mail:mailers:smtp:host', config('mail.mailers.smtp.host')) }}" />
                                         <p class="text-muted small">Enter the SMTP server address that mail should be sent through.</p>
                                     </div>
                                 </div>
                                 <div class="form-group col-md-2">
                                     <label class="control-label">SMTP Port</label>
                                     <div>
-                                        <input required type="number" class="form-control" name="mail:port" value="{{ old('mail:port', config('mail.mailers.smtp.port')) }}" />
+                                        <input required type="number" class="form-control" name="mail:mailers:smtp:port" value="{{ old('mail:mailers:smtp:port', config('mail.mailers.smtp.port')) }}" />
                                         <p class="text-muted small">Enter the SMTP server port that mail should be sent through.</p>
                                     </div>
                                 </div>
@@ -53,9 +53,9 @@
                                     <label class="control-label">Encryption</label>
                                     <div>
                                         @php
-                                            $encryption = old('mail:encryption', config('mail.mailers.smtp.encryption'));
+                                            $encryption = old('mail:mailers:smtp:encryption', config('mail.mailers.smtp.encryption'));
                                         @endphp
-                                        <select name="mail:encryption" class="form-control">
+                                        <select name="mail:mailers:smtp:encryption" class="form-control">
                                             <option value="" @if($encryption === '') selected @endif>None</option>
                                             <option value="tls" @if($encryption === 'tls') selected @endif>Transport Layer Security (TLS)</option>
                                             <option value="ssl" @if($encryption === 'ssl') selected @endif>Secure Sockets Layer (SSL)</option>
@@ -66,14 +66,14 @@
                                 <div class="form-group col-md-6">
                                     <label class="control-label">Username <span class="field-optional"></span></label>
                                     <div>
-                                        <input type="text" class="form-control" name="mail:username" value="{{ old('mail:username', config('mail.mailers.smtp.username')) }}" />
+                                        <input type="text" class="form-control" name="mail:mailers:smtp:username" value="{{ old('mail:mailers:smtp:username', config('mail.mailers.smtp.username')) }}" />
                                         <p class="text-muted small">The username to use when connecting to the SMTP server.</p>
                                     </div>
                                 </div>
                                 <div class="form-group col-md-6">
                                     <label class="control-label">Password <span class="field-optional"></span></label>
                                     <div>
-                                        <input type="password" class="form-control" name="mail:password"/>
+                                        <input type="password" class="form-control" name="mail:mailers:smtp:password"/>
                                         <p class="text-muted small">The password to use in conjunction with the SMTP username. Leave blank to continue using the existing password. To set the password to an empty value enter <code>!e</code> into the field.</p>
                                     </div>
                                 </div>
@@ -120,11 +120,11 @@
                 url: '/admin/settings/mail',
                 contentType: 'application/json',
                 data: JSON.stringify({
-                    'mail:host': $('input[name="mail:host"]').val(),
-                    'mail:port': $('input[name="mail:port"]').val(),
-                    'mail:encryption': $('select[name="mail:encryption"]').val(),
-                    'mail:username': $('input[name="mail:username"]').val(),
-                    'mail:password': $('input[name="mail:password"]').val(),
+                    'mail:mailers:smtp:host': $('input[name="mail:mailers:smtp:host"]').val(),
+                    'mail:mailers:smtp:port': $('input[name="mail:mailers:smtp:port"]').val(),
+                    'mail:mailers:smtp:encryption': $('select[name="mail:mailers:smtp:encryption"]').val(),
+                    'mail:mailers:smtp:username': $('input[name="mail:mailers:smtp:username"]').val(),
+                    'mail:mailers:smtp:password': $('input[name="mail:mailers:smtp:password"]').val(),
                     'mail:from:address': $('input[name="mail:from:address"]').val(),
                     'mail:from:name': $('input[name="mail:from:name"]').val()
                 }),


### PR DESCRIPTION
With the recent Laravel 9 update the config names for the mail settings changed. https://github.com/pterodactyl/panel/commit/e49ba657094fc009387b567fe5d8c8a97f4a40ee partly dealt with it.
The current problem is that the [config values aren't set](https://github.com/pterodactyl/panel/blob/develop/app/Providers/SettingsServiceProvider.php#L105) because the [key names](https://github.com/pterodactyl/panel/blob/develop/app/Providers/SettingsServiceProvider.php#L39:L46) no longer match the config values. So the correct values are saved in the `settings` table on the database but the actual config value is never set.
This also results in displaying the "wrong" values on the panel when editing the mail settings. ("Mail settings don't save" problems)

I'm not sure about backwards compatibility tho.
I tested it on my panel and it worked. But that was probably because I also set the values in my `.env` file, so it pulled the right defaults for me.
Maybe it would be better to edit the `SettingsServiceProvider`'s `boot` function to transform the key values?

Fixes #4602