### PR TITLE
Fix missing onDismissed trigger for modal render

### DIFF
--- a/resources/scripts/components/elements/Modal.tsx
+++ b/resources/scripts/components/elements/Modal.tsx
@@ -97,6 +97,12 @@ function Modal({
         }
     }, [visible]);
 
+    useEffect(() => {
+        if (!render) {
+            onDismissed();
+        }
+    }, [render])
+
     return (
         <FadeTransition as={Fragment} show={render} duration="duration-150" appear={appear ?? true} unmount>
             <ModalMask


### PR DESCRIPTION
Fixes an issue with the (old) modal element in v2 which does not trigger the `onDismissed` function when the render is set to `false` / the Fade is exited, due to the removal of the Fade element / onExited property, which causes modals not to be reopenable without reloading the page / resetting the `useState` to its default, hidden value, which normally would be done in the onDismissed function