### PR TITLE
Update Java Version Model Feature to add Minecraft 1.19 error

### DIFF
--- a/resources/scripts/components/server/features/JavaVersionModalFeature.tsx
+++ b/resources/scripts/components/server/features/JavaVersionModalFeature.tsx
@@ -16,6 +16,7 @@ import InputSpinner from '@/components/elements/InputSpinner';
 const MATCH_ERRORS = [
     'minecraft 1.17 requires running the server with java 16 or above',
     'minecraft 1.18 requires running the server with java 17 or above',
+    'minecraft 1.19 requires running the server with java 17 or above',
     'java.lang.unsupportedclassversionerror',
     'unsupported major.minor version',
     'has been compiled by a more recent version of the java runtime',


### PR DESCRIPTION
Adds the `minecraft 1.19 requires running the server with java 17 or above` variant of the error message to the Java Version model