### PR TITLE
FIX: Renamed 'batch_uuid' field to 'batch' in ActivityLogService

### DIFF
--- a/app/Services/Activity/ActivityLogService.php
+++ b/app/Services/Activity/ActivityLogService.php
@@ -199,7 +199,7 @@ class ActivityLogService
 
         $this->activity = new ActivityLog([
             'ip' => Request::ip(),
-            'batch_uuid' => $this->batch->uuid(),
+            'batch' => $this->batch->uuid(),
             'properties' => Collection::make([]),
             'api_key_id' => $this->targetable->apiKeyId(),
         ]);


### PR DESCRIPTION
The field was renamed to match the column name in the database and to maintain consistency across the codebase.