### PR TITLE
ui(server): fix Minecraft EULA link

### DIFF
--- a/resources/scripts/components/server/features/eula/EulaModalFeature.tsx
+++ b/resources/scripts/components/server/features/eula/EulaModalFeature.tsx
@@ -72,7 +72,7 @@ const EulaModalFeature = () => {
                     target={'_blank'}
                     css={tw`text-primary-300 underline transition-colors duration-150 hover:text-primary-400`}
                     rel={'noreferrer noopener'}
-                    href='https://account.mojang.com/documents/minecraft_eula'
+                    href='https://www.minecraft.net/eula'
                 >
                     Minecraft&reg; EULA
                 </a>


### PR DESCRIPTION
This PR updates the Minecraft EULA link in the EULA model that appears when a Minecraft server starts without the EULA flag being set.

This replaces https://github.com/pterodactyl/panel/pull/5054 that was requested on the wrong branch.
Thank you to the original contributor.

Fixes https://github.com/pterodactyl/panel/issues/5089
