### PR TITLE
Don't delete the initial content when using "Ctrl+Z" to undo

### DIFF
--- a/resources/scripts/components/elements/CodemirrorEditor.tsx
+++ b/resources/scripts/components/elements/CodemirrorEditor.tsx
@@ -191,7 +191,12 @@ export default ({ style, initialContent, filename, mode, fetchContent, onContent
     }, [editor, mode]);
 
     useEffect(() => {
-        editor && editor.setValue(initialContent || '');
+        if (editor) {
+            editor.setValue(initialContent || '');
+            // Reset the history so that "Ctrl+Z" doesn't delete the intial content
+            // we just set above.
+            editor.setHistory({ done: [], undone: [] });
+        }
     }, [editor, initialContent]);
 
     useEffect(() => {


### PR DESCRIPTION
Resolves https://github.com/pterodactyl/panel/issues/5263