### PR TITLE
fix: navigation link

### DIFF
--- a/resources/scripts/components/NavigationBar.tsx
+++ b/resources/scripts/components/NavigationBar.tsx
@@ -77,9 +77,9 @@ export default () => {
 
                     {rootAdmin && (
                         <Tooltip placement="bottom" content="Admin">
-                            <a href="/admin" rel="noreferrer">
+                            <NavLink to="/admin">
                                 <FontAwesomeIcon icon={faScrewdriverWrench} />
-                            </a>
+                            </NavLink>
                         </Tooltip>
                     )}
 


### PR DESCRIPTION
Due to using `a` tag, made the page reload between pages.
Sincerely it's annoying to see the white blank page when working in the night.