### PR TITLE
Update Sail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "fakerphp/faker": "~1.21.0",
         "friendsofphp/php-cs-fixer": "~3.14.4",
         "itsgoingd/clockwork": "~5.1.12",
-        "laravel/sail": "~1.21.0",
+        "laravel/sail": "~v1.25.0",
         "mockery/mockery": "~1.5.1",
         "nunomaduro/collision": "~7.0.5",
         "nunomaduro/larastan": "~2.4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea6b61d325c0e7489fb7997f0b08077d",
+    "content-hash": "92b9b28338671f6ff8b133fcad53dba5",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -8721,24 +8721,28 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.21.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "758a914fc4da41f3f6ca5522c85902181b228bd1"
+                "reference": "e81a7bd7ac1a745ccb25572830fecf74a89bb48a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/758a914fc4da41f3f6ca5522c85902181b228bd1",
-                "reference": "758a914fc4da41f3f6ca5522c85902181b228bd1",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/e81a7bd7ac1a745ccb25572830fecf74a89bb48a",
+                "reference": "e81a7bd7ac1a745ccb25572830fecf74a89bb48a",
                 "shasum": ""
             },
             "require": {
                 "illuminate/console": "^8.0|^9.0|^10.0",
                 "illuminate/contracts": "^8.0|^9.0|^10.0",
                 "illuminate/support": "^8.0|^9.0|^10.0",
-                "php": "^7.3|^8.0",
+                "php": "^8.0",
                 "symfony/yaml": "^6.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^6.0|^7.0|^8.0",
+                "phpstan/phpstan": "^1.10"
             },
             "bin": [
                 "bin/sail"
@@ -8778,7 +8782,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2023-02-16T19:16:27+00:00"
+            "time": "2023-09-11T17:37:09+00:00"
         },
         {
             "name": "mockery/mockery",


### PR DESCRIPTION
- Include pnpm & bun support for development (required for development branch)
- Node version v18.19.0