### PR TITLE
Fix transfer status permission checks

### DIFF
--- a/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
@@ -34,7 +34,7 @@ class ServerTransferController extends Controller
      *
      * @throws \Throwable
      */
-    public function failure(string $uuid): JsonResponse
+    public function failure(Request $reqest, string $uuid): JsonResponse
     {
         $server = $this->repository->getByUuid($uuid);
         $transfer = $server->transfer;
@@ -42,9 +42,12 @@ class ServerTransferController extends Controller
             throw new ConflictHttpException('Server is not being transferred.');
         }
 
+        /** @var Node $node */
+        Assert::isInstanceOf($node = $request->attributes->get('node'), Node::class);
+
         // Either node can tell the panel that the transfer has failed. Only the new node
         // can tell the panel that it was successful.
-        if (! $server->node->is($transfer->newNode) && ! $server->node->is($transfer->oldNode)) {
+        if (! $node->is($transfer->newNode) && ! $node->is($transfer->oldNode)) {
             throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
         }
 

--- a/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
@@ -35,7 +35,7 @@ class ServerTransferController extends Controller
      *
      * @throws \Throwable
      */
-    public function failure(Request $reqest, string $uuid): JsonResponse
+    public function failure(Request $request, string $uuid): JsonResponse
     {
         $server = $this->repository->getByUuid($uuid);
         $transfer = $server->transfer;

--- a/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
@@ -15,6 +15,7 @@ use Pterodactyl\Repositories\Eloquent\ServerRepository;
 use Pterodactyl\Repositories\Wings\DaemonServerRepository;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
+use Webmozart\Assert\Assert;
 
 class ServerTransferController extends Controller
 {

--- a/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Pterodactyl\Models\Allocation;
 use Illuminate\Support\Facades\Log;
+use Pterodactyl\Models\Node;
 use Pterodactyl\Models\ServerTransfer;
 use Illuminate\Database\ConnectionInterface;
 use Pterodactyl\Http\Controllers\Controller;

--- a/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
@@ -2,6 +2,7 @@
 
 namespace Pterodactyl\Http\Controllers\Api\Remote\Servers;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Pterodactyl\Models\Allocation;
@@ -54,7 +55,7 @@ class ServerTransferController extends Controller
      *
      * @throws \Throwable
      */
-    public function success(string $uuid): JsonResponse
+    public function success(Request $request, string $uuid): JsonResponse
     {
         $server = $this->repository->getByUuid($uuid);
         $transfer = $server->transfer;
@@ -62,9 +63,12 @@ class ServerTransferController extends Controller
             throw new ConflictHttpException('Server is not being transferred.');
         }
 
+        /** @var Node $node */
+        Assert::isInstanceOf($node = $request->attributes->get('node'), Node::class);
+
         // Only the new node communicates a successful state to the panel, so we should
         // not allow the old node to hit this endpoint.
-        if (! $server->node->is($transfer->newNode)) {
+        if (! $node->is($transfer->newNode)) {
             throw new HttpForbiddenException('Requesting node does not have permission to access this server.');
         }
 

--- a/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerTransferController.php
@@ -3,11 +3,12 @@
 namespace Pterodactyl\Http\Controllers\Api\Remote\Servers;
 
 use Illuminate\Http\Request;
+use Pterodactyl\Models\Node;
+use Webmozart\Assert\Assert;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Pterodactyl\Models\Allocation;
 use Illuminate\Support\Facades\Log;
-use Pterodactyl\Models\Node;
 use Pterodactyl\Models\ServerTransfer;
 use Illuminate\Database\ConnectionInterface;
 use Pterodactyl\Http\Controllers\Controller;
@@ -16,7 +17,6 @@ use Pterodactyl\Repositories\Eloquent\ServerRepository;
 use Pterodactyl\Repositories\Wings\DaemonServerRepository;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
-use Webmozart\Assert\Assert;
 
 class ServerTransferController extends Controller
 {
@@ -43,7 +43,7 @@ class ServerTransferController extends Controller
             throw new ConflictHttpException('Server is not being transferred.');
         }
 
-        /** @var Node $node */
+        /* @var Node $node */
         Assert::isInstanceOf($node = $request->attributes->get('node'), Node::class);
 
         // Either node can tell the panel that the transfer has failed. Only the new node
@@ -68,7 +68,7 @@ class ServerTransferController extends Controller
             throw new ConflictHttpException('Server is not being transferred.');
         }
 
-        /** @var Node $node */
+        /* @var Node $node */
         Assert::isInstanceOf($node = $request->attributes->get('node'), Node::class);
 
         // Only the new node communicates a successful state to the panel, so we should

--- a/app/Models/ServerTransfer.php
+++ b/app/Models/ServerTransfer.php
@@ -2,6 +2,7 @@
 
 namespace Pterodactyl\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -18,12 +19,15 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property bool $archived
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
- * @property Server $server
- * @property Node $oldNode
- * @property Node $newNode
+ * @property \Pterodactyl\Models\Server $server
+ * @property \Pterodactyl\Models\Node $oldNode
+ * @property \Pterodactyl\Models\Node $newNode
  */
 class ServerTransfer extends Model
 {
+    /** @use HasFactory<\Database\Factories\ServerTransferFactory> */
+    use HasFactory;
+
     /**
      * The resource name for this model when it is transformed into an
      * API representation using fractal.

--- a/app/Models/ServerTransfer.php
+++ b/app/Models/ServerTransfer.php
@@ -2,9 +2,9 @@
 
 namespace Pterodactyl\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 /**
  * @property int $id
@@ -19,9 +19,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property bool $archived
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
- * @property \Pterodactyl\Models\Server $server
- * @property \Pterodactyl\Models\Node $oldNode
- * @property \Pterodactyl\Models\Node $newNode
+ * @property Server $server
+ * @property Node $oldNode
+ * @property Node $newNode
  */
 class ServerTransfer extends Model
 {

--- a/database/Factories/ServerTransferFactory.php
+++ b/database/Factories/ServerTransferFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use Pterodactyl\Models\ServerTransfer;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ServerTransferFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = ServerTransfer::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'old_additional_allocations' => [],
+            'new_additional_allocations' => [],
+            'successful' => null,
+            'archived' => false,
+        ];
+    }
+}

--- a/tests/Integration/Api/Remote/ServerTransferControllerTest.php
+++ b/tests/Integration/Api/Remote/ServerTransferControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Integration\Api\Remote;
+
+use Pterodactyl\Models\ServerTransfer;
+use Pterodactyl\Tests\Integration\IntegrationTestCase;
+
+class ServerTransferControllerTest extends IntegrationTestCase
+{
+    protected ServerTransfer $transfer;
+
+    public function setup(): void
+    {
+        parent::setUp();
+
+        $transfer = $this->createServerTransferModel();
+
+        $this->transfer = $transfer;
+    }
+
+    public function testSuccessStatusUpdateCanBeSentFromNewNode()
+    {
+        $server = $this->transfer->server;
+        $newNode = $this->transfer->newNode;
+
+        $this->withHeader(
+            'Authorization',
+            "Bearer $newNode->daemon_token_id." . $newNode->getDecryptedKey()
+        )->postJson("/api/remote/servers/$server->uuid/transfer/success")->assertNoContent();
+
+        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => true]);
+    }
+
+    public function testFailureStatusUpdateCanBeSentFromOldNode()
+    {
+        $server = $this->transfer->server;
+        $oldNode = $this->transfer->oldNode;
+
+        $this->withHeader(
+            'Authorization',
+            "Bearer $oldNode->daemon_token_id." . $oldNode->getDecryptedKey()
+        )->postJson("/api/remote/servers/$server->uuid/transfer/failure")->assertNoContent();
+
+        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => false]);
+    }
+
+    public function testFailureStatusUpdateCanBeSentFromNewNode()
+    {
+        $server = $this->transfer->server;
+        $newNode = $this->transfer->newNode;
+
+        $this->withHeader(
+            'Authorization',
+            "Bearer $newNode->daemon_token_id." . $newNode->getDecryptedKey()
+        )->postJson("/api/remote/servers/$server->uuid/transfer/failure")->assertNoContent();
+
+        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => false]);
+    }
+
+    public function testSuccessStatusUpdateCannotBeSentFromOldNode()
+    {
+        $server = $this->transfer->server;
+        $oldNode = $this->transfer->oldNode;
+
+        $response = $this->withHeader(
+            'Authorization',
+            "Bearer $oldNode->daemon_token_id." . $oldNode->getDecryptedKey()
+        )->postJson("/api/remote/servers/$server->uuid/transfer/success")->assertForbidden();
+
+        $response->assertJsonPath('errors.0.code', 'HttpForbiddenException');
+        $response->assertJsonPath('errors.0.detail', 'Requesting node does not have permission to access this server.');
+
+        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => null]);
+    }
+
+    public function testSuccessStatusUpdateCannotBeSentFromUnauthorizedNode()
+    {
+        $server = $this->transfer->server;
+        $susNode = $this->createNodeModel();
+
+        $response = $this->withHeader(
+            'Authorization',
+            "Bearer $susNode->daemon_token_id." . $susNode->getDecryptedKey()
+        )->postJson("/api/remote/servers/$server->uuid/transfer/success")->assertForbidden();
+
+        $response->assertJsonPath('errors.0.code', 'HttpForbiddenException');
+        $response->assertJsonPath('errors.0.detail', 'Requesting node does not have permission to access this server.');
+
+        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => null]);
+    }
+
+    public function testFailureStatusUpdateCannotBeSentFromUnauthorizedNode()
+    {
+        $server = $this->transfer->server;
+        $susNode = $this->createNodeModel();
+
+        $response = $this->withHeader(
+            'Authorization',
+            "Bearer $susNode->daemon_token_id." . $susNode->getDecryptedKey()
+        )->postJson("/api/remote/servers/$server->uuid/transfer/failure")->assertForbidden();
+
+        $response->assertJsonPath('errors.0.code', 'HttpForbiddenException');
+        $response->assertJsonPath('errors.0.detail', 'Requesting node does not have permission to access this server.');
+
+        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => null]);
+    }
+}

--- a/tests/Integration/Api/Remote/ServerTransferControllerTest.php
+++ b/tests/Integration/Api/Remote/ServerTransferControllerTest.php
@@ -1,7 +1,10 @@
 <?php
 
-namespace Integration\Api\Remote;
+namespace Pterodactyl\Tests\Integration\Api\Remote;
 
+use Pterodactyl\Models\Node;
+use Pterodactyl\Models\Location;
+use Pterodactyl\Models\Allocation;
 use Pterodactyl\Models\ServerTransfer;
 use Pterodactyl\Tests\Integration\IntegrationTestCase;
 
@@ -13,95 +16,96 @@ class ServerTransferControllerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $transfer = $this->createServerTransferModel();
+        $server = $this->createServerModel();
 
-        $this->transfer = $transfer;
+        $new = Node::factory()
+            ->for(Location::factory())
+            ->has(Allocation::factory())
+            ->create();
+
+        $this->transfer = ServerTransfer::factory()->for($server)->create([
+            'old_allocation' => $server->allocation_id,
+            'new_allocation' => $new->allocations->first()->id,
+            'new_node' => $new->id,
+            'old_node' => $server->node_id,
+        ]);
     }
 
-    public function testSuccessStatusUpdateCanBeSentFromNewNode()
+    public function testSuccessStatusUpdateCanBeSentFromNewNode(): void
     {
         $server = $this->transfer->server;
         $newNode = $this->transfer->newNode;
 
-        $this->withHeader(
-            'Authorization',
-            "Bearer $newNode->daemon_token_id." . $newNode->getDecryptedKey()
-        )->postJson("/api/remote/servers/$server->uuid/transfer/success")->assertNoContent();
+        $this
+            ->withHeader('Authorization', "Bearer $newNode->daemon_token_id." . $newNode->getDecryptedKey())
+            ->postJson("/api/remote/servers/{$server->uuid}/transfer/success")
+            ->assertNoContent();
 
-        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => true]);
+        $this->assertTrue($this->transfer->refresh()->successful);
     }
 
-    public function testFailureStatusUpdateCanBeSentFromOldNode()
+    public function testFailureStatusUpdateCanBeSentFromOldNode(): void
     {
         $server = $this->transfer->server;
         $oldNode = $this->transfer->oldNode;
 
-        $this->withHeader(
-            'Authorization',
-            "Bearer $oldNode->daemon_token_id." . $oldNode->getDecryptedKey()
-        )->postJson("/api/remote/servers/$server->uuid/transfer/failure")->assertNoContent();
+        $this->withHeader('Authorization', "Bearer $oldNode->daemon_token_id." . $oldNode->getDecryptedKey())
+            ->postJson("/api/remote/servers/{$server->uuid}/transfer/failure")
+            ->assertNoContent();
 
-        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => false]);
+        $this->assertFalse($this->transfer->refresh()->successful);
     }
 
-    public function testFailureStatusUpdateCanBeSentFromNewNode()
+    public function testFailureStatusUpdateCanBeSentFromNewNode(): void
     {
         $server = $this->transfer->server;
         $newNode = $this->transfer->newNode;
 
-        $this->withHeader(
-            'Authorization',
-            "Bearer $newNode->daemon_token_id." . $newNode->getDecryptedKey()
-        )->postJson("/api/remote/servers/$server->uuid/transfer/failure")->assertNoContent();
+        $this->withHeader('Authorization', "Bearer $newNode->daemon_token_id." . $newNode->getDecryptedKey())
+            ->postJson("/api/remote/servers/{$server->uuid}/transfer/failure")
+            ->assertNoContent();
 
-        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => false]);
+        $this->assertFalse($this->transfer->refresh()->successful);
     }
 
-    public function testSuccessStatusUpdateCannotBeSentFromOldNode()
+    public function testSuccessStatusUpdateCannotBeSentFromOldNode(): void
     {
         $server = $this->transfer->server;
         $oldNode = $this->transfer->oldNode;
 
-        $response = $this->withHeader(
-            'Authorization',
-            "Bearer $oldNode->daemon_token_id." . $oldNode->getDecryptedKey()
-        )->postJson("/api/remote/servers/$server->uuid/transfer/success")->assertForbidden();
+        $this->withHeader('Authorization', "Bearer $oldNode->daemon_token_id." . $oldNode->getDecryptedKey())
+            ->postJson("/api/remote/servers/{$server->uuid}/transfer/success")
+            ->assertForbidden()
+            ->assertJsonPath('errors.0.code', 'HttpForbiddenException')
+            ->assertJsonPath('errors.0.detail', 'Requesting node does not have permission to access this server.');
 
-        $response->assertJsonPath('errors.0.code', 'HttpForbiddenException');
-        $response->assertJsonPath('errors.0.detail', 'Requesting node does not have permission to access this server.');
-
-        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => null]);
+        $this->assertNull($this->transfer->refresh()->successful);
     }
 
-    public function testSuccessStatusUpdateCannotBeSentFromUnauthorizedNode()
+    public function testSuccessStatusUpdateCannotBeSentFromUnauthorizedNode(): void
     {
         $server = $this->transfer->server;
-        $susNode = $this->createNodeModel();
+        $node = Node::factory()->for(Location::factory())->create();
 
-        $response = $this->withHeader(
-            'Authorization',
-            "Bearer $susNode->daemon_token_id." . $susNode->getDecryptedKey()
-        )->postJson("/api/remote/servers/$server->uuid/transfer/success")->assertForbidden();
+        $this->withHeader('Authorization', "Bearer $node->daemon_token_id." . $node->getDecryptedKey())
+            ->postJson("/api/remote/servers/$server->uuid/transfer/success")
+            ->assertForbidden()
+            ->assertJsonPath('errors.0.code', 'HttpForbiddenException')
+            ->assertJsonPath('errors.0.detail', 'Requesting node does not have permission to access this server.');
 
-        $response->assertJsonPath('errors.0.code', 'HttpForbiddenException');
-        $response->assertJsonPath('errors.0.detail', 'Requesting node does not have permission to access this server.');
-
-        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => null]);
+        $this->assertNull($this->transfer->refresh()->successful);
     }
 
-    public function testFailureStatusUpdateCannotBeSentFromUnauthorizedNode()
+    public function testFailureStatusUpdateCannotBeSentFromUnauthorizedNode(): void
     {
         $server = $this->transfer->server;
-        $susNode = $this->createNodeModel();
+        $node = Node::factory()->for(Location::factory())->create();
 
-        $response = $this->withHeader(
-            'Authorization',
-            "Bearer $susNode->daemon_token_id." . $susNode->getDecryptedKey()
-        )->postJson("/api/remote/servers/$server->uuid/transfer/failure")->assertForbidden();
+        $this->withHeader('Authorization', "Bearer $node->daemon_token_id." . $node->getDecryptedKey())
+            ->postJson("/api/remote/servers/$server->uuid/transfer/failure")->assertForbidden()
+            ->assertJsonPath('errors.0.code', 'HttpForbiddenException')
+            ->assertJsonPath('errors.0.detail', 'Requesting node does not have permission to access this server.');
 
-        $response->assertJsonPath('errors.0.code', 'HttpForbiddenException');
-        $response->assertJsonPath('errors.0.detail', 'Requesting node does not have permission to access this server.');
-
-        $this->assertDatabaseHas('server_transfers', ['id' => $this->transfer->id, 'successful' => null]);
+        $this->assertNull($this->transfer->refresh()->successful);
     }
 }

--- a/tests/Traits/Integration/CreatesTestModels.php
+++ b/tests/Traits/Integration/CreatesTestModels.php
@@ -2,7 +2,6 @@
 
 namespace Pterodactyl\Tests\Traits\Integration;
 
-use Pterodactyl\Models\ServerTransfer;
 use Ramsey\Uuid\Uuid;
 use Pterodactyl\Models\Egg;
 use Pterodactyl\Models\Node;
@@ -73,65 +72,6 @@ trait CreatesTestModels
 
         return $server->fresh([
             'location', 'user', 'node', 'allocation', 'nest', 'egg',
-        ]);
-    }
-
-    public function createNodeModel(array $attributes = []): Node
-    {
-        if (!isset($attributes['location_id'])) {
-            /** @var Location $location */
-            $location = Location::factory()->create();
-            $attributes['location_id'] = $location->id;
-        }
-
-        /** @var Node $node */
-        $node = Node::factory()->create(['location_id' => $attributes['location_id']]);
-
-        return $node->fresh(['location']);
-    }
-
-    public function createServerTransferModel(array $attributes = [], array $serverAttributes = []): ServerTransfer
-    {
-        if (!isset($attributes['server_id'])) {
-            $server = $this->createServerModel($serverAttributes);
-            $attributes['server_id'] = $server->id;
-            $attributes['old_node'] = $server->node_id;
-        } else {
-            $server = Server::query()->with(['location', 'node', 'allocation'])
-                ->findOrFail($attributes['server_id']);
-        }
-
-        if (!isset($attributes['old_node'])) {
-            $attributes['old_node'] = $server->node_id;
-        }
-
-        if (!isset($attributes['new_node'])) {
-            if (!isset($attributes['location_id'])) {
-                /** @var Location $location */
-                $location = Location::factory()->create();
-                $attributes['location_id'] = $location->id;
-            }
-
-            /** @var Node $newNode */
-            $newNode = Node::factory()->create(['location_id' => $attributes['location_id']]);
-            $attributes['new_node'] = $newNode->id;
-        }
-
-        if (!isset($attributes['old_allocation'])) {
-            $attributes['old_allocation'] = $server->allocation_id;
-        }
-
-        if (!isset($attributes['new_allocation'])) {
-            /** @var Allocation $allocation */
-            $allocation = Allocation::factory()->create(['node_id' => $attributes['new_node']]);
-            $attributes['new_allocation'] = $allocation->id;
-        }
-
-        /** @var ServerTransfer $transfer */
-        $transfer = ServerTransfer::factory()->create(array_except($attributes, ['server', 'location_id']));
-
-        return $transfer->fresh([
-            'server', 'oldNode', 'newNode'
         ]);
     }
 

--- a/tests/Traits/Integration/CreatesTestModels.php
+++ b/tests/Traits/Integration/CreatesTestModels.php
@@ -2,6 +2,7 @@
 
 namespace Pterodactyl\Tests\Traits\Integration;
 
+use Pterodactyl\Models\ServerTransfer;
 use Ramsey\Uuid\Uuid;
 use Pterodactyl\Models\Egg;
 use Pterodactyl\Models\Node;
@@ -72,6 +73,65 @@ trait CreatesTestModels
 
         return $server->fresh([
             'location', 'user', 'node', 'allocation', 'nest', 'egg',
+        ]);
+    }
+
+    public function createNodeModel(array $attributes = []): Node
+    {
+        if (!isset($attributes['location_id'])) {
+            /** @var Location $location */
+            $location = Location::factory()->create();
+            $attributes['location_id'] = $location->id;
+        }
+
+        /** @var Node $node */
+        $node = Node::factory()->create(['location_id' => $attributes['location_id']]);
+
+        return $node->fresh(['location']);
+    }
+
+    public function createServerTransferModel(array $attributes = [], array $serverAttributes = []): ServerTransfer
+    {
+        if (!isset($attributes['server_id'])) {
+            $server = $this->createServerModel($serverAttributes);
+            $attributes['server_id'] = $server->id;
+            $attributes['old_node'] = $server->node_id;
+        } else {
+            $server = Server::query()->with(['location', 'node', 'allocation'])
+                ->findOrFail($attributes['server_id']);
+        }
+
+        if (!isset($attributes['old_node'])) {
+            $attributes['old_node'] = $server->node_id;
+        }
+
+        if (!isset($attributes['new_node'])) {
+            if (!isset($attributes['location_id'])) {
+                /** @var Location $location */
+                $location = Location::factory()->create();
+                $attributes['location_id'] = $location->id;
+            }
+
+            /** @var Node $newNode */
+            $newNode = Node::factory()->create(['location_id' => $attributes['location_id']]);
+            $attributes['new_node'] = $newNode->id;
+        }
+
+        if (!isset($attributes['old_allocation'])) {
+            $attributes['old_allocation'] = $server->allocation_id;
+        }
+
+        if (!isset($attributes['new_allocation'])) {
+            /** @var Allocation $allocation */
+            $allocation = Allocation::factory()->create(['node_id' => $attributes['new_node']]);
+            $attributes['new_allocation'] = $allocation->id;
+        }
+
+        /** @var ServerTransfer $transfer */
+        $transfer = ServerTransfer::factory()->create(array_except($attributes, ['server', 'location_id']));
+
+        return $transfer->fresh([
+            'server', 'oldNode', 'newNode'
         ]);
     }
 


### PR DESCRIPTION
Before, the new node was checked against the servers current node (the old node) before the server is updated to the new node, causing the check to always fail.

Now the requesting node is checked against the new node.

Resolves [#5572](https://github.com/pterodactyl/panel/issues/5572)