### PR TITLE
Missing HttpForbiddenException in BackupRemoteUploadController.php

### DIFF
--- a/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\JsonResponse;
 use Pterodactyl\Http\Controllers\Controller;
 use Pterodactyl\Extensions\Backups\BackupManager;
 use Pterodactyl\Extensions\Filesystem\S3Filesystem;
+use Pterodactyl\Exceptions\Http\HttpForbiddenException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 


### PR DESCRIPTION
HttpForbiddenException needed to be imported into the BackupRemoteUploadController.php file used in line 56.