### PR TITLE
Wait timeout decompression for Cloudflare

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/FileController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileController.php
@@ -192,7 +192,7 @@ class FileController extends ClientApiController
      */
     public function decompress(DecompressFilesRequest $request, Server $server): JsonResponse
     {
-        set_time_limit(300);
+        set_time_limit(99);
 
         $this->fileRepository->setServer($server)->decompressFile(
             $request->input('root'),


### PR DESCRIPTION
Source: https://community.cloudflare.com/t/default-timeout-limit-increase/240042

Cloudflare only has 100 seconds timeout limit, so if you are proxying the panel with cloudflare, decompressing a large archive would be a problem. and this happens to me several times, so i have to access the VPS to extract the archive.

I have a custom panel myself, committing a change for a help.