### PR TITLE
Fix: Enable Select2 dropdowns inside modals on Transfer Server (Search functionality now working)

### DIFF
--- a/public/themes/pterodactyl/js/admin/server/transfer.js
+++ b/public/themes/pterodactyl/js/admin/server/transfer.js
@@ -1,25 +1,32 @@
 $(document).ready(function () {
+    const $modal = $('#transferServerModal');
+
     $('#pNodeId').select2({
         placeholder: 'Select a Node',
+        dropdownParent: $modal,
     }).change();
 
     $('#pAllocation').select2({
         placeholder: 'Select a Default Allocation',
+        dropdownParent: $modal,
     });
 
     $('#pAllocationAdditional').select2({
         placeholder: 'Select Additional Allocations',
+        dropdownParent: $modal,
     });
 });
 
 $('#pNodeId').on('change', function () {
     let currentNode = $(this).val();
+    const $modal = $('#transferServerModal');
 
     $.each(Pterodactyl.nodeData, function (i, v) {
         if (v.id == currentNode) {
             $('#pAllocation').html('').select2({
                 data: v.allocations,
                 placeholder: 'Select a Default Allocation',
+                dropdownParent: $modal,
             });
 
             updateAdditionalAllocations();
@@ -34,6 +41,7 @@ $('#pAllocation').on('change', function () {
 function updateAdditionalAllocations() {
     let currentAllocation = $('#pAllocation').val();
     let currentNode = $('#pNodeId').val();
+    const $modal = $('#transferServerModal');
 
     $.each(Pterodactyl.nodeData, function (i, v) {
         if (v.id == currentNode) {
@@ -50,6 +58,7 @@ function updateAdditionalAllocations() {
             $('#pAllocationAdditional').html('').select2({
                 data: allocations,
                 placeholder: 'Select Additional Allocations',
+                dropdownParent: $modal,
             });
         }
     });


### PR DESCRIPTION
-- FIX FOR: https://github.com/pterodactyl/panel/issues/5588

Ensure select2 dropdowns for the transfer server UI are appended to the transfer modal to avoid z-index/overflow issues. Adds dropdownParent: $modal to the pNodeId, pAllocation, and pAllocationAdditional select2 initializations and to the dynamic allocation reload, and defines a $modal reference in the relevant scopes.

<img width="593" height="144" alt="image" src="https://github.com/user-attachments/assets/420676a6-515d-454d-b057-45aa5d33c24b" />

<img width="584" height="203" alt="image" src="https://github.com/user-attachments/assets/8f9a9032-c374-40ae-961e-ac502155b7c4" />