### PR TITLE
fix: timezone is lost during the creation of CarbonImmutable in Schedule

### DIFF
--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -120,8 +120,8 @@ class Schedule extends Model
     {
         $formatted = sprintf('%s %s %s %s %s', $this->cron_minute, $this->cron_hour, $this->cron_day_of_month, $this->cron_month, $this->cron_day_of_week);
 
-        return CarbonImmutable::createFromTimestamp(
-            (new CronExpression($formatted))->getNextRunDate()->getTimestamp()
+        return CarbonImmutable::instance(
+            (new CronExpression($formatted))->getNextRunDate()
         );
     }
 


### PR DESCRIPTION
Problem: The schedule was running multiple times instead of once because the next run date was being set to UTC, ignoring the specified timezone for Pterodactyl.

Solution: Changed the code to use CarbonImmutable::instance instead of CarbonImmutable::createFromTimestamp. This preserves the timezone information from the CronExpression's getNextRunDate method, ensuring the schedule runs at the correct local time.