### PR TITLE
Enabled reinitializing for email address form

### DIFF
--- a/resources/scripts/components/dashboard/forms/UpdateEmailAddressForm.tsx
+++ b/resources/scripts/components/dashboard/forms/UpdateEmailAddressForm.tsx
@@ -51,7 +51,7 @@ export default () => {
     };
 
     return (
-        <Formik onSubmit={submit} validationSchema={schema} initialValues={{ email: user!.email, password: '' }}>
+        <Formik onSubmit={submit} validationSchema={schema} initialValues={{ email: user!.email, password: '' }} enableReinitialize>
             {({ isSubmitting, isValid }) => (
                 <React.Fragment>
                     <SpinnerOverlay size={'large'} visible={isSubmitting} />


### PR DESCRIPTION
Added `enableReinitialize` to the `UpdateEmailAddressForm`, currently when updating the email the `resetForm()` resets to the old `user!.email` which is still set as `initialValue`, by adding `enableReinitialize` the newly updated user email is set as the initial value as soon as it changes and so it will not reset to the old email.