### PR TITLE
fix(4752): Can't set server description to empty from client UI

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/SettingsController.php
+++ b/app/Http/Controllers/Api/Client/Servers/SettingsController.php
@@ -35,7 +35,7 @@ class SettingsController extends ClientApiController
     public function rename(RenameServerRequest $request, Server $server): JsonResponse
     {
         $name = $request->input('name');
-        $description = $request->input('description') ?? $server->description;
+        $description = $request->has('description') ? (string) $request->input('description') : $server->description;
         $this->repository->update($server->id, [
             'name' => $name,
             'description' => $description,


### PR DESCRIPTION
Fixes #4752 

Issue is that the middleware `ConvertEmptyStringsToNull` is enabled by default by Laravel.

Request:
![image](https://github.com/pterodactyl/panel/assets/16354517/b1a82918-25fd-46ab-8d6a-d4237e746d98)
Values:
![image](https://github.com/pterodactyl/panel/assets/16354517/35da1bcc-67b7-4c0c-ab81-5843c3afc83f)


New behavior after fix:
If description is not included in the request it will keep the old value.
If description is included but has a value of `null` or empty string it gets converted to `null` by the middleware, and then casted to empty string using a `(string)` cast.
If description is included and not empty, it will save that value.