### PR TITLE
Change selectOnClose option to false in allocation view

### DIFF
--- a/resources/views/admin/nodes/view/allocation.blade.php
+++ b/resources/views/admin/nodes/view/allocation.blade.php
@@ -184,7 +184,7 @@
     $('#pAllocationIP').select2({
         tags: true,
         maximumSelectionLength: 1,
-        selectOnClose: true,
+        selectOnClose: false,
         tokenSeparators: [',', ' '],
     });
 


### PR DESCRIPTION
I don't know what you think, but I never liked that when you remove an IP, another one is added when you exit the input. Because maybe I'm going to look for it or I'll just exit and it will be added again...