### PR TITLE
Fix TypeError in backup presigned URL generation

### DIFF
--- a/config/backups.php
+++ b/config/backups.php
@@ -10,7 +10,7 @@ return [
 
     // This value is used to determine the lifespan of UploadPart presigned urls that wings
     // uses to upload backups to S3 storage.  Value is in minutes, so this would default to an hour.
-    'presigned_url_lifespan' => env('BACKUP_PRESIGNED_URL_LIFESPAN', 60),
+    'presigned_url_lifespan' => (int) env('BACKUP_PRESIGNED_URL_LIFESPAN', 60),
 
     // This value defines the maximal size of a single part for the S3 multipart upload during backups
     // The maximal part size must be given in bytes. The default value is 5GB.


### PR DESCRIPTION
Fixes a `TypeError` when generating presigned URLs for S3 backups caused by Carbon's strict type checking.

### Problem
When `BACKUP_PRESIGNED_URL_LIFESPAN` is set via environment variable, `env()` returns a string (e.g., `"60"` instead of `60`). Carbon 3.x enforces strict typing on `addMinutes()`, which expects `int|float`, causing:

`TypeError: Carbon\CarbonImmutable::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given`

### Solution
Cast the config value to integer in `config/backups.php`, consistent with how `max_part_size` is already handled.