### PR TITLE
Pass correct value to old() to stop Maintenance Mode from defaulting to the value of Behind Proxy

### DIFF
--- a/resources/views/admin/nodes/view/settings.blade.php
+++ b/resources/views/admin/nodes/view/settings.blade.php
@@ -107,11 +107,11 @@
                         <label class="form-label"><span class="label label-warning"><i class="fa fa-wrench"></i></span> Maintenance Mode</label>
                         <div>
                             <div class="radio radio-success radio-inline">
-                                <input type="radio" id="pMaintenanceFalse" value="0" name="maintenance_mode" {{ (old('behind_proxy', $node->maintenance_mode) == false) ? 'checked' : '' }}>
+                                <input type="radio" id="pMaintenanceFalse" value="0" name="maintenance_mode" {{ (old('maintenance_mode', $node->maintenance_mode) == false) ? 'checked' : '' }}>
                                 <label for="pMaintenanceFalse"> Disabled</label>
                             </div>
                             <div class="radio radio-warning radio-inline">
-                                <input type="radio" id="pMaintenanceTrue" value="1" name="maintenance_mode" {{ (old('behind_proxy', $node->maintenance_mode) == true) ? 'checked' : '' }}>
+                                <input type="radio" id="pMaintenanceTrue" value="1" name="maintenance_mode" {{ (old('maintenance_mode', $node->maintenance_mode) == true) ? 'checked' : '' }}>
                                 <label for="pMaintenanceTrue"> Enabled</label>
                             </div>
                         </div>


### PR DESCRIPTION
Pass correct value to old() to stop Maintenance Mode from defaulting to the value of Behind Proxy

Fixes #4926 