### PR TITLE
Update node/view/servers title to be consistent

### DIFF
--- a/resources/views/admin/nodes/view/servers.blade.php
+++ b/resources/views/admin/nodes/view/servers.blade.php
@@ -32,7 +32,7 @@
     <div class="col-sm-12">
         <div class="box box-primary">
             <div class="box-header with-border">
-                <h3 class="box-title">Process Manager</h3>
+                <h3 class="box-title">Server List</h3>
             </div>
             <div class="box-body table-responsive no-padding">
                 <table class="table table-hover">


### PR DESCRIPTION
I don't know if this was intentional or not, but I figured I could just make this so it can easily be fixed or not. The grid title while viewing servers on a node is "Process Manager" currently, when I believe it should be "Server List" to be standard with the plain servers tab.


Example images:
Server list
<img width="525" height="247" alt="Medal_xDSXkwzn5A" src="https://github.com/user-attachments/assets/0fcf2e79-2758-4ef8-8dec-0a7adb86b04c" />

Node server list
<img width="632" height="290" alt="Medal_bdqwJrqisl" src="https://github.com/user-attachments/assets/b1c46c14-9409-4e8f-9f4a-64037af590b2" />
