### PR TITLE
Fix admin server manage boxes misalignment when suspending a server

### DIFF
--- a/public/themes/pterodactyl/css/pterodactyl.css
+++ b/public/themes/pterodactyl/css/pterodactyl.css
@@ -833,3 +833,23 @@ pre {
     background-color: #515f6cbb;
     border-color: #1f2933;
 }
+
+/* Make the row a flex container so all columns in the same row can have equal height */
+.equal-height {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.equal-height>[class*="col-"] {
+    display: flex;
+}
+
+.equal-height .box {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+
+.equal-height .box-body {
+    flex: 1;
+}

--- a/resources/views/admin/servers/view/manage.blade.php
+++ b/resources/views/admin/servers/view/manage.blade.php
@@ -16,7 +16,7 @@
 
 @section('content')
     @include('admin.servers.partials.navigation')
-    <div class="row">
+    <div class="row equal-height">
         <div class="col-sm-4">
             <div class="box box-danger">
                 <div class="box-header with-border">


### PR DESCRIPTION
The PR is a bit basic, but the interface problem will be fixed. And it doesn't have any problems with other screens.

old:
<img width="1556" height="663" alt="image" src="https://github.com/user-attachments/assets/6a989e33-a2f8-4eaf-a9ea-08f108671383" />
<img width="1542" height="610" alt="image" src="https://github.com/user-attachments/assets/36843562-6aed-4376-b914-ea525c3f84d7" />

new:
<img width="1547" height="670" alt="image" src="https://github.com/user-attachments/assets/4a0c5695-f64d-46c8-bb9c-eea8c9cddcdc" />
