### PR TITLE
Scope the remote node token to limit the servers it can manage for backups/transfers

### DIFF
--- a/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
@@ -49,7 +49,7 @@ class BackupRemoteUploadController extends Controller
         // from messing with backups that they don't own.
         $server = $model->server;
         if ($server->node_id !== $node->id) {
-            throw new HttpForbiddenException('You do not have permission to access that backup.');
+            throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
         }
 
         // Prevent backups that have already been completed from trying to

--- a/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
@@ -45,7 +45,7 @@ class BackupStatusController extends Controller
         /** @var \Pterodactyl\Models\Server $server */
         $server = $model->server;
         if ($server->node_id !== $node->id) {
-            throw new HttpForbiddenException('You do not have permission to access that backup.');
+            throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
         }
 
         if ($model->is_successful) {
@@ -94,6 +94,11 @@ class BackupStatusController extends Controller
     {
         /** @var Backup $model */
         $model = Backup::query()->where('uuid', $backup)->firstOrFail();
+
+        $node = $request->attributes->get('node');
+        if (! $model->server->node->is($node)) {
+            throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
+        }
 
         $model->server->update(['status' => null]);
 

--- a/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
@@ -40,7 +40,16 @@ class ServerDetailsController extends Controller
         Assert::isInstanceOf($node = $request->attributes->get('node'), Node::class);
 
         $server = $this->repository->getByUuid($uuid);
-        if (! $server->node->is($node)) {
+        $transfer = $server->transfer;
+
+        // If the server is being transferred allow either node to request information about
+        // the server. If the server is not being transferred only the target node is allowed
+        // to fetch these details.
+        $valid = $transfer
+            ? $node->id === $transfer->old_node || $node->id === $transfer->new_node
+            : $node->id === $server->node_id;
+
+        if (! $valid) {
             throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
         }
 

--- a/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
@@ -3,12 +3,15 @@
 namespace Pterodactyl\Http\Controllers\Api\Remote\Servers;
 
 use Illuminate\Http\Request;
+use Pterodactyl\Models\Node;
+use Webmozart\Assert\Assert;
 use Pterodactyl\Models\Server;
 use Illuminate\Http\JsonResponse;
 use Pterodactyl\Facades\Activity;
 use Illuminate\Database\ConnectionInterface;
 use Pterodactyl\Http\Controllers\Controller;
 use Pterodactyl\Services\Eggs\EggConfigurationService;
+use Pterodactyl\Exceptions\Http\HttpForbiddenException;
 use Pterodactyl\Repositories\Eloquent\ServerRepository;
 use Pterodactyl\Http\Resources\Wings\ServerConfigurationCollection;
 use Pterodactyl\Services\Servers\ServerConfigurationStructureService;
@@ -34,7 +37,12 @@ class ServerDetailsController extends Controller
      */
     public function __invoke(Request $request, string $uuid): JsonResponse
     {
+        Assert::isInstanceOf($node = $request->attributes->get('node'), Node::class);
+
         $server = $this->repository->getByUuid($uuid);
+        if (! $server->node->is($node)) {
+            throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
+        }
 
         return new JsonResponse([
             'settings' => $this->configurationStructureService->handle($server),
@@ -47,7 +55,7 @@ class ServerDetailsController extends Controller
      */
     public function list(Request $request): ServerConfigurationCollection
     {
-        /** @var \Pterodactyl\Models\Node $node */
+        /** @var Node $node */
         $node = $request->attributes->get('node');
 
         // Avoid run-away N+1 SQL queries by preloading the relationships that are used

--- a/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerInstallController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Response;
 use Pterodactyl\Models\Server;
 use Illuminate\Http\JsonResponse;
 use Pterodactyl\Http\Controllers\Controller;
+use Pterodactyl\Exceptions\Http\HttpForbiddenException;
 use Pterodactyl\Repositories\Eloquent\ServerRepository;
 use Pterodactyl\Events\Server\Installed as ServerInstalled;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
@@ -32,6 +33,10 @@ class ServerInstallController extends Controller
         $server = $this->repository->getByUuid($uuid);
         $egg = $server->egg;
 
+        if (! $server->node->is($request->attributes->get('node'))) {
+            throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
+        }
+
         return new JsonResponse([
             'container_image' => $egg->copy_script_container,
             'entrypoint' => $egg->copy_script_entry,
@@ -49,6 +54,10 @@ class ServerInstallController extends Controller
     {
         $server = $this->repository->getByUuid($uuid);
         $status = null;
+
+        if (! $server->node->is($request->attributes->get('node'))) {
+            throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
+        }
 
         // Make sure the type of failure is accurate
         if (!$request->boolean('successful')) {

--- a/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
@@ -40,6 +40,8 @@ class ServerTransferController extends Controller
             throw new ConflictHttpException('Server is not being transferred.');
         }
 
+        // Either node can tell the panel that the transfer has failed. Only the new node
+        // can tell the panel that it was successful.
         if (! $server->node->is($transfer->newNode) && ! $server->node->is($transfer->oldNode)) {
             throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
         }
@@ -60,7 +62,9 @@ class ServerTransferController extends Controller
             throw new ConflictHttpException('Server is not being transferred.');
         }
 
-        if (! $server->node->is($transfer->newNode) && ! $server->node->is($transfer->oldNode)) {
+        // Only the new node communicates a successful state to the panel, so we should
+        // not allow the old node to hit this endpoint.
+        if (! $server->node->is($transfer->newNode)) {
             throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
         }
 

--- a/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Log;
 use Pterodactyl\Models\ServerTransfer;
 use Illuminate\Database\ConnectionInterface;
 use Pterodactyl\Http\Controllers\Controller;
+use Pterodactyl\Exceptions\Http\HttpForbiddenException;
 use Pterodactyl\Repositories\Eloquent\ServerRepository;
 use Pterodactyl\Repositories\Wings\DaemonServerRepository;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
@@ -39,6 +40,10 @@ class ServerTransferController extends Controller
             throw new ConflictHttpException('Server is not being transferred.');
         }
 
+        if (! $server->node->is($transfer->newNode) && ! $server->node->is($transfer->oldNode)) {
+            throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
+        }
+
         return $this->processFailedTransfer($transfer);
     }
 
@@ -53,6 +58,10 @@ class ServerTransferController extends Controller
         $transfer = $server->transfer;
         if (is_null($transfer)) {
             throw new ConflictHttpException('Server is not being transferred.');
+        }
+
+        if (! $server->node->is($transfer->newNode) && ! $server->node->is($transfer->oldNode)) {
+            throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
         }
 
         /** @var \Pterodactyl\Models\Server $server */

--- a/routes/api-remote.php
+++ b/routes/api-remote.php
@@ -14,9 +14,6 @@ Route::group(['prefix' => '/servers/{uuid}'], function () {
     Route::get('/', Remote\Servers\ServerDetailsController::class);
     Route::get('/install', [Remote\Servers\ServerInstallController::class, 'index']);
     Route::post('/install', [Remote\Servers\ServerInstallController::class, 'store']);
-
-    Route::get('/transfer/failure', [Remote\Servers\ServerTransferController::class, 'failure']);
-    Route::get('/transfer/success', [Remote\Servers\ServerTransferController::class, 'success']);
     Route::post('/transfer/failure', [Remote\Servers\ServerTransferController::class, 'failure']);
     Route::post('/transfer/success', [Remote\Servers\ServerTransferController::class, 'success']);
 });


### PR DESCRIPTION
Improves the security posture of things more by limiting the servers that a node can even communicate about with the Panel.