### PR TITLE
Update Laravel validation doc links to 11.x

### DIFF
--- a/resources/views/admin/eggs/variables.blade.php
+++ b/resources/views/admin/eggs/variables.blade.php
@@ -76,7 +76,7 @@
                         <div class="form-group">
                             <label class="form-label">Input Rules</label>
                             <input type="text" name="rules" class="form-control" value="{{ $variable->rules }}" />
-                            <p class="text-muted small">These rules are defined using standard <a href="https://laravel.com/docs/5.7/validation#available-validation-rules" target="_blank">Laravel Framework validation rules</a>.</p>
+                            <p class="text-muted small">These rules are defined using standard <a href="https://laravel.com/docs/11.x/validation#available-validation-rules" target="_blank">Laravel Framework validation rules</a>.</p>
                         </div>
                     </div>
                     <div class="box-footer">
@@ -129,7 +129,7 @@
                     <div class="form-group">
                         <label class="control-label">Input Rules <span class="field-required"></span></label>
                         <input type="text" name="rules" class="form-control" value="{{ old('rules', 'required|string|max:20') }}" placeholder="required|string|max:20" />
-                        <p class="text-muted small">These rules are defined using standard <a href="https://laravel.com/docs/5.7/validation#available-validation-rules" target="_blank">Laravel Framework validation rules</a>.</p>
+                        <p class="text-muted small">These rules are defined using standard <a href="https://laravel.com/docs/11.x/validation#available-validation-rules" target="_blank">Laravel Framework validation rules</a>.</p>
                     </div>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
Replace references to the Laravel 5.7 validation docs with links to the 11.x documentation in resources/views/admin/eggs/variables.blade.php


<img width="374" height="25" alt="image" src="https://github.com/user-attachments/assets/38090fe3-6ed8-4a73-b700-f8ce8d3060ab" />
