### PR TITLE
Allow MassActionBar div to be clicked through (again)

### DIFF
--- a/resources/scripts/components/server/files/MassActionsBar.tsx
+++ b/resources/scripts/components/server/files/MassActionsBar.tsx
@@ -93,7 +93,7 @@ const MassActionsBar = () => {
                     />
                 )}
                 <Portal>
-                    <div className={'fixed bottom-0 mb-6 flex justify-center w-full z-50'}>
+                    <div className={'pointer-events-none fixed bottom-0 mb-6 flex justify-center w-full z-50'}>
                         <Fade timeout={75} in={selectedFiles.length > 0} unmountOnExit>
                             <div css={tw`flex items-center space-x-4 pointer-events-auto rounded p-4 bg-black/50`}>
                                 <Button onClick={() => setShowMove(true)}>Move</Button>


### PR DESCRIPTION
https://github.com/pterodactyl/panel/pull/3359 originally fixed this but https://github.com/pterodactyl/panel/commit/2824db735219eba3be1e14a3b61a350429a54593 reintroduced the problem.

Closes #4553