### PR TITLE
fix: added loading of .env file to entrypoint.sh

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -29,6 +29,12 @@ else
   ln -s /app/var/.env /app/
 fi
 
+## load .env file
+if [ -f /app/.env ]; then
+  echo "Loading environment variables from /app/.env"
+  export $(grep -v '^#' /app/.env | xargs)
+fi
+
 echo "Checking if https is required."
 if [ -f /etc/nginx/http.d/panel.conf ]; then
   echo "Using nginx config already in place."


### PR DESCRIPTION
Fix: Load environment variables from /app/.env in entrypoint.sh

When using the Pterodactyl panel with Docker, environment variables such as DB_PORT and DB_HOST were not being loaded in entrypoint.sh. This commit resolves the issue by loading the /app/.env file using xargs, ensuring that all necessary environment variables are available at runtime.