### PR TITLE
Fixed sum up issue with node viability function

### DIFF
--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -228,6 +228,6 @@ class Node extends Model
         $memoryLimit = $this->memory * (1 + ($this->memory_overallocate / 100));
         $diskLimit = $this->disk * (1 + ($this->disk_overallocate / 100));
 
-        return ($this->sum_memory + $memory) <= $memoryLimit && ($this->sum_disk + $disk) <= $diskLimit;
+        return ($this->servers->sum('memory') + $memory) <= $memoryLimit && ($this->servers->sum('disk') + $disk) <= $diskLimit;
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -11,7 +11,7 @@ return [
     | change this value if you are not maintaining your own internal versions.
     */
 
-    'version' => 'canary',
+    'version' => '1.11.4',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -11,7 +11,7 @@ return [
     | change this value if you are not maintaining your own internal versions.
     */
 
-    'version' => '1.11.4',
+    'version' => 'canary',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Fixed sum up issue with node viability function, in which `sum_memory` and `sum_disk` always where `0`