### PR TITLE
Remove `mail` mail driver, add `sendmail`

### DIFF
--- a/app/Console/Commands/Environment/EmailSettingsCommand.php
+++ b/app/Console/Commands/Environment/EmailSettingsCommand.php
@@ -44,7 +44,7 @@ class EmailSettingsCommand extends Command
             trans('command/messages.environment.mail.ask_driver'),
             [
                 'smtp' => 'SMTP Server',
-                'mail' => 'PHP\'s Internal Mail Function',
+                'sendmail' => 'sendmail Binary',
                 'mailgun' => 'Mailgun Transactional Email',
                 'mandrill' => 'Mandrill Transactional Email',
                 'postmark' => 'Postmark Transactional Email',


### PR DESCRIPTION
Laravel 9 replaced the Swiftmailer library with Symfony Mailer. This change removed the `mail` mail driver. (php's internal mail function)

I added `sendmail` as a "similar" replacement.