### PR TITLE
Make wording in prune-backup command clearer

### DIFF
--- a/app/Console/Commands/Maintenance/PruneOrphanedBackupsCommand.php
+++ b/app/Console/Commands/Maintenance/PruneOrphanedBackupsCommand.php
@@ -10,7 +10,7 @@ class PruneOrphanedBackupsCommand extends Command
 {
     protected $signature = 'p:maintenance:prune-backups {--prune-age=}';
 
-    protected $description = 'Marks all backups that have not completed in the last "n" minutes as being failed.';
+    protected $description = 'Marks all backups older than "n" minutes that have not yet completed as being failed.';
 
     /**
      * PruneOrphanedBackupsCommand constructor.
@@ -29,7 +29,7 @@ class PruneOrphanedBackupsCommand extends Command
 
         $query = $this->backupRepository->getBuilder()
             ->whereNull('completed_at')
-            ->where('created_at', '>=', CarbonImmutable::now()->subMinutes($since)->toDateTimeString());
+            ->where('created_at', '<=', CarbonImmutable::now()->subMinutes($since)->toDateTimeString());
 
         $count = $query->count();
         if (!$count) {
@@ -38,7 +38,7 @@ class PruneOrphanedBackupsCommand extends Command
             return;
         }
 
-        $this->warn("Marking $count backups that have not been marked as completed in the last $since minutes as failed.");
+        $this->warn("Marking $count uncompleted backups that are older than $since minutes as failed.");
 
         $query->update([
             'is_successful' => false,

--- a/app/Console/Commands/Maintenance/PruneOrphanedBackupsCommand.php
+++ b/app/Console/Commands/Maintenance/PruneOrphanedBackupsCommand.php
@@ -29,7 +29,7 @@ class PruneOrphanedBackupsCommand extends Command
 
         $query = $this->backupRepository->getBuilder()
             ->whereNull('completed_at')
-            ->where('created_at', '<=', CarbonImmutable::now()->subMinutes($since)->toDateTimeString());
+            ->where('created_at', '>=', CarbonImmutable::now()->subMinutes($since)->toDateTimeString());
 
         $count = $query->count();
         if (!$count) {


### PR DESCRIPTION
This makes the wording of prune-backup command description a bit clearer.