### PR TITLE
Remove deprecated version in compose file

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 x-common:
   database:
     &db-environment


### PR DESCRIPTION
This minor change removes the deprecated `version` property from the Docker Compose file to avoid the warning when running it, aligning it with current best practices and recommendations.