### PR TITLE
feat: Add HTTP Header Authentication for SSO proxy integration (#4026)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,10 @@ MAIL_FROM_NAME="Pterodactyl Panel"
 #
 # @see: https://github.com/pterodactyl/panel/pull/3110
 # MAIL_EHLO_DOMAIN=panel.example.com
+
+# HTTP Header Authentication Configuration
+# Enable authentication via HTTP headers (e.g., for SSO proxies like Authelia/Authentik)
+AUTH_HEADER_ENABLED=false
+AUTH_HEADER_USERNAME_HEADER=X-Auth-Username
+AUTH_HEADER_EMAIL_HEADER=X-Auth-Email
+AUTH_HEADER_AUTO_CREATE_USER=true

--- a/AUTH_HEADER_FEATURE.md
+++ b/AUTH_HEADER_FEATURE.md
@@ -1,0 +1,136 @@
+# HTTP Header Authentication Feature
+
+## Overview
+
+This implementation adds support for authentication via HTTP headers, which enables Pterodactyl Panel to work behind SSO proxies like Authelia, Authentik, or OIDC providers.
+
+## Feature Description
+
+When running behind a reverse proxy that handles authentication (such as Authelia, Authentik, LDAP, or OIDC), the proxy can pass authenticated user credentials to Pterodactyl via HTTP headers. This feature allows Pterodactyl to automatically authenticate users based on those headers.
+
+## Implementation Details
+
+### Files Added
+
+1. **`app/Http/Middleware/AuthenticateHeader.php`** - Middleware that handles HTTP header authentication
+2. **`tests/Unit/Http/Middleware/AuthenticateHeaderTest.php`** - Comprehensive test suite
+
+### Files Modified
+
+1. **`.env.example`** - Added environment variables for header authentication configuration
+2. **`config/auth.php`** - Added header authentication configuration section
+3. **`app/Http/Kernel.php`** - Registered middleware in the web middleware group
+
+## Configuration
+
+Add the following environment variables to your `.env` file:
+
+```env
+# Enable authentication via HTTP headers
+AUTH_HEADER_ENABLED=true
+
+# The HTTP header containing the username
+AUTH_HEADER_USERNAME_HEADER=X-Auth-Username
+
+# The HTTP header containing the email
+AUTH_HEADER_EMAIL_HEADER=X-Auth-Email
+
+# Automatically create users if they don't exist
+AUTH_HEADER_AUTO_CREATE_USER=true
+```
+
+## Usage Example
+
+### Nginx Proxy Configuration
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name panel.example.com;
+
+    location / {
+        # Authentik/SSO proxy adds these headers after successful authentication
+        proxy_set_header X-Auth-Username $remote_user;
+        proxy_set_header X-Auth-Email $remote_user_email;
+
+        proxy_pass http://pterodactyl-panel;
+    }
+}
+```
+
+### Authelia Configuration Example
+
+In Authelia configuration, you can set headers to pass to the backend:
+
+```yaml
+access_control:
+  default_policy: one_factor
+
+session:
+  cookies:
+    - name: authelia_session
+      domain: example.com
+```
+
+The proxy will automatically add the configured headers after successful authentication.
+
+## Security Considerations
+
+1. **Proxy Trust**: This feature should only be used when the application is behind a trusted reverse proxy. The proxy should be configured to strip these headers from client requests.
+
+2. **Header Validation**: The middleware checks for the presence of configured headers and only processes authentication when both username and email are available for user creation.
+
+3. **Auto-Creation Control**: User auto-creation can be disabled by setting `AUTH_HEADER_AUTO_CREATE_USER=false` if you prefer manual user management.
+
+4. **Existing Users**: The middleware first attempts to find existing users by username or email before attempting to create new ones.
+
+## How It Works
+
+1. Middleware intercepts all web requests
+2. If header authentication is enabled and user is not already authenticated:
+   - Checks for configured HTTP headers
+   - Attempts to find existing user by username or email
+   - If user not found and auto-creation is enabled:
+     - Creates new user with provided credentials
+     - Generates a random password (not used for header auth)
+   - Logs in the user
+3. Request continues to the application with authenticated user
+
+## Test Coverage
+
+The implementation includes comprehensive tests covering:
+- Header authentication disabled scenario
+- Authentication with valid headers
+- User lookup by username
+- User lookup by email
+- Automatic user creation
+- User auto-creation disabled
+- Already authenticated user handling
+- Requirements for both headers for auto-creation
+
+Run tests with:
+```bash
+vendor/bin/phpunit tests/Unit/Http/Middleware/AuthenticateHeaderTest.php
+```
+
+## Benefits
+
+1. **SSO Integration**: Enables seamless integration with SSO providers
+2. **Flexibility**: Supports various SSO solutions (Authelia, Authentik, LDAP, OIDC)
+3. **Security**: Leverages proxy authentication for centralized user management
+4. **Ease of Use**: Simple configuration via environment variables
+5. **Automatic User Provisioning**: Optional auto-creation of users on first login
+
+## Backward Compatibility
+
+This feature is fully backward compatible:
+- Disabled by default
+- Does not affect existing authentication methods
+- Only activates when explicitly configured
+
+## References
+
+- Issue: https://github.com/pterodactyl/panel/issues/4026
+- Related services using similar approach:
+  - Paperless: https://docs.paperless-ngx.com/configuration/
+  - Firefly III: https://firefly-iii.readthedocs.io/en/latest/configuration/authentication/

--- a/CHANGELOG_ENTRY.md
+++ b/CHANGELOG_ENTRY.md
@@ -1,0 +1,13 @@
+## [Unreleased] - 2026-02-12
+
+### Added
+- HTTP Header Authentication support for SSO proxy integration (#4026)
+  - New middleware `AuthenticateHeader` for authenticating users via HTTP headers
+  - Configuration options in `.env` for enabling and customizing header authentication
+  - Automatic user creation feature for new authenticated users
+  - Comprehensive test coverage for header authentication
+
+### Changed
+- `config/auth.php` - Added `header` configuration section
+- `.env.example` - Added header authentication environment variables
+- `app/Http/Kernel.php` - Added `AuthenticateHeader` to web middleware group

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,6 +64,7 @@ class Kernel extends HttpKernel
             VerifyCsrfToken::class,
             SubstituteBindings::class,
             LanguageMiddleware::class,
+            \Pterodactyl\Http\Middleware\AuthenticateHeader::class,
         ],
         'api' => [
             EnsureStatefulRequests::class,

--- a/app/Http/Middleware/AuthenticateHeader.php
+++ b/app/Http/Middleware/AuthenticateHeader.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Pterodactyl\Http\Middleware;
+
+use Illuminate\Http\Request;
+use Pterodactyl\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Event;
+use Pterodactyl\Events\Auth\DirectLogin;
+
+class AuthenticateHeader
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, \Closure $next)
+    {
+        // Check if header authentication is enabled
+        if (!config('auth.header.enabled', false)) {
+            return $next($request);
+        }
+
+        // Skip if already authenticated
+        if (Auth::check()) {
+            return $next($request);
+        }
+
+        // Get header names from config
+        $usernameHeader = config('auth.header.username_header', 'X-Auth-Username');
+        $emailHeader = config('auth.header.email_header', 'X-Auth-Email');
+
+        // Check if required headers are present
+        $username = $request->header($usernameHeader);
+        $email = $request->header($emailHeader);
+
+        if (empty($username) && empty($email)) {
+            return $next($request);
+        }
+
+        // Try to find existing user by username or email
+        $user = null;
+        if (!empty($username)) {
+            $user = User::where('username', $username)->first();
+        }
+
+        if (!$user && !empty($email)) {
+            $user = User::where('email', $email)->first();
+        }
+
+        // Auto-create user if enabled and user not found
+        if (!$user && config('auth.header.auto_create_user', false)) {
+            if (!empty($username) && !empty($email)) {
+                $user = $this->createUser($username, $email);
+            }
+        }
+
+        // Authenticate user if found
+        if ($user) {
+            Auth::login($user, true);
+            Event::dispatch(new DirectLogin($user, true));
+            Log::info('User authenticated via HTTP header', ['user_id' => $user->id, 'username' => $user->username]);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Create a new user from header credentials.
+     *
+     * @param  string  $username
+     * @param  string  $email
+     * @return \Pterodactyl\Models\User
+     */
+    protected function createUser(string $username, string $email): User
+    {
+        $user = User::create([
+            'uuid' => Str::uuid()->toString(),
+            'username' => $username,
+            'email' => $email,
+            'name_first' => $username,
+            'name_last' => 'User',
+            'password' => Hash::make(Str::random(32)),
+            'language' => config('app.locale', 'en'),
+        ]);
+
+        Log::info('User auto-created via HTTP header', ['user_id' => $user->id, 'username' => $user->username]);
+
+        return $user;
+    }
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -126,4 +126,23 @@ return [
     */
 
     'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 10800),
+
+    /*
+    |--------------------------------------------------------------------------
+    | HTTP Header Authentication
+    |--------------------------------------------------------------------------
+    |
+    | This configuration allows authentication via HTTP headers, which is useful
+    | when running behind an SSO proxy like Authelia, Authentik, or OIDC providers.
+    |
+    | The proxy will handle authentication and pass user credentials via HTTP headers.
+    |
+    */
+
+    'header' => [
+        'enabled' => env('AUTH_HEADER_ENABLED', false),
+        'username_header' => env('AUTH_HEADER_USERNAME_HEADER', 'X-Auth-Username'),
+        'email_header' => env('AUTH_HEADER_EMAIL_HEADER', 'X-Auth-Email'),
+        'auto_create_user' => env('AUTH_HEADER_AUTO_CREATE_USER', true),
+    ],
 ];

--- a/tests/Unit/Http/Middleware/AuthenticateHeaderTest.php
+++ b/tests/Unit/Http/Middleware/AuthenticateHeaderTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Pterodactyl\Tests\Unit\Http\Middleware;
+
+use Pterodactyl\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Pterodactyl\Tests\Unit\Http\Middleware\MiddlewareTestCase;
+use Pterodactyl\Http\Middleware\AuthenticateHeader;
+
+class AuthenticateHeaderTest extends MiddlewareTestCase
+{
+    use RefreshDatabase;
+
+    protected AuthenticateHeader $middleware;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->middleware = new AuthenticateHeader();
+    }
+
+    public function test_header_authentication_is_disabled_by_default()
+    {
+        Config::set('auth.header.enabled', false);
+
+        $request = $this->requestWithHeaders([
+            'X-Auth-Username' => 'testuser',
+            'X-Auth-Email' => 'test@example.com',
+        ]);
+
+        $response = $this->middleware->handle($request, fn () => response('ok'));
+
+        $this->assertFalse(Auth::check());
+        $this->assertEquals('ok', $response->getContent());
+    }
+
+    public function test_it_authenticates_user_with_valid_headers()
+    {
+        Config::set('auth.header.enabled', true);
+        Config::set('auth.header.username_header', 'X-Auth-Username');
+        Config::set('auth.header.email_header', 'X-Auth-Email');
+
+        $user = User::factory()->create([
+            'username' => 'testuser',
+            'email' => 'test@example.com',
+        ]);
+
+        $request = $this->requestWithHeaders([
+            'X-Auth-Username' => 'testuser',
+            'X-Auth-Email' => 'test@example.com',
+        ]);
+
+        $response = $this->middleware->handle($request, fn () => response('ok'));
+
+        $this->assertTrue(Auth::check());
+        $this->assertEquals($user->id, Auth::id());
+    }
+
+    public function test_it_finds_user_by_username()
+    {
+        Config::set('auth.header.enabled', true);
+        Config::set('auth.header.username_header', 'X-Auth-Username');
+        Config::set('auth.header.email_header', 'X-Auth-Email');
+
+        $user = User::factory()->create([
+            'username' => 'testuser',
+            'email' => 'test@example.com',
+        ]);
+
+        $request = $this->requestWithHeaders([
+            'X-Auth-Username' => 'testuser',
+        ]);
+
+        $response = $this->middleware->handle($request, fn () => response('ok'));
+
+        $this->assertTrue(Auth::check());
+        $this->assertEquals($user->id, Auth::id());
+    }
+
+    public function test_it_finds_user_by_email()
+    {
+        Config::set('auth.header.enabled', true);
+        Config::set('auth.header.username_header', 'X-Auth-Username');
+        Config::set('auth.header.email_header', 'X-Auth-Email');
+
+        $user = User::factory()->create([
+            'username' => 'testuser',
+            'email' => 'test@example.com',
+        ]);
+
+        $request = $this->requestWithHeaders([
+            'X-Auth-Email' => 'test@example.com',
+        ]);
+
+        $response = $this->middleware->handle($request, fn () => response('ok'));
+
+        $this->assertTrue(Auth::check());
+        $this->assertEquals($user->id, Auth::id());
+    }
+
+    public function test_it_auto_creates_user_when_enabled()
+    {
+        Config::set('auth.header.enabled', true);
+        Config::set('auth.header.username_header', 'X-Auth-Username');
+        Config::set('auth.header.email_header', 'X-Auth-Email');
+        Config::set('auth.header.auto_create_user', true);
+
+        $request = $this->requestWithHeaders([
+            'X-Auth-Username' => 'newuser',
+            'X-Auth-Email' => 'newuser@example.com',
+        ]);
+
+        $response = $this->middleware->handle($request, fn () => response('ok'));
+
+        $this->assertTrue(Auth::check());
+        $this->assertDatabaseHas('users', [
+            'username' => 'newuser',
+            'email' => 'newuser@example.com',
+        ]);
+    }
+
+    public function test_it_does_not_auto_create_user_when_disabled()
+    {
+        Config::set('auth.header.enabled', true);
+        Config::set('auth.header.username_header', 'X-Auth-Username');
+        Config::set('auth.header.email_header', 'X-Auth-Email');
+        Config::set('auth.header.auto_create_user', false);
+
+        $request = $this->requestWithHeaders([
+            'X-Auth-Username' => 'newuser',
+            'X-Auth-Email' => 'newuser@example.com',
+        ]);
+
+        $response = $this->middleware->handle($request, fn () => response('ok'));
+
+        $this->assertFalse(Auth::check());
+        $this->assertDatabaseMissing('users', [
+            'username' => 'newuser',
+            'email' => 'newuser@example.com',
+        ]);
+    }
+
+    public function test_it_skips_already_authenticated_user()
+    {
+        Config::set('auth.header.enabled', true);
+        Config::set('auth.header.username_header', 'X-Auth-Username');
+        Config::set('auth.header.email_header', 'X-Auth-Email');
+
+        $user = User::factory()->create();
+        Auth::login($user);
+
+        $request = $this->requestWithHeaders([
+            'X-Auth-Username' => 'otheruser',
+            'X-Auth-Email' => 'other@example.com',
+        ]);
+
+        $response = $this->middleware->handle($request, fn () => response('ok'));
+
+        $this->assertTrue(Auth::check());
+        $this->assertEquals($user->id, Auth::id());
+    }
+
+    public function test_it_requires_both_headers_for_auto_creation()
+    {
+        Config::set('auth.header.enabled', true);
+        Config::set('auth.header.username_header', 'X-Auth-Username');
+        Config::set('auth.header.email_header', 'X-Auth-Email');
+        Config::set('auth.header.auto_create_user', true);
+
+        $request = $this->requestWithHeaders([
+            'X-Auth-Username' => 'newuser',
+        ]);
+
+        $response = $this->middleware->handle($request, fn () => response('ok'));
+
+        $this->assertFalse(Auth::check());
+        $this->assertDatabaseMissing('users', [
+            'username' => 'newuser',
+        ]);
+    }
+
+    protected function requestWithHeaders(array $headers): \Illuminate\Http\Request
+    {
+        return \Illuminate\Http\Request::create('/test', 'GET', [], [], [], $this->transformHeadersToServerVars($headers));
+    }
+
+    protected function transformHeadersToServerVars(array $headers): array
+    {
+        $server = [];
+        foreach ($headers as $key => $value) {
+            $server['HTTP_' . strtoupper(str_replace('-', '_', $key))] = $value;
+        }
+        return $server;
+    }
+}


### PR DESCRIPTION

   ## Overview

   This implementation adds support for authentication via HTTP headers, which enables Pterodactyl Panel to
   work behind SSO proxies like Authelia, Authentik, or OIDC providers.

   ## Feature Description

   When running behind a reverse proxy that handles authentication (such as Authelia, Authentik, LDAP, or
   OIDC), the proxy can pass authenticated user credentials to Pterodactyl via HTTP headers. This feature
   allows Pterodactyl to automatically authenticate users based on those headers.

   ## Implementation Details

   ### Files Added
   - `app/Http/Middleware/AuthenticateHeader.php` - Middleware that handles HTTP header authentication
   - `tests/Unit/Http/Middleware/AuthenticateHeaderTest.php` - Comprehensive test suite

   ### Files Modified
   - `.env.example` - Added environment variables for header authentication configuration
   - `config/auth.php` - Added header authentication configuration section
   - `app/Http/Kernel.php` - Registered middleware in the web middleware group

   ## Configuration

   Add the following environment variables to your `.env` file:
  AUTH_HEADER_ENABLED=true
  AUTH_HEADER_USERNAME_HEADER=X-Auth-Username
  AUTH_HEADER_EMAIL_HEADER=X-Auth-Email
  AUTH_HEADER_AUTO_CREATE_USER=true

   ## Security Considerations

   1. This feature should only be used when the application is behind a trusted reverse proxy
   2. The proxy should be configured to strip these headers from client requests
   3. User auto-creation can be disabled if manual user management is preferred

   ## AI Assistance Disclosure

   This PR was developed with AI assistance for code generation and analysis. All PR descriptions, comments,
   and interactions are written by a human.

   ## Related Issue

   Closes #4026