### PR TITLE
[Issue][5533] - Version comparison.

### DIFF
--- a/app/Services/Helpers/SoftwareVersionService.php
+++ b/app/Services/Helpers/SoftwareVersionService.php
@@ -65,7 +65,11 @@ class SoftwareVersionService
             return true;
         }
 
-        return version_compare(config('app.version'), $this->getPanel()) >= 0;
+        return version_compare(
+            ltrim(config('app.version'), 'vV'),
+            ltrim($this->getPanel(), 'vV'),
+            '>='
+        );
     }
 
     /**


### PR DESCRIPTION
Issue - [5533](https://github.com/pterodactyl/panel/issues/5533).

`version_compare` does not like leading 'v'.
Solution was to trim the leading 'v' in the comparison.

<img width="1049" height="481" alt="image" src="https://github.com/user-attachments/assets/72b6e5a7-f287-40dc-8283-39abeb489111" />
