### PR TITLE
Change server link button to open in new tab

### DIFF
--- a/resources/views/admin/servers/index.blade.php
+++ b/resources/views/admin/servers/index.blade.php
@@ -61,7 +61,7 @@
                                     @endif
                                 </td>
                                 <td class="text-center">
-                                    <a class="btn btn-xs btn-default" href="/server/{{ $server->uuidShort }}"><i class="fa fa-wrench"></i></a>
+                                    <a class="btn btn-xs btn-default" target="_blank" href="/server/{{ $server->uuidShort }}"><i class="fa fa-external-link"></i></a>
                                 </td>
                             </tr>
                         @endforeach


### PR DESCRIPTION
This is better, because now you have a wrench and it's not very clear what it does if you don't click on it.

now:
<img width="1558" height="113" alt="image" src="https://github.com/user-attachments/assets/0ae9bbc7-bbc2-407a-8a6f-3517b08ecd98" />
with the updated:
<img width="1556" height="105" alt="image" src="https://github.com/user-attachments/assets/d7c08b5e-aeb8-4043-9eb4-9a8121f3217a" />