### PR TITLE
Catch error when User Creation Email fails at UserCreationService 

### DIFF
--- a/app/Services/Users/UserCreationService.php
+++ b/app/Services/Users/UserCreationService.php
@@ -4,6 +4,7 @@ namespace Pterodactyl\Services\Users;
 
 use Ramsey\Uuid\Uuid;
 use Pterodactyl\Models\User;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Auth\PasswordBroker;
@@ -51,7 +52,14 @@ class UserCreationService
         }
 
         $this->connection->commit();
-        $user->notify(new AccountCreated($user, $token ?? null));
+        
+        try {
+            // Attempt email notification.
+            $user->notify(new AccountCreated($user, $token ?? null));
+        } catch (\Exception $exception) {
+            // Just log the error.
+            Log::error($exception);
+        }
 
         return $user;
     }


### PR DESCRIPTION
In the current 1.x release of Pterodactyl, when a Pterodactyl instance doesn't have emails configured or email details are invalid, administrative users are given a '500 Error' screen when creating a user rather than being shown the successfully created user's details page.

In this PR, I've simply caught the error and logged it. Opting not to display the error to the user, the user is then redirected to the successfully created user screen. There are many instances where emails aren't configured and the instance administrator is aware, so it makes sense not to hinder the user creation sequence. 

I did consider returning an email sent successful state as part of the UserCreationService#handle, to then forward onto the user along with the new user object, however I was unsure if it would cause any major conflicts with forks or some project-specific software design choices I am unaware of.

I was thinking something similar to this if I were to return the error with the user object: https://hastebin.com/share/hamifisihe.php

Any feedback welcome. :) 