### PR TITLE
Load `IBM Plex Sans` from code and export as part of bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "@babel/preset-react": "^7.12.1",
         "@babel/preset-typescript": "^7.12.1",
         "@babel/runtime": "^7.12.1",
+        "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@testing-library/dom": "^8.14.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "12.1.5",

--- a/resources/scripts/assets/css/GlobalStylesheet.ts
+++ b/resources/scripts/assets/css/GlobalStylesheet.ts
@@ -1,7 +1,18 @@
 import tw from 'twin.macro';
 import { createGlobalStyle } from 'styled-components/macro';
+// @ts-expect-error untyped font file
+import font from '@fontsource-variable/ibm-plex-sans/files/ibm-plex-sans-latin-wght-normal.woff2';
 
 export default createGlobalStyle`
+    @font-face {
+        font-family: 'IBM Plex Sans';
+        font-style: normal;
+        font-display: swap;
+        font-weight: 100 700;
+        src: url(${font}) format('woff2-variations');
+        unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+    }
+
     body {
         ${tw`font-sans bg-neutral-800 text-neutral-200`};
         letter-spacing: 0.015em;

--- a/resources/scripts/components/NavigationBar.tsx
+++ b/resources/scripts/components/NavigationBar.tsx
@@ -53,7 +53,7 @@ export default () => {
                     <Link
                         to={'/'}
                         className={
-                            'text-2xl font-header px-4 no-underline text-neutral-200 hover:text-neutral-100 transition-colors duration-150'
+                            'text-2xl font-header font-medium px-4 no-underline text-neutral-200 hover:text-neutral-100 transition-colors duration-150'
                         }
                     >
                         {name}

--- a/resources/scripts/components/server/console/ChartBlock.tsx
+++ b/resources/scripts/components/server/console/ChartBlock.tsx
@@ -11,7 +11,9 @@ interface ChartBlockProps {
 export default ({ title, legend, children }: ChartBlockProps) => (
     <div className={classNames(styles.chart_container, 'group')}>
         <div className={'flex items-center justify-between px-4 py-2'}>
-            <h3 className={'font-header transition-colors duration-100 group-hover:text-gray-50'}>{title}</h3>
+            <h3 className={'font-header font-medium transition-colors duration-100 group-hover:text-gray-50'}>
+                {title}
+            </h3>
             {legend && <p className={'text-sm flex items-center'}>{legend}</p>}
         </div>
         <div className={'z-10 ml-2'}>{children}</div>

--- a/resources/scripts/components/server/console/ServerConsoleContainer.tsx
+++ b/resources/scripts/components/server/console/ServerConsoleContainer.tsx
@@ -34,7 +34,9 @@ const ServerConsoleContainer = () => {
             )}
             <div className={'grid grid-cols-4 gap-4 mb-4'}>
                 <div className={'hidden sm:block sm:col-span-2 lg:col-span-3 pr-4'}>
-                    <h1 className={'font-header text-2xl text-gray-50 leading-relaxed line-clamp-1'}>{name}</h1>
+                    <h1 className={'font-header font-medium text-2xl text-gray-50 leading-relaxed line-clamp-1'}>
+                        {name}
+                    </h1>
                     <p className={'text-sm line-clamp-2'}>{description}</p>
                 </div>
                 <div className={'col-span-4 sm:col-span-2 lg:col-span-1 self-end'}>

--- a/resources/scripts/components/server/console/StatBlock.tsx
+++ b/resources/scripts/components/server/console/StatBlock.tsx
@@ -32,7 +32,7 @@ export default ({ title, copyOnClick, icon, color, className, children }: StatBl
                     />
                 </div>
                 <div className={'flex flex-col justify-center overflow-hidden w-full'}>
-                    <p className={'font-header leading-tight text-xs md:text-sm text-gray-200'}>{title}</p>
+                    <p className={'font-header font-medium leading-tight text-xs md:text-sm text-gray-200'}>{title}</p>
                     <div
                         ref={ref}
                         className={'h-[1.75rem] w-full font-semibold text-gray-50 truncate'}

--- a/resources/views/templates/wrapper.blade.php
+++ b/resources/views/templates/wrapper.blade.php
@@ -31,10 +31,6 @@
                 </script>
             @endif
         @show
-        <style>
-            @import url('//fonts.googleapis.com/css?family=Rubik:300,400,500&display=swap');
-            @import url('//fonts.googleapis.com/css?family=IBM+Plex+Mono|IBM+Plex+Sans:500&display=swap');
-        </style>
 
         @yield('assets')
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,10 @@ module.exports = {
                 },
             },
             {
+                test: /\.(woff|woff2)$/i,
+                type: 'asset/resource',
+            },
+            {
                 test: /\.svg$/,
                 loader: 'svg-url-loader',
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,6 +1636,11 @@
     "@floating-ui/dom" "^0.5.3"
     use-isomorphic-layout-effect "^1.1.1"
 
+"@fontsource-variable/ibm-plex-sans@^5.2.8":
+  version "5.2.8"
+  resolved "https://registry.yarnpkg.com/@fontsource-variable/ibm-plex-sans/-/ibm-plex-sans-5.2.8.tgz#8947cca46a35ca91266b88ebcbcac09ff264aabc"
+  integrity sha512-n5PF2iFa0CZT0QYTPzxvZ39opC9LnU0zdoRccoADbs+Dtsd+lbXOZF7RNuIPHcQX1dKjF63sxnRImQIB5eD0Ag==
+
 "@fortawesome/fontawesome-common-types@^0.2.32":
   version "0.2.32"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz#3436795d5684f22742989bfa08f46f50f516f259"


### PR DESCRIPTION
Removes the need to load any external resources for fonts. Resolves https://github.com/pterodactyl/panel/issues/5343