### PR TITLE
fix: backup complete event not being used

### DIFF
--- a/resources/scripts/components/server/backups/BackupRow.tsx
+++ b/resources/scripts/components/server/backups/BackupRow.tsx
@@ -21,9 +21,13 @@ interface Props {
 export default ({ backup, className }: Props) => {
     const { mutate } = getServerBackups();
 
-    useWebsocketEvent(`${SocketEvent.BACKUP_COMPLETED}:${backup.uuid}` as SocketEvent, (data) => {
+    useWebsocketEvent(SocketEvent.BACKUP_COMPLETED, (data) => {
         try {
             const parsed = JSON.parse(data);
+
+            if (parsed.uuid != backup.uuid) {
+                return;
+            }
 
             mutate(
                 (data) => ({


### PR DESCRIPTION
Wings doesn't send the colon separated event name.

https://github.com/pterodactyl/wings/blob/f1c5bbd42d423986e7017b4f3c43057a1b7d1717/server/backup.go#L81-L87 https://github.com/pterodactyl/wings/blob/f1c5bbd42d423986e7017b4f3c43057a1b7d1717/events/events.go#L35-L54