### PR TITLE
Update HashidsServiceProvider.php

### DIFF
--- a/app/Providers/HashidsServiceProvider.php
+++ b/app/Providers/HashidsServiceProvider.php
@@ -18,9 +18,9 @@ class HashidsServiceProvider extends ServiceProvider
             $config = $this->app['config'];
 
             return new Hashids(
-                $config->get('hashids.salt', ''),
-                $config->get('hashids.length', 0),
-                $config->get('hashids.alphabet', 'abcdefghijkmlnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')
+                (string) $config->get('hashids.salt', ''),
+                (int) $config->get('hashids.length', 0),
+                (string) $config->get('hashids.alphabet', 'abcdefghijkmlnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890')
             );
         });
 


### PR DESCRIPTION
Missing hash salt is passed as null to Hashids::__construct, triggering a 500 error when viewing the servers' databases in the user server panel.

<img width="1470" alt="Screenshot_2025-03-30_at_23 12 13" src="https://github.com/user-attachments/assets/69ecb695-1113-446b-aa6f-ab5bd67ea99b" />

Tested in a Docker deployment.
