### PR TITLE
Update Minecraft Eula link

### DIFF
--- a/resources/scripts/components/server/features/eula/EulaModalFeature.tsx
+++ b/resources/scripts/components/server/features/eula/EulaModalFeature.tsx
@@ -72,7 +72,7 @@ const EulaModalFeature = () => {
                     target={'_blank'}
                     css={tw`text-primary-300 underline transition-colors duration-150 hover:text-primary-400`}
                     rel={'noreferrer noopener'}
-                    href="https://account.mojang.com/documents/minecraft_eula"
+                    href="https://www.minecraft.net/eula"
                 >
                     Minecraft&reg; EULA
                 </a>


### PR DESCRIPTION
The previous minecraft eula link does not work, it is corrected by the new link that redirects to the browser language.