### PR TITLE
Don't endlessly poll websocket when disconnected due to suspension

### DIFF
--- a/resources/scripts/components/server/WebsocketHandler.tsx
+++ b/resources/scripts/components/server/WebsocketHandler.tsx
@@ -34,6 +34,9 @@ export default () => {
 
         socket.on('auth success', () => setConnectionState(true));
         socket.on('SOCKET_CLOSE', () => setConnectionState(false));
+        socket.on('SOCKET_CONNECT_ERROR', () => {
+            setError('Failed to connect to websocket instance after multiple attempts: try refreshing the page.');
+        });
         socket.on('SOCKET_ERROR', () => {
             setError('connecting');
             setConnectionState(false);


### PR DESCRIPTION
This work is associated with the changes in https://github.com/pterodactyl/wings/pull/287 and fixes the front-end websocket logic a bit.

The existing library now handles the reconnect attempts (up to 20, once per second) and throws an error message to the user if it fails to connect after 20 attempts. We could increase the attempts down the road if people are noticing this constantly gives them error messages, but if it doesn't connect after 20 seconds there is probably a bigger issue and we're wasting time here.

This logic now also aborts the reconnect loop if the Wings instance responds with a `4400` or `4409` connection closing message code. This indicates a server suspension or some other internal server issue and we don't want the websocket to actually try reconnecting.