### PR TITLE
Correct getMySQLTimezoneOffset() to not round timezones and cut off minutes

### DIFF
--- a/app/Helpers/Time.php
+++ b/app/Helpers/Time.php
@@ -15,8 +15,6 @@ final class Time
      */
     public static function getMySQLTimezoneOffset(string $timezone): string
     {
-        $offset = round(CarbonImmutable::now($timezone)->getTimezone()->getOffset(CarbonImmutable::now('UTC')) / 3600);
-
-        return sprintf('%s%s:00', $offset > 0 ? '+' : '-', str_pad((string) abs($offset), 2, '0', STR_PAD_LEFT));
+        return CarbonImmutable::now($timezone)->getTimezone()->toOffsetName();
     }
 }


### PR DESCRIPTION
The current version of getMySQLTimezoneOffset() assumes that all timezones are whole hours, no minutes. This assumption was wrong.

This caused issues with schedules as the timezone offset we are setting up our database connections were wrong because of this in some timezones.

Fixes #4821 