### PR TITLE
Add missing BackupRemoteUploadController Exception

### DIFF
--- a/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Pterodactyl\Models\Backup;
 use Illuminate\Http\JsonResponse;
 use Pterodactyl\Http\Controllers\Controller;
+use Pterodactyl\Exceptions\Http\HttpForbiddenException;
 use Pterodactyl\Extensions\Backups\BackupManager;
 use Pterodactyl\Extensions\Filesystem\S3Filesystem;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;


### PR DESCRIPTION
@matthewpi forgot to add `use Pterodactyl\Exceptions\Http\HttpForbiddenException;` in https://github.com/pterodactyl/panel/commit/7bfc265a7ef0b7f8f55b69edb12a8552bfd50a8c

This was patched 4 days later in https://github.com/pterodactyl/panel/commit/f8dfef04c41edbafbd426357875046c82ac29229