### PR TITLE
Fix: External identifier validation error handling

### DIFF
--- a/app/Http/Controllers/Admin/ServersController.php
+++ b/app/Http/Controllers/Admin/ServersController.php
@@ -66,12 +66,30 @@ class ServersController extends Controller
      *
      * @throws DataValidationException
      * @throws \Pterodactyl\Exceptions\Repository\RecordNotFoundException
+     * @throws ValidationException
      */
     public function setDetails(Request $request, Server $server): RedirectResponse
     {
-        $this->detailsModificationService->handle($server, $request->only([
-            'owner_id', 'external_id', 'name', 'description',
-        ]));
+        if ($request->input('external_id')) {
+            $externalId = $request->input('external_id');
+            $exists = Server::where('external_id', $externalId)
+                ->where('id', '!=', $server->id)
+                ->exists();
+
+            if ($exists) {
+                throw ValidationException::withMessages([
+                    'external_id' => 'The external identifier must be unique to this server.',
+                ]);
+            }
+        }
+
+        try {
+            $this->detailsModificationService->handle($server, $request->only([
+                'owner_id', 'external_id', 'name', 'description',
+            ]));
+        } catch (DataValidationException $exception) {
+            throw new ValidationException($exception->getValidator());
+        }
 
         $this->alert->success(trans('admin/server.alerts.details_updated'))->flash();
 

--- a/app/Http/Controllers/Admin/ServersController.php
+++ b/app/Http/Controllers/Admin/ServersController.php
@@ -78,7 +78,7 @@ class ServersController extends Controller
 
             if ($exists) {
                 throw ValidationException::withMessages([
-                    'external_id' => 'The external identifier must be unique to this server.',
+                    'external_id' => 'The external identifier must be unique among all servers.',
                 ]);
             }
         }

--- a/app/Http/Requests/Admin/ServerFormRequest.php
+++ b/app/Http/Requests/Admin/ServerFormRequest.php
@@ -65,7 +65,7 @@ class ServerFormRequest extends AdminFormRequest
                 }
 
                 if ($query->exists()) {
-                    $validator->errors()->add('external_id', 'The external identifier must be unique to this server.');
+                    $validator->errors()->add('external_id', 'The external identifier must be unique among all servers.');
                 }
             }
         });

--- a/app/Http/Requests/Admin/ServerFormRequest.php
+++ b/app/Http/Requests/Admin/ServerFormRequest.php
@@ -53,6 +53,21 @@ class ServerFormRequest extends AdminFormRequest
             ], function ($input) {
                 return !$input->auto_deploy;
             });
+
+            if ($this->input('external_id')) {
+                $server = $this->route('server');
+                $externalId = $this->input('external_id');
+
+                $query = Server::where('external_id', $externalId);
+
+                if ($server) {
+                    $query->where('id', '!=', $server->id);
+                }
+
+                if ($query->exists()) {
+                    $validator->errors()->add('external_id', 'The external identifier must be unique to this server.');
+                }
+            }
         });
     }
 }

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Pterodactyl\Exceptions\Http\Server\ServerStateConflictException;
+use Illuminate\Validation\Rule;
 
 /**
  * \Pterodactyl\Models\Server.
@@ -215,6 +216,35 @@ class Server extends Model
     public function isSuspended(): bool
     {
         return $this->status === self::STATUS_SUSPENDED;
+    }
+
+    public static function getRulesForUpdate($model, string $column = 'id'): array
+    {
+        if ($model instanceof Model) {
+            [$id, $column] = [$model->getKey(), $model->getKeyName()];
+        }
+
+        $rules = static::getRules();
+        foreach ($rules as $key => &$data) {
+            foreach ($data as &$datum) {
+                if (!is_string($datum) || !str_starts_with($datum, 'unique')) {
+                    continue;
+                }
+
+                [, $args] = explode(':', $datum);
+                $args = explode(',', $args);
+
+                if ($key === 'external_id') {
+                    $datum = Rule::unique($args[0], $args[1] ?? $key)
+                        ->ignore($id ?? $model, $column)
+                        ->whereNotNull('external_id');
+                } else {
+                    $datum = Rule::unique($args[0], $args[1] ?? $key)->ignore($id ?? $model, $column);
+                }
+            }
+        }
+
+        return $rules;
     }
 
     /**


### PR DESCRIPTION
This pull request introduces stricter validation to ensure that the `external_id` field for servers remains unique when updating server details, and adds a utility method for update validation rules. The changes enhance data integrity and provide clearer error handling for duplicate external IDs.

**Validation Improvements:**

* Added a uniqueness check for `external_id` in the `ServersController` update logic, throwing a `ValidationException` if a duplicate is found when updating a server.
* Added a similar uniqueness validation for `external_id` in `ServerFormRequest`, ensuring that form requests also enforce this rule and provide user-friendly error messages.

**Model Enhancements:**

* Introduced a new static method `getRulesForUpdate` in the `Server` model to generate validation rules suitable for update operations, handling uniqueness checks and allowing for the exclusion of the current record.
* Imported the `Rule` class in `Server.php` to support advanced validation rule definitions.


🔗 Linked Issue:

#5549 