### PR TITLE
Fixed 'Subuser without all permissions cannot edit another Subuser's permissions' and 'PermissionTitleRow Select All applies to disabled/dis-allowed permissions'

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -54,6 +54,7 @@ class UserController extends Controller
                 ->groupBy('users.id')
         )
             ->allowedFilters(['username', 'email', 'uuid'])
+            ->defaultSort('-root_admin')
             ->allowedSorts(['id', 'uuid'])
             ->paginate(50);
 

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -54,7 +54,6 @@ class UserController extends Controller
                 ->groupBy('users.id')
         )
             ->allowedFilters(['username', 'email', 'uuid'])
-            ->defaultSort('-root_admin')
             ->allowedSorts(['id', 'uuid'])
             ->paginate(50);
 

--- a/app/Http/Requests/Api/Client/Servers/Subusers/SubuserRequest.php
+++ b/app/Http/Requests/Api/Client/Servers/Subusers/SubuserRequest.php
@@ -80,5 +80,4 @@ abstract class SubuserRequest extends ClientApiRequest
             throw new HttpForbiddenException('Cannot assign permissions to a subuser that your account does not actively possess.');
         }
     }
-    }
 }

--- a/app/Http/Requests/Api/Client/Servers/Subusers/SubuserRequest.php
+++ b/app/Http/Requests/Api/Client/Servers/Subusers/SubuserRequest.php
@@ -68,12 +68,17 @@ abstract class SubuserRequest extends ClientApiRequest
         $service = $this->container->make(GetUserPermissionsService::class);
 
         $subuser = $this->route()->parameter('user');
-        $currentPermissions = $service->handle($server, $subuser);
 
-        $addedPermissions = array_diff($permissions, $currentPermissions);
-        $removedPermissions = array_diff($currentPermissions, $permissions);
+        $modifiedPermissions = $permissions;
 
-        $modifiedPermissions = array_merge($addedPermissions, $removedPermissions);
+        if (!is_null($subuser)) {
+            $currentPermissions = $service->handle($server, $subuser);
+
+            $addedPermissions = array_diff($permissions, $currentPermissions);
+            $removedPermissions = array_diff($currentPermissions, $permissions);
+
+            $modifiedPermissions = array_merge($addedPermissions, $removedPermissions);
+        }
 
         // Checks if user has all the permissions they are modifying on the Subuser
         if (count(array_intersect($service->handle($server, $user), $modifiedPermissions)) !== count($modifiedPermissions)) {

--- a/app/Http/Requests/Api/Client/Servers/Subusers/SubuserRequest.php
+++ b/app/Http/Requests/Api/Client/Servers/Subusers/SubuserRequest.php
@@ -67,7 +67,10 @@ abstract class SubuserRequest extends ClientApiRequest
         /** @var \Pterodactyl\Services\Servers\GetUserPermissionsService $service */
         $service = $this->container->make(GetUserPermissionsService::class);
 
-        if (count(array_diff($permissions, $service->handle($server, $user))) > 0) {
+        $subuser = $this->route()->parameter('user');
+        $permissionDifference = array_diff($service->handle($server, $subuser), $permissions);
+
+        if (count(array_diff($permissionDifference, $service->handle($server, $user))) > 0) {
             throw new HttpForbiddenException('Cannot assign permissions to a subuser that your account does not actively possess.');
         }
     }

--- a/resources/scripts/components/elements/Input.tsx
+++ b/resources/scripts/components/elements/Input.tsx
@@ -34,6 +34,10 @@ const checkboxStyle = css<Props>`
         ${tw`outline-none border-primary-300`};
         box-shadow: 0 0 0 1px rgba(9, 103, 210, 0.25);
     }
+
+    &:disabled {
+        ${tw`opacity-50 cursor-default border-transparent`};
+    }
 `;
 
 const inputStyle = css<Props>`

--- a/resources/scripts/components/server/users/EditSubuserModal.tsx
+++ b/resources/scripts/components/server/users/EditSubuserModal.tsx
@@ -143,7 +143,8 @@ const EditSubuserModal = ({ subuser }: Props) => {
                                 key={`permission_${key}`}
                                 title={key}
                                 isEditable={canEditUser}
-                                permissions={editablePermissions.filter((p) => p.startsWith(key))}
+                                permissions={Object.keys(permissions[key].keys).map((pkey) => `${key}.${pkey}`)}
+                                editablePermissions={editablePermissions.filter((p) => p.startsWith(key))}
                                 css={index > 0 ? tw`mt-4` : undefined}
                             >
                                 <p css={tw`text-sm text-neutral-400 mb-4`}>{permissions[key].description}</p>

--- a/resources/scripts/components/server/users/EditSubuserModal.tsx
+++ b/resources/scripts/components/server/users/EditSubuserModal.tsx
@@ -143,7 +143,7 @@ const EditSubuserModal = ({ subuser }: Props) => {
                                 key={`permission_${key}`}
                                 title={key}
                                 isEditable={canEditUser}
-                                permissions={Object.keys(permissions[key].keys).map((pkey) => `${key}.${pkey}`)}
+                                permissions={editablePermissions.filter((p) => p.startsWith(key))}
                                 css={index > 0 ? tw`mt-4` : undefined}
                             >
                                 <p css={tw`text-sm text-neutral-400 mb-4`}>{permissions[key].description}</p>

--- a/resources/scripts/components/server/users/PermissionTitleBox.tsx
+++ b/resources/scripts/components/server/users/PermissionTitleBox.tsx
@@ -9,18 +9,19 @@ interface Props {
     isEditable: boolean;
     title: string;
     permissions: string[];
+    editablePermissions: string[];
     className?: string;
 }
 
-const PermissionTitleBox: React.FC<Props> = memo(({ isEditable, title, permissions, className, children }) => {
+const PermissionTitleBox: React.FC<Props> = memo(({ isEditable, title, permissions, editablePermissions, className, children }) => {
     const [{ value }, , { setValue }] = useField<string[]>('permissions');
 
     const onCheckboxClicked = useCallback(
         (e: React.ChangeEvent<HTMLInputElement>) => {
             if (e.currentTarget.checked) {
-                setValue([...value, ...permissions.filter((p) => !value.includes(p))]);
+                setValue([...value, ...permissions.filter((p) => !value.includes(p) && editablePermissions.includes(p))]);
             } else {
-                setValue(value.filter((p) => !permissions.includes(p)));
+                setValue(value.filter((p) => !editablePermissions.includes(p)));
             }
         },
         [permissions, value]
@@ -34,8 +35,9 @@ const PermissionTitleBox: React.FC<Props> = memo(({ isEditable, title, permissio
                     {isEditable && (
                         <Input
                             type={'checkbox'}
-                            checked={permissions.every((p) => value.includes(p))}
+                            checked={editablePermissions.every((p) => value.includes(p))}
                             onChange={onCheckboxClicked}
+                            disabled={editablePermissions.filter((p) => p.startsWith(title)).length === 0}
                         />
                     )}
                 </div>

--- a/resources/scripts/components/server/users/PermissionTitleBox.tsx
+++ b/resources/scripts/components/server/users/PermissionTitleBox.tsx
@@ -35,7 +35,7 @@ const PermissionTitleBox: React.FC<Props> = memo(({ isEditable, title, permissio
                     {isEditable && (
                         <Input
                             type={'checkbox'}
-                            checked={editablePermissions.every((p) => value.includes(p))}
+                            checked={editablePermissions.every((p) => value.includes(p)) && value.find((p) => p.startsWith(title)) != null}
                             onChange={onCheckboxClicked}
                             disabled={editablePermissions.filter((p) => p.startsWith(title)).length === 0}
                         />


### PR DESCRIPTION
Currently, Subusers who don't have all permissions for a server cannot edit another Subuser's permissions due to the SubuserRequest not accounting for pre-existing permissions, so the Panel believes the user is trying to edit all the permissions. 

This is the error the user gets when their request is denied.
![image](https://github.com/user-attachments/assets/2965b932-d4a1-406e-83cc-d319103bec66)

So, I've added some logic to work out which permissions were removed and added and then check the user has all those modified permissions.

In relation to this, Subusers can currently use the Select All even when all permissions within the group are disabled  causing all disabled/dis-allowed permissions to be selected - I've fixed this bug in this PR. 
![image](https://github.com/user-attachments/assets/7e8d2046-04e9-4427-afa2-3429fec09a1b)

With my fix, the button is disabled when all permissions within the group are disabled and when there are some (not all) permissions available, only the ones available are affected.