### PR TITLE
Update most buttons to the modern Button component

### DIFF
--- a/resources/scripts/components/dashboard/ApiKeyModal.tsx
+++ b/resources/scripts/components/dashboard/ApiKeyModal.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import tw from 'twin.macro';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import asModal from '@/hoc/asModal';
 import ModalContext from '@/context/ModalContext';
 import CopyOnClick from '@/components/elements/CopyOnClick';

--- a/resources/scripts/components/dashboard/ApiKeyModal.tsx
+++ b/resources/scripts/components/dashboard/ApiKeyModal.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import tw from 'twin.macro';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import asModal from '@/hoc/asModal';
 import ModalContext from '@/context/ModalContext';
 import CopyOnClick from '@/components/elements/CopyOnClick';

--- a/resources/scripts/components/dashboard/forms/CreateApiKeyForm.tsx
+++ b/resources/scripts/components/dashboard/forms/CreateApiKeyForm.tsx
@@ -9,7 +9,7 @@ import { httpErrorToHuman } from '@/api/http';
 import SpinnerOverlay from '@/components/elements/SpinnerOverlay';
 import { ApiKey } from '@/api/account/getApiKeys';
 import tw from 'twin.macro';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import Input, { Textarea } from '@/components/elements/Input';
 import styled from 'styled-components/macro';
 import ApiKeyModal from '@/components/dashboard/ApiKeyModal';

--- a/resources/scripts/components/dashboard/forms/CreateApiKeyForm.tsx
+++ b/resources/scripts/components/dashboard/forms/CreateApiKeyForm.tsx
@@ -9,7 +9,7 @@ import { httpErrorToHuman } from '@/api/http';
 import SpinnerOverlay from '@/components/elements/SpinnerOverlay';
 import { ApiKey } from '@/api/account/getApiKeys';
 import tw from 'twin.macro';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import Input, { Textarea } from '@/components/elements/Input';
 import styled from 'styled-components/macro';
 import ApiKeyModal from '@/components/dashboard/ApiKeyModal';

--- a/resources/scripts/components/dashboard/ssh/CreateSSHKeyForm.tsx
+++ b/resources/scripts/components/dashboard/ssh/CreateSSHKeyForm.tsx
@@ -4,7 +4,7 @@ import { object, string } from 'yup';
 import FormikFieldWrapper from '@/components/elements/FormikFieldWrapper';
 import SpinnerOverlay from '@/components/elements/SpinnerOverlay';
 import tw from 'twin.macro';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import Input, { Textarea } from '@/components/elements/Input';
 import styled from 'styled-components/macro';
 import { useFlashKey } from '@/plugins/useFlash';

--- a/resources/scripts/components/dashboard/ssh/CreateSSHKeyForm.tsx
+++ b/resources/scripts/components/dashboard/ssh/CreateSSHKeyForm.tsx
@@ -4,7 +4,7 @@ import { object, string } from 'yup';
 import FormikFieldWrapper from '@/components/elements/FormikFieldWrapper';
 import SpinnerOverlay from '@/components/elements/SpinnerOverlay';
 import tw from 'twin.macro';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import Input, { Textarea } from '@/components/elements/Input';
 import styled from 'styled-components/macro';
 import { useFlashKey } from '@/plugins/useFlash';

--- a/resources/scripts/components/server/backups/CreateBackupButton.tsx
+++ b/resources/scripts/components/server/backups/CreateBackupButton.tsx
@@ -7,7 +7,7 @@ import FormikFieldWrapper from '@/components/elements/FormikFieldWrapper';
 import useFlash from '@/plugins/useFlash';
 import createServerBackup from '@/api/server/backups/createServerBackup';
 import FlashMessageRender from '@/components/FlashMessageRender';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import tw from 'twin.macro';
 import { Textarea } from '@/components/elements/Input';
 import getServerBackups from '@/api/swr/getServerBackups';

--- a/resources/scripts/components/server/backups/CreateBackupButton.tsx
+++ b/resources/scripts/components/server/backups/CreateBackupButton.tsx
@@ -7,7 +7,7 @@ import FormikFieldWrapper from '@/components/elements/FormikFieldWrapper';
 import useFlash from '@/plugins/useFlash';
 import createServerBackup from '@/api/server/backups/createServerBackup';
 import FlashMessageRender from '@/components/FlashMessageRender';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import tw from 'twin.macro';
 import { Textarea } from '@/components/elements/Input';
 import getServerBackups from '@/api/swr/getServerBackups';

--- a/resources/scripts/components/server/features/GSLTokenModalFeature.tsx
+++ b/resources/scripts/components/server/features/GSLTokenModalFeature.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { ServerContext } from '@/state/server';
 import Modal from '@/components/elements/Modal';
 import tw from 'twin.macro';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import FlashMessageRender from '@/components/FlashMessageRender';
 import useFlash from '@/plugins/useFlash';
 import { SocketEvent, SocketRequest } from '@/components/server/events';

--- a/resources/scripts/components/server/features/GSLTokenModalFeature.tsx
+++ b/resources/scripts/components/server/features/GSLTokenModalFeature.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { ServerContext } from '@/state/server';
 import Modal from '@/components/elements/Modal';
 import tw from 'twin.macro';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import FlashMessageRender from '@/components/FlashMessageRender';
 import useFlash from '@/plugins/useFlash';
 import { SocketEvent, SocketRequest } from '@/components/server/events';

--- a/resources/scripts/components/server/files/ChmodFileModal.tsx
+++ b/resources/scripts/components/server/files/ChmodFileModal.tsx
@@ -7,7 +7,7 @@ import Field from '@/components/elements/Field';
 import chmodFiles from '@/api/server/files/chmodFiles';
 import { ServerContext } from '@/state/server';
 import tw from 'twin.macro';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import useFlash from '@/plugins/useFlash';
 
 interface FormikValues {

--- a/resources/scripts/components/server/files/ChmodFileModal.tsx
+++ b/resources/scripts/components/server/files/ChmodFileModal.tsx
@@ -7,7 +7,7 @@ import Field from '@/components/elements/Field';
 import chmodFiles from '@/api/server/files/chmodFiles';
 import { ServerContext } from '@/state/server';
 import tw from 'twin.macro';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import useFlash from '@/plugins/useFlash';
 
 interface FormikValues {

--- a/resources/scripts/components/server/files/FileEditContainer.tsx
+++ b/resources/scripts/components/server/files/FileEditContainer.tsx
@@ -11,7 +11,7 @@ import FlashMessageRender from '@/components/FlashMessageRender';
 import PageContentBlock from '@/components/elements/PageContentBlock';
 import { ServerError } from '@/components/elements/ScreenBlock';
 import tw from 'twin.macro';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import Select from '@/components/elements/Select';
 import modes from '@/modes';
 import useFlash from '@/plugins/useFlash';

--- a/resources/scripts/components/server/files/FileEditContainer.tsx
+++ b/resources/scripts/components/server/files/FileEditContainer.tsx
@@ -11,7 +11,7 @@ import FlashMessageRender from '@/components/FlashMessageRender';
 import PageContentBlock from '@/components/elements/PageContentBlock';
 import { ServerError } from '@/components/elements/ScreenBlock';
 import tw from 'twin.macro';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import Select from '@/components/elements/Select';
 import modes from '@/modes';
 import useFlash from '@/plugins/useFlash';

--- a/resources/scripts/components/server/files/FileNameModal.tsx
+++ b/resources/scripts/components/server/files/FileNameModal.tsx
@@ -6,7 +6,7 @@ import Field from '@/components/elements/Field';
 import { ServerContext } from '@/state/server';
 import { join } from 'pathe';
 import tw from 'twin.macro';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 
 type Props = RequiredModalProps & {
     onFileNamed: (name: string) => void;

--- a/resources/scripts/components/server/files/FileNameModal.tsx
+++ b/resources/scripts/components/server/files/FileNameModal.tsx
@@ -6,7 +6,7 @@ import Field from '@/components/elements/Field';
 import { ServerContext } from '@/state/server';
 import { join } from 'pathe';
 import tw from 'twin.macro';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 
 type Props = RequiredModalProps & {
     onFileNamed: (name: string) => void;

--- a/resources/scripts/components/server/files/RenameFileModal.tsx
+++ b/resources/scripts/components/server/files/RenameFileModal.tsx
@@ -6,7 +6,7 @@ import { join } from 'pathe';
 import renameFiles from '@/api/server/files/renameFiles';
 import { ServerContext } from '@/state/server';
 import tw from 'twin.macro';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import useFileManagerSwr from '@/plugins/useFileManagerSwr';
 import useFlash from '@/plugins/useFlash';
 

--- a/resources/scripts/components/server/files/RenameFileModal.tsx
+++ b/resources/scripts/components/server/files/RenameFileModal.tsx
@@ -6,7 +6,7 @@ import { join } from 'pathe';
 import renameFiles from '@/api/server/files/renameFiles';
 import { ServerContext } from '@/state/server';
 import tw from 'twin.macro';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import useFileManagerSwr from '@/plugins/useFileManagerSwr';
 import useFlash from '@/plugins/useFlash';
 

--- a/resources/scripts/components/server/network/NetworkContainer.tsx
+++ b/resources/scripts/components/server/network/NetworkContainer.tsx
@@ -4,7 +4,7 @@ import { useFlashKey } from '@/plugins/useFlash';
 import ServerContentBlock from '@/components/elements/ServerContentBlock';
 import { ServerContext } from '@/state/server';
 import AllocationRow from '@/components/server/network/AllocationRow';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import createServerAllocation from '@/api/server/network/createServerAllocation';
 import tw from 'twin.macro';
 import Can from '@/components/elements/Can';

--- a/resources/scripts/components/server/network/NetworkContainer.tsx
+++ b/resources/scripts/components/server/network/NetworkContainer.tsx
@@ -4,7 +4,7 @@ import { useFlashKey } from '@/plugins/useFlash';
 import ServerContentBlock from '@/components/elements/ServerContentBlock';
 import { ServerContext } from '@/state/server';
 import AllocationRow from '@/components/server/network/AllocationRow';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import createServerAllocation from '@/api/server/network/createServerAllocation';
 import tw from 'twin.macro';
 import Can from '@/components/elements/Can';

--- a/resources/scripts/components/server/users/EditSubuserModal.tsx
+++ b/resources/scripts/components/server/users/EditSubuserModal.tsx
@@ -12,7 +12,7 @@ import Can from '@/components/elements/Can';
 import { usePermissions } from '@/plugins/usePermissions';
 import { useDeepCompareMemo } from '@/plugins/useDeepCompareMemo';
 import tw from 'twin.macro';
-import Button from '@/components/elements/Button';
+import { Button } from "@/components/elements/button/index";
 import PermissionTitleBox from '@/components/server/users/PermissionTitleBox';
 import asModal from '@/hoc/asModal';
 import PermissionRow from '@/components/server/users/PermissionRow';

--- a/resources/scripts/components/server/users/EditSubuserModal.tsx
+++ b/resources/scripts/components/server/users/EditSubuserModal.tsx
@@ -12,7 +12,7 @@ import Can from '@/components/elements/Can';
 import { usePermissions } from '@/plugins/usePermissions';
 import { useDeepCompareMemo } from '@/plugins/useDeepCompareMemo';
 import tw from 'twin.macro';
-import { Button } from "@/components/elements/button/index";
+import { Button } from '@/components/elements/button/index';
 import PermissionTitleBox from '@/components/server/users/PermissionTitleBox';
 import asModal from '@/hoc/asModal';
 import PermissionRow from '@/components/server/users/PermissionRow';


### PR DESCRIPTION
Currently, several components are still using the old button (`import Button from '@/components/elements/Button'`). This PR aims to replace most of these buttons with the newer version, to ensure visual and functional consistency across the panel.

Files currently using the old button:

```
resources/scripts/components/auth/LoginContainer.tsx
resources/scripts/components/auth/ResetPasswordContainer.tsx
resources/scripts/components/auth/LoginCheckpointContainer.tsx
resources/scripts/components/auth/ForgotPasswordContainer.tsx
resources/scripts/components/elements/ScreenBlock.tsx
resources/scripts/components/elements/ConfirmationModal.tsx
resources/scripts/components/elements/Pagination.tsx
resources/scripts/components/server/features/PIDLimitModalFeature.tsx
resources/scripts/components/server/features/JavaVersionModalFeature.tsx
resources/scripts/components/server/features/SteamDiskSpaceFeature.tsx
resources/scripts/components/server/features/eula/EulaModalFeature.tsx
resources/scripts/components/server/databases/DatabaseRow.tsx
resources/scripts/components/server/databases/RotatePasswordButton.tsx
resources/scripts/components/server/databases/CreateDatabaseButton.tsx
```

⚠️ **Note:**
There are other components that still use it. If anyone wants to contribute and update the remaining buttons, I would greatly appreciate it! I may change the ones that are missing when I have more time.

**For example:**
new:
<img width="474" height="95" alt="image" src="https://github.com/user-attachments/assets/6fba021a-5f2c-4aea-94eb-ce964117c0d2" />
old:
<img width="381" height="75" alt="image" src="https://github.com/user-attachments/assets/0f8cfcad-6d0c-44e8-bf03-143253d60ff6" />
