### PR TITLE
Disconnect SFTP/Websocket when a user is removed as a subuser

### DIFF
--- a/app/Repositories/Wings/DaemonRepository.php
+++ b/app/Repositories/Wings/DaemonRepository.php
@@ -8,10 +8,6 @@ use Webmozart\Assert\Assert;
 use Pterodactyl\Models\Server;
 use Illuminate\Contracts\Foundation\Application;
 
-/**
- * @method \Pterodactyl\Repositories\Wings\DaemonRepository setNode(\Pterodactyl\Models\Node $node)
- * @method \Pterodactyl\Repositories\Wings\DaemonRepository setServer(\Pterodactyl\Models\Server $server)
- */
 abstract class DaemonRepository
 {
     protected ?Server $server;

--- a/app/Repositories/Wings/DaemonRevocationRepository.php
+++ b/app/Repositories/Wings/DaemonRevocationRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Pterodactyl\Repositories\Wings;
+
+use GuzzleHttp\Exception\TransferException;
+use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
+
+class DaemonRevocationRepository extends DaemonRepository
+{
+    /**
+     * Deauthorizes a user (disconnects websockets and SFTP) on the Wings instance for
+     * the provided servers. If no servers are provided, the user is deauthorized on all
+     * servers on the instance.
+     *
+     * @param string[] $servers
+     */
+    public function deauthorize(string $user, array $servers = []): void
+    {
+        try {
+            $this->getHttpClient()->post('/api/deauthorize-user', [
+                'json' => ['user' => $user, 'servers' => $servers],
+            ]);
+        } catch (TransferException $exception) {
+            throw new DaemonConnectionException($exception);
+        }
+    }
+}

--- a/app/Repositories/Wings/DaemonServerRepository.php
+++ b/app/Repositories/Wings/DaemonServerRepository.php
@@ -131,6 +131,9 @@ class DaemonServerRepository extends DaemonRepository
      * make it easier to revoke tokens on the fly. This ensures that the JTI key is formatted
      * correctly and avoids any costly mistakes in the codebase.
      *
+     * @deprecated
+     * @see \Pterodactyl\Repositories\Wings\DaemonRevocationRepository::deauthorize()
+     *
      * @throws DaemonConnectionException
      */
     public function revokeUserJTI(int $id): void

--- a/app/Services/Servers/DetailsModificationService.php
+++ b/app/Services/Servers/DetailsModificationService.php
@@ -7,6 +7,7 @@ use Pterodactyl\Models\Server;
 use Illuminate\Database\ConnectionInterface;
 use Pterodactyl\Traits\Services\ReturnsUpdatedModels;
 use Pterodactyl\Repositories\Wings\DaemonServerRepository;
+use Pterodactyl\Repositories\Wings\DaemonRevocationRepository;
 use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
 
 class DetailsModificationService
@@ -16,8 +17,11 @@ class DetailsModificationService
     /**
      * DetailsModificationService constructor.
      */
-    public function __construct(private ConnectionInterface $connection, private DaemonServerRepository $serverRepository)
-    {
+    public function __construct(
+        private ConnectionInterface $connection,
+        private DaemonServerRepository $serverRepository,
+        private DaemonRevocationRepository $revocationRepository,
+    ) {
     }
 
     /**
@@ -28,7 +32,7 @@ class DetailsModificationService
     public function handle(Server $server, array $data): Server
     {
         return $this->connection->transaction(function () use ($data, $server) {
-            $owner = $server->owner_id;
+            $original = $server->user;
 
             $server->forceFill([
                 'external_id' => Arr::get($data, 'external_id'),
@@ -40,9 +44,12 @@ class DetailsModificationService
             // If the owner_id value is changed we need to revoke any tokens that exist for the server
             // on the Wings instance so that the old owner no longer has any permission to access the
             // websockets.
-            if ($server->owner_id !== $owner) {
+            if (! $server->refresh()->user->is($original)) {
                 try {
-                    $this->serverRepository->setServer($server)->revokeUserJTI($owner);
+                    $this->revocationRepository->setNode($server->node)->deauthorize(
+                        $original->uuid,
+                        [$server->uuid],
+                    );
                 } catch (DaemonConnectionException $exception) {
                     // Do nothing. A failure here is not ideal, but it is likely to be caused by Wings
                     // being offline, or in an entirely broken state. Remember, these tokens reset every


### PR DESCRIPTION
This work is in association with https://github.com/pterodactyl/wings/pull/288 and resolves a security issue where SFTP & Websocket connections were not revoked when a subuser was deleted, or when their permissions changed for file access.

https://github.com/pterodactyl/panel/security/advisories/GHSA-8c39-xppg-479c