### PR TITLE
Fix: Prevent laravel/sanctum from going beyond version 4.2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "laracasts/utilities": "~3.2.3",
         "laravel/framework": "^11.31.0",
         "laravel/helpers": "^1.8.0",
-        "laravel/sanctum": "^4.2.0",
+        "laravel/sanctum": "~4.2.4",
         "laravel/tinker": "^2.10.0",
         "laravel/ui": "~4.5.2",
         "lcobucci/jwt": "^5.6.0",


### PR DESCRIPTION
If anyone runs any form of composer update they'll get `laravel/sanctum` version `4.3.1`, but `4.3.0` introduced a breaking change that will cause errors in Pterodactyl installs.

In `\Pterodactyl\Extensions\Laravel\Sanctum\NewAccessToken` you're relying on the underlying class' (`\Laravel\Sanctum\NewAccessToken`) lack of typing on the `accessToken` property. In Laravel Sanctum `4.3.0` the laravel/sanctum#586 PR changes were released, which refactors the underlying class to use property promotion, and specifies a type.

https://github.com/laravel/sanctum/blob/224864063d51d6adddc8c061ccf61eafa0e8f7ce/src/NewAccessToken.php#L10-L18