### PR TITLE
Fixes broken locale translations from 1.11.11 security fix.

### DIFF
--- a/app/Http/Requests/Base/LocaleRequest.php
+++ b/app/Http/Requests/Base/LocaleRequest.php
@@ -10,7 +10,7 @@ class LocaleRequest extends FormRequest
     {
         return [
             'locale' => ['required', 'string', 'regex:/^[a-z][a-z]$/'],
-            'namespace' => ['required', 'string', 'regex:/^[a-z]{1,191}$/'],
+            'namespace' => ['required', 'string', 'regex:/^[a-z][a-z\/]*$/'],
         ];
     }
 }


### PR DESCRIPTION
Current regex too restrictive.

Changed regex on namespace to allow the use of forward slashes as some theme templates do.