### PR TITLE
Enable Image Preview in Pterodactyl Files via Clickable Modal

### DIFF
--- a/resources/scripts/components/server/files/FileObjectRow.tsx
+++ b/resources/scripts/components/server/files/FileObjectRow.tsx
@@ -8,50 +8,36 @@ import FileDropdownMenu from '@/components/server/files/FileDropdownMenu';
 import { ServerContext } from '@/state/server';
 import { NavLink, useRouteMatch } from 'react-router-dom';
 import tw from 'twin.macro';
-import isEqual from "react-fast-compare";
-import SelectFileCheckbox from "@/components/server/files/SelectFileCheckbox";
-import { usePermissions } from "@/plugins/usePermissions";
-import { join } from "pathe";
-import { bytesToString } from "@/lib/formatters";
-import styles from "./style.module.css";
-import ImagePreviewModal from "@/components/server/files/ImagePreviewModal";
+import isEqual from 'react-fast-compare';
+import SelectFileCheckbox from '@/components/server/files/SelectFileCheckbox';
+import { usePermissions } from '@/plugins/usePermissions';
+import { join } from 'pathe';
+import { bytesToString } from '@/lib/formatters';
+import styles from './style.module.css';
+import ImagePreviewModal from '@/components/server/files/ImagePreviewModal';
 
-const IMAGE_EXTENSIONS = [
-  "png",
-  "jpg",
-  "jpeg",
-  "gif",
-  "webp",
-];
+const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp'];
 
 const isImageFile = (filename: string): boolean => {
-  const ext = filename.split(".").pop()?.toLowerCase();
+  const ext = filename.split('.').pop()?.toLowerCase();
   return ext ? IMAGE_EXTENSIONS.includes(ext) : false;
 };
 
-const Clickable: React.FC<{ file: FileObject; onImageClick?: () => void }> =
-  memo(({ file, children, onImageClick }) => {
-    const [canRead] = usePermissions(["file.read"]);
-    const [canReadContents] = usePermissions(["file.read-content"]);
-    const directory = ServerContext.useStoreState(
-      (state) => state.files.directory
-    );
-
+const Clickable: React.FC<{ file: FileObject; onImageClick?: () => void }> = memo(
+  ({ file, children, onImageClick }) => {
+    const [canRead] = usePermissions(['file.read']);
+    const [canReadContents] = usePermissions(['file.read-content']);
+    const directory = ServerContext.useStoreState((state) => state.files.directory);
     const match = useRouteMatch();
 
-    const isImage =
-      file.isFile && isImageFile(file.name) && canReadContents && onImageClick;
+    const isImage = file.isFile && isImageFile(file.name) && canReadContents && onImageClick;
     const canClick =
-      (file.isFile && file.isEditable() && canReadContents) ||
-      (!file.isFile && canRead) ||
-      isImage;
+      (file.isFile && file.isEditable() && canReadContents) || (!file.isFile && canRead) || isImage;
 
     return canClick ? (
       <NavLink
         className={styles.details}
-        to={`${match.url}${file.isFile ? "/edit" : ""}#${encodePathSegments(
-          join(directory, file.name)
-        )}`}
+        to={`${match.url}${file.isFile ? '/edit' : ''}#${encodePathSegments(join(directory, file.name))}`}
         onClick={
           isImage
             ? (e) => {
@@ -66,13 +52,13 @@ const Clickable: React.FC<{ file: FileObject; onImageClick?: () => void }> =
     ) : (
       <div className={styles.details}>{children}</div>
     );
-  }, isEqual);
+  },
+  isEqual
+);
 
 const FileObjectRow = ({ file }: { file: FileObject }) => {
   const [showImageModal, setShowImageModal] = useState(false);
-  const directory = ServerContext.useStoreState(
-    (state) => state.files.directory
-  );
+  const directory = ServerContext.useStoreState((state) => state.files.directory);
   const fullPath = join(directory, file.name);
   const isImage = file.isFile && isImageFile(file.name);
 
@@ -91,10 +77,7 @@ const FileObjectRow = ({ file }: { file: FileObject }) => {
         }}
       >
         <SelectFileCheckbox name={file.name} />
-        <Clickable
-          file={file}
-          onImageClick={isImage ? () => setShowImageModal(true) : undefined}
-        >
+        <Clickable file={file} onImageClick={isImage ? () => setShowImageModal(true) : undefined}>
           <div css={tw`flex-none text-neutral-400 ml-6 mr-4 text-lg pl-3`}>
             {file.isFile ? (
               <FontAwesomeIcon
@@ -113,30 +96,17 @@ const FileObjectRow = ({ file }: { file: FileObject }) => {
             )}
           </div>
           <div css={tw`flex-1 truncate`}>{file.name}</div>
-          {file.isFile && (
-            <div css={tw`w-1/6 text-right mr-4 hidden sm:block`}>
-              {bytesToString(file.size)}
-            </div>
-          )}
-          <div
-            css={tw`w-1/5 text-right mr-4 hidden md:block`}
-            title={file.modifiedAt.toString()}
-          >
+          {file.isFile && <div css={tw`w-1/6 text-right mr-4 hidden sm:block`}>{bytesToString(file.size)}</div>}
+          <div css={tw`w-1/5 text-right mr-4 hidden md:block`} title={file.modifiedAt.toString()}>
             {Math.abs(differenceInHours(file.modifiedAt, new Date())) > 48
-              ? format(file.modifiedAt, "MMM do, yyyy h:mma")
+              ? format(file.modifiedAt, 'MMM do, yyyy h:mma')
               : formatDistanceToNow(file.modifiedAt, { addSuffix: true })}
           </div>
         </Clickable>
         <FileDropdownMenu file={file} />
       </div>
 
-      {isImage && (
-        <ImagePreviewModal
-          open={showImageModal}
-          onClose={() => setShowImageModal(false)}
-          file={fullPath}
-        />
-      )}
+      {isImage && <ImagePreviewModal open={showImageModal} onClose={() => setShowImageModal(false)} file={fullPath} />}
     </>
   );
 };
@@ -144,11 +114,7 @@ const FileObjectRow = ({ file }: { file: FileObject }) => {
 export default memo(FileObjectRow, (prevProps, nextProps) => {
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const { isArchiveType, isEditable, ...prevFile } = prevProps.file;
-  const {
-    isArchiveType: nextIsArchiveType,
-    isEditable: nextIsEditable,
-    ...nextFile
-  } = nextProps.file;
+  const { isArchiveType: nextIsArchiveType, isEditable: nextIsEditable, ...nextFile } = nextProps.file;
   /* eslint-enable @typescript-eslint/no-unused-vars */
 
   return isEqual(prevFile, nextFile);

--- a/resources/scripts/components/server/files/FileObjectRow.tsx
+++ b/resources/scripts/components/server/files/FileObjectRow.tsx
@@ -1,116 +1,164 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFileAlt, faFileArchive, faFileImport, faFolder, faImage } from '@fortawesome/free-solid-svg-icons';
-import { encodePathSegments } from '@/helpers';
-import { differenceInHours, format, formatDistanceToNow } from 'date-fns';
-import React, { memo, useState } from 'react';
-import { FileObject } from '@/api/server/files/loadDirectory';
-import FileDropdownMenu from '@/components/server/files/FileDropdownMenu';
-import { ServerContext } from '@/state/server';
-import { NavLink, useRouteMatch } from 'react-router-dom';
-import tw from 'twin.macro';
-import isEqual from 'react-fast-compare';
-import SelectFileCheckbox from '@/components/server/files/SelectFileCheckbox';
-import { usePermissions } from '@/plugins/usePermissions';
-import { join } from 'pathe';
-import { bytesToString } from '@/lib/formatters';
-import styles from './style.module.css';
-import ImagePreviewModal from '@/components/server/files/ImagePreviewModal';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faFileAlt,
+  faFileArchive,
+  faFileImport,
+  faFolder,
+  faImage,
+} from "@fortawesome/free-solid-svg-icons";
+import { encodePathSegments } from "@/helpers";
+import { differenceInHours, format, formatDistanceToNow } from "date-fns";
+import React, { memo, useState } from "react";
+import { FileObject } from "@/api/server/files/loadDirectory";
+import FileDropdownMenu from "@/components/server/files/FileDropdownMenu";
+import { ServerContext } from "@/state/server";
+import { NavLink, useRouteMatch } from "react-router-dom";
+import tw from "twin.macro";
+import isEqual from "react-fast-compare";
+import SelectFileCheckbox from "@/components/server/files/SelectFileCheckbox";
+import { usePermissions } from "@/plugins/usePermissions";
+import { join } from "pathe";
+import { bytesToString } from "@/lib/formatters";
+import styles from "./style.module.css";
+import ImagePreviewModal from "@/components/server/files/ImagePreviewModal";
 
-const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'];
+const IMAGE_EXTENSIONS = [
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "bmp",
+  "ico",
+];
 
 const isImageFile = (filename: string): boolean => {
-    const ext = filename.split('.').pop()?.toLowerCase();
-    return ext ? IMAGE_EXTENSIONS.includes(ext) : false;
+  const ext = filename.split(".").pop()?.toLowerCase();
+  return ext ? IMAGE_EXTENSIONS.includes(ext) : false;
 };
 
-const Clickable: React.FC<{ file: FileObject; onImageClick?: () => void }> = memo(({ file, children, onImageClick }) => {
-    const [canRead] = usePermissions(['file.read']);
-    const [canReadContents] = usePermissions(['file.read-content']);
-    const directory = ServerContext.useStoreState((state) => state.files.directory);
+const Clickable: React.FC<{ file: FileObject; onImageClick?: () => void }> =
+  memo(({ file, children, onImageClick }) => {
+    const [canRead] = usePermissions(["file.read"]);
+    const [canReadContents] = usePermissions(["file.read-content"]);
+    const directory = ServerContext.useStoreState(
+      (state) => state.files.directory
+    );
 
     const match = useRouteMatch();
 
-    const isImage = file.isFile && isImageFile(file.name) && canReadContents && onImageClick;
-    const canClick = (file.isFile && file.isEditable() && canReadContents) || (!file.isFile && canRead) || isImage;
+    const isImage =
+      file.isFile && isImageFile(file.name) && canReadContents && onImageClick;
+    const canClick =
+      (file.isFile && file.isEditable() && canReadContents) ||
+      (!file.isFile && canRead) ||
+      isImage;
 
     return canClick ? (
-        <NavLink
-            className={styles.details}
-            to={`${match.url}${file.isFile ? '/edit' : ''}#${encodePathSegments(join(directory, file.name))}`}
-            onClick={isImage ? (e) => {
+      <NavLink
+        className={styles.details}
+        to={`${match.url}${file.isFile ? "/edit" : ""}#${encodePathSegments(
+          join(directory, file.name)
+        )}`}
+        onClick={
+          isImage
+            ? (e) => {
                 e.preventDefault();
                 onImageClick();
-            } : undefined}
-        >
-            {children}
-        </NavLink>
+              }
+            : undefined
+        }
+      >
+        {children}
+      </NavLink>
     ) : (
-        <div className={styles.details}>{children}</div>
+      <div className={styles.details}>{children}</div>
     );
-}, isEqual);
+  }, isEqual);
 
 const FileObjectRow = ({ file }: { file: FileObject }) => {
-    const [showImageModal, setShowImageModal] = useState(false);
-    const directory = ServerContext.useStoreState((state) => state.files.directory);
-    const fullPath = join(directory, file.name);
-    const isImage = file.isFile && isImageFile(file.name);
+  const [showImageModal, setShowImageModal] = useState(false);
+  const directory = ServerContext.useStoreState(
+    (state) => state.files.directory
+  );
+  const fullPath = join(directory, file.name);
+  const isImage = file.isFile && isImageFile(file.name);
 
-    return (
-        <>
-            <div
-                className={styles.file_row}
-                key={file.name}
-                onContextMenu={(e) => {
-                    e.preventDefault();
-                    window.dispatchEvent(new CustomEvent(`pterodactyl:files:ctx:${file.key}`, { detail: e.clientX }));
-                }}
-            >
-                <SelectFileCheckbox name={file.name} />
-                <Clickable file={file} onImageClick={isImage ? () => setShowImageModal(true) : undefined}>
-                    <div css={tw`flex-none text-neutral-400 ml-6 mr-4 text-lg pl-3`}>
-                        {file.isFile ? (
-                            <FontAwesomeIcon
-                                icon={
-                                    isImage
-                                        ? faImage
-                                        : file.isSymlink
-                                            ? faFileImport
-                                            : file.isArchiveType()
-                                                ? faFileArchive
-                                                : faFileAlt
-                                }
-                            />
-                        ) : (
-                            <FontAwesomeIcon icon={faFolder} />
-                        )}
-                    </div>
-                    <div css={tw`flex-1 truncate`}>{file.name}</div>
-                    {file.isFile && <div css={tw`w-1/6 text-right mr-4 hidden sm:block`}>{bytesToString(file.size)}</div>}
-                    <div css={tw`w-1/5 text-right mr-4 hidden md:block`} title={file.modifiedAt.toString()}>
-                        {Math.abs(differenceInHours(file.modifiedAt, new Date())) > 48
-                            ? format(file.modifiedAt, 'MMM do, yyyy h:mma')
-                            : formatDistanceToNow(file.modifiedAt, { addSuffix: true })}
-                    </div>
-                </Clickable>
-                <FileDropdownMenu file={file} />
-            </div>
-
-            {isImage && (
-                <ImagePreviewModal
-                    open={showImageModal}
-                    onClose={() => setShowImageModal(false)}
-                    file={fullPath}
-                />
+  return (
+    <>
+      <div
+        className={styles.file_row}
+        key={file.name}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          window.dispatchEvent(
+            new CustomEvent(`pterodactyl:files:ctx:${file.key}`, {
+              detail: e.clientX,
+            })
+          );
+        }}
+      >
+        <SelectFileCheckbox name={file.name} />
+        <Clickable
+          file={file}
+          onImageClick={isImage ? () => setShowImageModal(true) : undefined}
+        >
+          <div css={tw`flex-none text-neutral-400 ml-6 mr-4 text-lg pl-3`}>
+            {file.isFile ? (
+              <FontAwesomeIcon
+                icon={
+                  isImage
+                    ? faImage
+                    : file.isSymlink
+                    ? faFileImport
+                    : file.isArchiveType()
+                    ? faFileArchive
+                    : faFileAlt
+                }
+              />
+            ) : (
+              <FontAwesomeIcon icon={faFolder} />
             )}
-        </>
-    );
+          </div>
+          <div css={tw`flex-1 truncate`}>{file.name}</div>
+          {file.isFile && (
+            <div css={tw`w-1/6 text-right mr-4 hidden sm:block`}>
+              {bytesToString(file.size)}
+            </div>
+          )}
+          <div
+            css={tw`w-1/5 text-right mr-4 hidden md:block`}
+            title={file.modifiedAt.toString()}
+          >
+            {Math.abs(differenceInHours(file.modifiedAt, new Date())) > 48
+              ? format(file.modifiedAt, "MMM do, yyyy h:mma")
+              : formatDistanceToNow(file.modifiedAt, { addSuffix: true })}
+          </div>
+        </Clickable>
+        <FileDropdownMenu file={file} />
+      </div>
+
+      {isImage && (
+        <ImagePreviewModal
+          open={showImageModal}
+          onClose={() => setShowImageModal(false)}
+          file={fullPath}
+        />
+      )}
+    </>
+  );
 };
 
 export default memo(FileObjectRow, (prevProps, nextProps) => {
-    /* eslint-disable @typescript-eslint/no-unused-vars */
-    const { isArchiveType, isEditable, ...prevFile } = prevProps.file;
-    const { isArchiveType: nextIsArchiveType, isEditable: nextIsEditable, ...nextFile } = nextProps.file;
-    /* eslint-enable @typescript-eslint/no-unused-vars */
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  const { isArchiveType, isEditable, ...prevFile } = prevProps.file;
+  const {
+    isArchiveType: nextIsArchiveType,
+    isEditable: nextIsEditable,
+    ...nextFile
+  } = nextProps.file;
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 
-    return isEqual(prevFile, nextFile);
+  return isEqual(prevFile, nextFile);
 });

--- a/resources/scripts/components/server/files/FileObjectRow.tsx
+++ b/resources/scripts/components/server/files/FileObjectRow.tsx
@@ -1,8 +1,8 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFileAlt, faFileArchive, faFileImport, faFolder } from '@fortawesome/free-solid-svg-icons';
+import { faFileAlt, faFileArchive, faFileImport, faFolder, faImage } from '@fortawesome/free-solid-svg-icons';
 import { encodePathSegments } from '@/helpers';
 import { differenceInHours, format, formatDistanceToNow } from 'date-fns';
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import { FileObject } from '@/api/server/files/loadDirectory';
 import FileDropdownMenu from '@/components/server/files/FileDropdownMenu';
 import { ServerContext } from '@/state/server';
@@ -14,57 +14,97 @@ import { usePermissions } from '@/plugins/usePermissions';
 import { join } from 'pathe';
 import { bytesToString } from '@/lib/formatters';
 import styles from './style.module.css';
+import ImagePreviewModal from '@/components/server/files/ImagePreviewModal';
 
-const Clickable: React.FC<{ file: FileObject }> = memo(({ file, children }) => {
+const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'];
+
+const isImageFile = (filename: string): boolean => {
+    const ext = filename.split('.').pop()?.toLowerCase();
+    return ext ? IMAGE_EXTENSIONS.includes(ext) : false;
+};
+
+const Clickable: React.FC<{ file: FileObject; onImageClick?: () => void }> = memo(({ file, children, onImageClick }) => {
     const [canRead] = usePermissions(['file.read']);
     const [canReadContents] = usePermissions(['file.read-content']);
     const directory = ServerContext.useStoreState((state) => state.files.directory);
 
     const match = useRouteMatch();
 
-    return (file.isFile && (!file.isEditable() || !canReadContents)) || (!file.isFile && !canRead) ? (
-        <div className={styles.details}>{children}</div>
-    ) : (
+    const isImage = file.isFile && isImageFile(file.name) && canReadContents && onImageClick;
+    const canClick = (file.isFile && file.isEditable() && canReadContents) || (!file.isFile && canRead) || isImage;
+
+    return canClick ? (
         <NavLink
             className={styles.details}
             to={`${match.url}${file.isFile ? '/edit' : ''}#${encodePathSegments(join(directory, file.name))}`}
+            onClick={isImage ? (e) => {
+                e.preventDefault();
+                onImageClick();
+            } : undefined}
         >
             {children}
         </NavLink>
+    ) : (
+        <div className={styles.details}>{children}</div>
     );
 }, isEqual);
 
-const FileObjectRow = ({ file }: { file: FileObject }) => (
-    <div
-        className={styles.file_row}
-        key={file.name}
-        onContextMenu={(e) => {
-            e.preventDefault();
-            window.dispatchEvent(new CustomEvent(`pterodactyl:files:ctx:${file.key}`, { detail: e.clientX }));
-        }}
-    >
-        <SelectFileCheckbox name={file.name} />
-        <Clickable file={file}>
-            <div css={tw`flex-none text-neutral-400 ml-6 mr-4 text-lg pl-3`}>
-                {file.isFile ? (
-                    <FontAwesomeIcon
-                        icon={file.isSymlink ? faFileImport : file.isArchiveType() ? faFileArchive : faFileAlt}
-                    />
-                ) : (
-                    <FontAwesomeIcon icon={faFolder} />
-                )}
+const FileObjectRow = ({ file }: { file: FileObject }) => {
+    const [showImageModal, setShowImageModal] = useState(false);
+    const directory = ServerContext.useStoreState((state) => state.files.directory);
+    const fullPath = join(directory, file.name);
+    const isImage = file.isFile && isImageFile(file.name);
+
+    return (
+        <>
+            <div
+                className={styles.file_row}
+                key={file.name}
+                onContextMenu={(e) => {
+                    e.preventDefault();
+                    window.dispatchEvent(new CustomEvent(`pterodactyl:files:ctx:${file.key}`, { detail: e.clientX }));
+                }}
+            >
+                <SelectFileCheckbox name={file.name} />
+                <Clickable file={file} onImageClick={isImage ? () => setShowImageModal(true) : undefined}>
+                    <div css={tw`flex-none text-neutral-400 ml-6 mr-4 text-lg pl-3`}>
+                        {file.isFile ? (
+                            <FontAwesomeIcon
+                                icon={
+                                    isImage
+                                        ? faImage
+                                        : file.isSymlink
+                                            ? faFileImport
+                                            : file.isArchiveType()
+                                                ? faFileArchive
+                                                : faFileAlt
+                                }
+                            />
+                        ) : (
+                            <FontAwesomeIcon icon={faFolder} />
+                        )}
+                    </div>
+                    <div css={tw`flex-1 truncate`}>{file.name}</div>
+                    {file.isFile && <div css={tw`w-1/6 text-right mr-4 hidden sm:block`}>{bytesToString(file.size)}</div>}
+                    <div css={tw`w-1/5 text-right mr-4 hidden md:block`} title={file.modifiedAt.toString()}>
+                        {Math.abs(differenceInHours(file.modifiedAt, new Date())) > 48
+                            ? format(file.modifiedAt, 'MMM do, yyyy h:mma')
+                            : formatDistanceToNow(file.modifiedAt, { addSuffix: true })}
+                    </div>
+                </Clickable>
+                <FileDropdownMenu file={file} />
             </div>
-            <div css={tw`flex-1 truncate`}>{file.name}</div>
-            {file.isFile && <div css={tw`w-1/6 text-right mr-4 hidden sm:block`}>{bytesToString(file.size)}</div>}
-            <div css={tw`w-1/5 text-right mr-4 hidden md:block`} title={file.modifiedAt.toString()}>
-                {Math.abs(differenceInHours(file.modifiedAt, new Date())) > 48
-                    ? format(file.modifiedAt, 'MMM do, yyyy h:mma')
-                    : formatDistanceToNow(file.modifiedAt, { addSuffix: true })}
-            </div>
-        </Clickable>
-        <FileDropdownMenu file={file} />
-    </div>
-);
+
+            {isImage && (
+                <ImagePreviewModal
+                    open={showImageModal}
+                    onClose={() => setShowImageModal(false)}
+                    file={fullPath}
+                />
+            )}
+        </>
+    );
+};
 
 export default memo(FileObjectRow, (prevProps, nextProps) => {
     /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/resources/scripts/components/server/files/FileObjectRow.tsx
+++ b/resources/scripts/components/server/files/FileObjectRow.tsx
@@ -1,19 +1,13 @@
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faFileAlt,
-  faFileArchive,
-  faFileImport,
-  faFolder,
-  faImage,
-} from "@fortawesome/free-solid-svg-icons";
-import { encodePathSegments } from "@/helpers";
-import { differenceInHours, format, formatDistanceToNow } from "date-fns";
-import React, { memo, useState } from "react";
-import { FileObject } from "@/api/server/files/loadDirectory";
-import FileDropdownMenu from "@/components/server/files/FileDropdownMenu";
-import { ServerContext } from "@/state/server";
-import { NavLink, useRouteMatch } from "react-router-dom";
-import tw from "twin.macro";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faFileAlt, faFileArchive, faFileImport, faFolder, faImage } from '@fortawesome/free-solid-svg-icons';
+import { encodePathSegments } from '@/helpers';
+import { differenceInHours, format, formatDistanceToNow } from 'date-fns';
+import React, { memo, useState } from 'react';
+import { FileObject } from '@/api/server/files/loadDirectory';
+import FileDropdownMenu from '@/components/server/files/FileDropdownMenu';
+import { ServerContext } from '@/state/server';
+import { NavLink, useRouteMatch } from 'react-router-dom';
+import tw from 'twin.macro';
 import isEqual from "react-fast-compare";
 import SelectFileCheckbox from "@/components/server/files/SelectFileCheckbox";
 import { usePermissions } from "@/plugins/usePermissions";
@@ -28,9 +22,6 @@ const IMAGE_EXTENSIONS = [
   "jpeg",
   "gif",
   "webp",
-  "svg",
-  "bmp",
-  "ico",
 ];
 
 const isImageFile = (filename: string): boolean => {

--- a/resources/scripts/components/server/files/ImagePreviewModal.tsx
+++ b/resources/scripts/components/server/files/ImagePreviewModal.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Dialog } from '@/components/elements/dialog';
 import { ServerContext } from '@/state/server';
 import tw from 'twin.macro';
 import { httpErrorToHuman } from '@/api/http';
@@ -31,10 +30,7 @@ const ImagePreviewContent = ({ file }: Props) => {
 
                 if (ext === 'jpg' || ext === 'jpeg') mimeType = 'image/jpeg';
                 else if (ext === 'gif') mimeType = 'image/gif';
-                else if (ext === 'svg') mimeType = 'image/svg+xml';
                 else if (ext === 'webp') mimeType = 'image/webp';
-                else if (ext === 'bmp') mimeType = 'image/bmp';
-                else if (ext === 'ico') mimeType = 'image/x-icon';
 
                 const blob = new Blob([response.data], { type: mimeType });
                 const url = URL.createObjectURL(blob);

--- a/resources/scripts/components/server/files/ImagePreviewModal.tsx
+++ b/resources/scripts/components/server/files/ImagePreviewModal.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { Dialog } from '@/components/elements/dialog';
+import { ServerContext } from '@/state/server';
+import tw from 'twin.macro';
+import { httpErrorToHuman } from '@/api/http';
+import http from '@/api/http';
+import Spinner from '@/components/elements/Spinner';
+import asDialog from '@/hoc/asDialog';
+
+interface Props {
+    file: string;
+}
+
+const ImagePreviewContent = ({ file }: Props) => {
+    const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [imageUrl, setImageUrl] = useState<string | null>(null);
+
+    useEffect(() => {
+        setLoading(true);
+        setError(null);
+
+        http.get(`/api/client/servers/${uuid}/files/contents`, {
+            params: { file },
+            responseType: 'blob',
+        })
+            .then((response) => {
+                const ext = file.split('.').pop()?.toLowerCase();
+                let mimeType = 'image/png';
+
+                if (ext === 'jpg' || ext === 'jpeg') mimeType = 'image/jpeg';
+                else if (ext === 'gif') mimeType = 'image/gif';
+                else if (ext === 'svg') mimeType = 'image/svg+xml';
+                else if (ext === 'webp') mimeType = 'image/webp';
+                else if (ext === 'bmp') mimeType = 'image/bmp';
+                else if (ext === 'ico') mimeType = 'image/x-icon';
+
+                const blob = new Blob([response.data], { type: mimeType });
+                const url = URL.createObjectURL(blob);
+                setImageUrl(url);
+                setLoading(false);
+            })
+            .catch((err) => {
+                console.error(err);
+                setError(httpErrorToHuman(err));
+                setLoading(false);
+            });
+
+        return () => {
+            if (imageUrl) {
+                URL.revokeObjectURL(imageUrl);
+            }
+        };
+    }, [file, uuid]);
+
+    if (loading) {
+        return (
+            <div css={tw`flex items-center justify-center py-12`}>
+                <Spinner size="large" />
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div css={tw`p-4 bg-red-500/10 border border-red-500 rounded text-red-400 text-sm`}>
+                <p css={tw`font-semibold mb-1`}>Error loading image</p>
+                <p>{error}</p>
+            </div>
+        );
+    }
+
+    if (!imageUrl) {
+        return null;
+    }
+
+    return (
+        <div css={tw`flex flex-col items-center mt-4`}>
+            <p css={tw`text-neutral-400 text-xs mb-4 truncate max-w-full font-mono px-2`}>{file}</p>
+            <div css={tw`w-full flex justify-center items-center bg-neutral-900 rounded-lg p-6`}>
+                <img
+                    src={imageUrl}
+                    alt={file}
+                    css={tw`max-w-full h-auto rounded shadow-lg`}
+                    style={{ maxHeight: '70vh' }}
+                />
+            </div>
+        </div>
+    );
+};
+
+const ImagePreviewModal = asDialog({
+    title: 'Image Preview',
+})(ImagePreviewContent);
+
+export default ImagePreviewModal;


### PR DESCRIPTION
Currently, images in the Pterodactyl file manager cannot be viewed directly.
This pull request adds support for previewing image files by opening them in a modal when clicked.

The new behavior improves usability by allowing users to quickly view image contents without downloading them or leaving the file manager. The implementation is lightweight and integrates seamlessly with the existing UI.

Preview:
<img width="1024" height="544" alt="image" src="https://github.com/user-attachments/assets/5964becb-ee77-4fce-a987-1dec072ccfb7" />
<img width="894" height="644" alt="image" src="https://github.com/user-attachments/assets/11a1469a-8599-483a-89ef-1da690d2f3a3" />
(Idea taken from an add-on from builtbybit)