### PR TITLE
Fix: renameColumn syntax for daemonSecret

### DIFF
--- a/database/migrations/2020_04_10_141024_store_node_tokens_as_encrypted_value.php
+++ b/database/migrations/2020_04_10_141024_store_node_tokens_as_encrypted_value.php
@@ -25,7 +25,7 @@ class StoreNodeTokensAsEncryptedValue extends Migration
             $table->char('uuid', 36)->after('id');
             $table->char('daemon_token_id', 16)->after('upload_size');
 
-            $table->renameColumn('`daemonSecret`', 'daemon_token');
+            $table->renameColumn('daemonSecret', 'daemon_token');
         });
 
         Schema::table('nodes', function (Blueprint $table) {


### PR DESCRIPTION
This fix the Unknown column error on migration.

After I changed from mysql to mariadb the latest version.
I got the error:

```
  2020_04_04_131016_add_table_server_transfers ........................................................................................ 71.15ms DONE
  2020_04_10_141024_store_node_tokens_as_encrypted_value .............................................................................. 72.99ms FAIL

In Connection.php line 825:
                                                                                                                                                                                         
  SQLSTATE[42S22]: Column not found: 1054 Unknown column '`daemonSecret`' in 'nodes' (Connection: mariadb, SQL: alter table `nodes` rename column ```daemonSecret``` to `daemon_token`)  
                                                                                                                                                                                         

In Connection.php line 571:
                                                                                      
  SQLSTATE[42S22]: Column not found: 1054 Unknown column '`daemonSecret`' in 'nodes'  
```

To Remove the ` fixed this.