### PR TITLE
Fix Unicode character width rendering using Unicode11Addon in xterm.js [TO FIX #2484]

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "xterm-addon-fit": "^0.5.0",
         "xterm-addon-search": "^0.9.0",
         "xterm-addon-search-bar": "^0.2.0",
+        "xterm-addon-unicode11": "^0.6.0",
         "xterm-addon-web-links": "^0.6.0",
         "yup": "^0.29.1"
     },

--- a/resources/scripts/components/server/console/Console.tsx
+++ b/resources/scripts/components/server/console/Console.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import { SearchAddon } from 'xterm-addon-search';
 import { SearchBarAddon } from 'xterm-addon-search-bar';
 import { WebLinksAddon } from 'xterm-addon-web-links';
+import { Unicode11Addon } from 'xterm-addon-unicode11';
 import { ScrollDownHelperAddon } from '@/plugins/XtermScrollDownHelperAddon';
 import SpinnerOverlay from '@/components/elements/SpinnerOverlay';
 import { ServerContext } from '@/state/server';
@@ -59,6 +60,7 @@ export default () => {
     const searchAddon = new SearchAddon();
     const searchBar = new SearchBarAddon({ searchAddon });
     const webLinksAddon = new WebLinksAddon();
+    const unicode11Addon = new Unicode11Addon();
     const scrollDownHelperAddon = new ScrollDownHelperAddon();
     const { connected, instance } = ServerContext.useStoreState((state) => state.socket);
     const [canSendCommands] = usePermissions(['control.console']);
@@ -127,9 +129,14 @@ export default () => {
             terminal.loadAddon(searchAddon);
             terminal.loadAddon(searchBar);
             terminal.loadAddon(webLinksAddon);
+            terminal.loadAddon(unicode11Addon);
             terminal.loadAddon(scrollDownHelperAddon);
 
             terminal.open(ref.current);
+
+            // Activate Unicode 11 for proper emoji and special character width handling
+            terminal.unicode.activeVersion = '11';
+
             fitAddon.fit();
             searchBar.addNewStyle(zIndex);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9452,6 +9452,11 @@ xterm-addon-search@^0.9.0:
   resolved "https://registry.yarnpkg.com/xterm-addon-search/-/xterm-addon-search-0.9.0.tgz#95278ebb818cfcf882209ae75be96e0bea5d52a5"
   integrity sha512-aoolI8YuHvdGw+Qjg8g2M4kst0v86GtB7WeBm4F0jNXA005/6QbWWy9eCsvnIDLJOFI5JSSrZnD6CaOkvBQYPA==
 
+xterm-addon-unicode11@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xterm-addon-unicode11/-/xterm-addon-unicode11-0.6.0.tgz#733fd17bdf2ae6e818493db1d41241c999de0786"
+  integrity sha512-5pkb8YoS/deRtNqQRw8t640mu+Ga8B2MG3RXGQu0bwgcfr8XiXIRI880TWM49ICAHhTmnOLPzIIBIjEnCq7k2A==
+
 xterm-addon-web-links@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/xterm-addon-web-links/-/xterm-addon-web-links-0.6.0.tgz#0296cb6c99588847894670d998c9ea6a6aeb26ee"


### PR DESCRIPTION
TO FIX:
https://github.com/pterodactyl/panel/issues/2484

<img width="446" height="139" alt="image" src="https://github.com/user-attachments/assets/00139c4a-6faa-47dc-a88c-bc04701bb275" />

Before:
<img width="529" height="116" alt="image" src="https://github.com/user-attachments/assets/e29d8991-51f3-45fe-a779-14ed73447d03" />

