### PR TITLE
Add header-based authentication support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,9 @@ MAIL_FROM_NAME="Pterodactyl Panel"
 #
 # @see: https://github.com/pterodactyl/panel/pull/3110
 # MAIL_EHLO_DOMAIN=panel.example.com
+
+# Header Authentication Settings
+AUTH_HEADER_ENABLED=false
+AUTH_HEADER_USERNAME=X-Auth-Username
+AUTH_HEADER_EMAIL=X-Auth-Email
+AUTH_HEADER_AUTO_CREATE=false

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -60,6 +60,7 @@ class Kernel extends HttpKernel
             VerifyCsrfToken::class,
             SubstituteBindings::class,
             LanguageMiddleware::class,
+            \Pterodactyl\Http\Middleware\HeaderAuthentication::class,
         ],
         'api' => [
             EnsureStatefulRequests::class,

--- a/app/Http/Middleware/HeaderAuthentication.php
+++ b/app/Http/Middleware/HeaderAuthentication.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Pterodactyl\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Pterodactyl\Models\User;
+use Symfony\Component\HttpFoundation\Response;
+
+class HeaderAuthentication
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!config('auth.header.enabled', false)) {
+            return $next($request);
+        }
+
+        $usernameHeader = config('auth.header.username_header', 'X-Auth-Username');
+        $emailHeader = config('auth.header.email_header', 'X-Auth-Email');
+
+        $username = $request->header($usernameHeader);
+        $email = $request->header($emailHeader);
+
+        if (!$username || !$email) {
+            return $next($request);
+        }
+
+        $user = User::where('email', $email)->first();
+
+        if (!$user && config('auth.header.auto_create', false)) {
+            $user = User::create([
+                'username' => $username,
+                'email' => $email,
+                'name_first' => $username,
+                'name_last' => '',
+                'password' => bcrypt(str_random(32)),
+                'root_admin' => false,
+            ]);
+        }
+
+        if ($user) {
+            Auth::login($user);
+        }
+
+        return $next($request);
+    }
+} 

--- a/app/Http/Middleware/HeaderAuthentication.php
+++ b/app/Http/Middleware/HeaderAuthentication.php
@@ -3,9 +3,10 @@
 namespace Pterodactyl\Http\Middleware;
 
 use Closure;
+use Ramsey\Uuid\Uuid;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Pterodactyl\Models\User;
+use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class HeaderAuthentication
@@ -29,14 +30,21 @@ class HeaderAuthentication
         $user = User::where('email', $email)->first();
 
         if (!$user && config('auth.header.auto_create', false)) {
-            $user = User::create([
-                'username' => $username,
-                'email' => $email,
-                'name_first' => $username,
-                'name_last' => '',
-                'password' => bcrypt(str_random(32)),
-                'root_admin' => false,
-            ]);
+            $user = new User();
+            $user->uuid = Uuid::uuid4()->toString();
+            $user->username = $username;
+            $user->email = $email;
+            $user->name_first = $username;
+            $user->name_last = $username;
+            $user->password = bcrypt(Uuid::uuid4()->toString());
+            $user->language = config('app.locale', 'en');
+            $user->root_admin = false;
+            $user->use_totp = false;
+            $user->totp_secret = null;
+            $user->external_id = '';
+            $user->gravatar = true;
+            $user->totp_authenticated_at = null;
+            $user->save();
         }
 
         if ($user) {

--- a/config/auth.php
+++ b/config/auth.php
@@ -55,9 +55,8 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
-
-        'api' => [
-            'driver' => 'token',
+        'sanctum' => [
+            'driver' => 'sanctum',
             'provider' => 'users',
         ],
     ],
@@ -126,4 +125,11 @@ return [
     */
 
     'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 10800),
+
+    'header' => [
+        'enabled' => env('AUTH_HEADER_ENABLED', false),
+        'username_header' => env('AUTH_HEADER_USERNAME', 'X-Auth-Username'),
+        'email_header' => env('AUTH_HEADER_EMAIL', 'X-Auth-Email'),
+        'auto_create' => env('AUTH_HEADER_AUTO_CREATE', false),
+    ],
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -55,9 +55,11 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
-        'sanctum' => [
-            'driver' => 'sanctum',
+
+        'api' => [
+            'driver' => 'token',
             'provider' => 'users',
+            'hash' => false,
         ],
     ],
 
@@ -128,8 +130,8 @@ return [
 
     'header' => [
         'enabled' => env('AUTH_HEADER_ENABLED', false),
+        'auto_create' => env('AUTH_HEADER_AUTO_CREATE', false),
         'username_header' => env('AUTH_HEADER_USERNAME', 'X-Auth-Username'),
         'email_header' => env('AUTH_HEADER_EMAIL', 'X-Auth-Email'),
-        'auto_create' => env('AUTH_HEADER_AUTO_CREATE', false),
     ],
 ];

--- a/tests/Unit/Http/Middleware/HeaderAuthenticationTest.php
+++ b/tests/Unit/Http/Middleware/HeaderAuthenticationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Pterodactyl\Tests\Unit\Http\Middleware;
+
+use Ramsey\Uuid\Uuid;
+use Illuminate\Http\Request;
+use Pterodactyl\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Pterodactyl\Tests\TestCase;
+use Pterodactyl\Http\Middleware\HeaderAuthentication;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class HeaderAuthenticationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        config()->set('auth.header.enabled', true);
+    }
+
+    public function test_middleware_does_nothing_when_disabled()
+    {
+        config()->set('auth.header.enabled', false);
+
+        $middleware = new HeaderAuthentication();
+        $request = new Request();
+
+        $response = $middleware->handle($request, function ($req) {
+            return response('OK');
+        });
+
+        $this->assertEquals('OK', $response->getContent());
+        $this->assertFalse(Auth::check());
+    }
+
+    public function test_middleware_authenticates_existing_user()
+    {
+        $user = User::factory()->create([
+            'username' => 'testuser',
+            'email' => 'test@example.com',
+            'name_first' => 'Test',
+            'name_last' => 'User',
+            'external_id' => '',
+        ]);
+
+        $middleware = new HeaderAuthentication();
+        $request = new Request();
+        $request->headers->set('X-Auth-Username', 'testuser');
+        $request->headers->set('X-Auth-Email', 'test@example.com');
+
+        $response = $middleware->handle($request, function ($req) {
+            return response('OK');
+        });
+
+        $this->assertEquals('OK', $response->getContent());
+        $this->assertTrue(Auth::check());
+        $this->assertEquals($user->id, Auth::id());
+    }
+
+    public function test_middleware_creates_new_user_when_enabled()
+    {
+        config()->set('auth.header.auto_create', true);
+
+        $middleware = new HeaderAuthentication();
+        $request = new Request();
+        $request->headers->set('X-Auth-Username', 'testuser');
+        $request->headers->set('X-Auth-Email', 'test@example.com');
+
+        $response = $middleware->handle($request, function ($req) {
+            return response('OK');
+        });
+
+        $this->assertEquals('OK', $response->getContent());
+        $this->assertTrue(Auth::check());
+        $user = Auth::user();
+        $this->assertEquals('testuser', $user->username);
+        $this->assertEquals('test@example.com', $user->email);
+        $this->assertEquals('', $user->external_id);
+        $this->assertNotNull($user->uuid);
+    }
+
+    public function test_middleware_does_not_create_user_when_auto_create_disabled()
+    {
+        config()->set('auth.header.auto_create', false);
+
+        $middleware = new HeaderAuthentication();
+        $request = new Request();
+        $request->headers->set('X-Auth-Username', 'testuser');
+        $request->headers->set('X-Auth-Email', 'test@example.com');
+
+        $response = $middleware->handle($request, function ($req) {
+            return response('OK');
+        });
+
+        $this->assertEquals('OK', $response->getContent());
+        $this->assertFalse(Auth::check());
+    }
+
+    public function test_middleware_uses_custom_header_names()
+    {
+        config()->set('auth.header.username_header', 'HTTP_X_USERNAME');
+        config()->set('auth.header.email_header', 'HTTP_X_EMAIL');
+
+        $user = User::factory()->create([
+            'username' => 'testuser',
+            'email' => 'test@example.com',
+            'name_first' => 'Test',
+            'name_last' => 'User',
+            'external_id' => '',
+        ]);
+
+        $middleware = new HeaderAuthentication();
+        $request = new Request();
+        $request->headers->set('HTTP_X_USERNAME', 'testuser');
+        $request->headers->set('HTTP_X_EMAIL', 'test@example.com');
+
+        $response = $middleware->handle($request, function ($req) {
+            return response('OK');
+        });
+
+        $this->assertEquals('OK', $response->getContent());
+        $this->assertTrue(Auth::check());
+        $this->assertEquals($user->id, Auth::id());
+    }
+} 


### PR DESCRIPTION
This PR adds support for header-based authentication, allowing users to authenticate via HTTP headers. This is particularly useful for proxy authentication via SSO providers like Authelia or Authentik.

Features:
- New HeaderAuthentication middleware
- Configurable header names for username and email
- Optional automatic user creation
- Comprehensive test suite
- SQLite and MySQL compatibility

The feature can be enabled via environment variables:
```
AUTH_HEADER_ENABLED=true
AUTH_HEADER_AUTO_CREATE=true
AUTH_HEADER_USERNAME=X-Auth-Username
AUTH_HEADER_EMAIL=X-Auth-Email
```

## Reverse Proxy Configuration
When using this feature with a reverse proxy, it is important to exclude the /api route from header authentication to prevent issues with API requests. Here is an example Nginx configuration:

```nginx
location /api {
    proxy_pass http://panel:80;
    # Do not add auth headers for API routes
}

location / {
    proxy_pass http://panel:80;
    # Add auth headers here
    proxy_set_header X-Auth-Username $user;
    proxy_set_header X-Auth-Email $email;
}
```

This implementation provides a simple way to integrate with existing SSO solutions without requiring complex LDAP, SAML, or OIDC implementations. The proxy handles the authentication, and the panel trusts the headers it receives.

All tests are passing, and the implementation is compatible with both MySQL and SQLite databases.

Fixes #4026
