### PR TITLE
Fix permissions check for viewing files & folders

### DIFF
--- a/resources/scripts/components/server/files/FileObjectRow.tsx
+++ b/resources/scripts/components/server/files/FileObjectRow.tsx
@@ -16,12 +16,13 @@ import { bytesToString } from '@/lib/formatters';
 import styles from './style.module.css';
 
 const Clickable: React.FC<{ file: FileObject }> = memo(({ file, children }) => {
+    const [canRead] = usePermissions(['file.read']);
     const [canReadContents] = usePermissions(['file.read-content']);
     const directory = ServerContext.useStoreState((state) => state.files.directory);
 
     const match = useRouteMatch();
 
-    return !canReadContents || (file.isFile && !file.isEditable()) ? (
+    return (file.isFile && (!file.isEditable() || !canReadContents)) || (!file.isFile && !canRead) ? (
         <div className={styles.details}>{children}</div>
     ) : (
         <NavLink


### PR DESCRIPTION
Check files for "read-content" permission only and check folders for "read" permission.
This way the permissions match their description again:
![image](https://github.com/pterodactyl/panel/assets/8203120/584c6d79-5f6a-4602-9b7e-699b5f603d04)

Fixes #4792