### PR TITLE
Fix: Compare to correct variable in startup variable activity log

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/StartupController.php
+++ b/app/Http/Controllers/Api/Client/Servers/StartupController.php
@@ -77,13 +77,13 @@ class StartupController extends ClientApiController
 
         $startup = $this->startupCommandService->handle($server);
 
-        if ($variable->env_variable !== $request->input('value')) {
+        if ($original !== $request->input('value')) {
             Activity::event('server:startup.edit')
                 ->subject($variable)
                 ->property([
                     'variable' => $variable->env_variable,
                     'old' => $original,
-                    'new' => $request->input('value'),
+                    'new' => $request->input('value') ?? '',
                 ])
                 ->log();
         }


### PR DESCRIPTION
- Fixes issue where the panel would create activity logs even when the value didn't change
- Log an empty string instead of displaying "null" when the variable is empty

Closes #5604 