### PR TITLE
fix: remove special handling for `^C` stop command

### DIFF
--- a/app/Services/Eggs/EggConfigurationService.php
+++ b/app/Services/Eggs/EggConfigurationService.php
@@ -64,13 +64,6 @@ class EggConfigurationService
         }
 
         $signal = substr($stop, 1);
-        if (strtoupper($signal) === 'C') {
-            return [
-                'type' => 'stop',
-                'value' => null,
-            ];
-        }
-
         return [
             'type' => 'signal',
             'value' => strtoupper($signal),

--- a/app/Services/Eggs/EggConfigurationService.php
+++ b/app/Services/Eggs/EggConfigurationService.php
@@ -64,6 +64,7 @@ class EggConfigurationService
         }
 
         $signal = substr($stop, 1);
+
         return [
             'type' => 'signal',
             'value' => strtoupper($signal),


### PR DESCRIPTION
Rewriting the ^C into a default stop action causes docker to run the default stop action. It will run whatever is specified by STOPSIGNAL (specified in the image Dockerfile), or SIGTERM by default.

This change allows wings to received the full data and issue the correct signal.