### PR TITLE
fix(security): block SSRF in file pull URL validation

### DIFF
--- a/app/Http/Requests/Api/Client/Servers/Files/PullFileRequest.php
+++ b/app/Http/Requests/Api/Client/Servers/Files/PullFileRequest.php
@@ -16,11 +16,55 @@ class PullFileRequest extends ClientApiRequest implements ClientPermissionsReque
     public function rules(): array
     {
         return [
-            'url' => 'required|string|url',
+            'url' => ['required', 'string', 'url', function ($attribute, $value, $fail) {
+                $this->validateUrlIsNotInternal($attribute, $value, $fail);
+            }],
             'directory' => 'nullable|string',
             'filename' => 'nullable|string',
             'use_header' => 'boolean',
             'foreground' => 'boolean',
         ];
+    }
+
+    /**
+     * Ensures the provided URL does not resolve to an internal or reserved IP address
+     * to prevent Server-Side Request Forgery (SSRF) attacks. Both the declared host
+     * and its resolved IPs (to prevent DNS rebinding) are checked.
+     */
+    protected function validateUrlIsNotInternal(string $attribute, string $value, callable $fail): void
+    {
+        $host = parse_url($value, PHP_URL_HOST);
+
+        if (empty($host)) {
+            $fail('Unable to parse the host from the provided URL.');
+            return;
+        }
+
+        // Strip IPv6 brackets so filter_var can validate correctly.
+        $bare = ltrim(rtrim($host, ']'), '[');
+
+        $ips = [];
+
+        if (filter_var($bare, FILTER_VALIDATE_IP)) {
+            // Host is already an IP literal — validate it directly.
+            $ips[] = $bare;
+        } else {
+            // Resolve the hostname to catch DNS-based redirects to internal ranges.
+            $resolved = @gethostbynamel($host);
+            if ($resolved === false || empty($resolved)) {
+                $fail('The URL hostname could not be resolved to a valid IP address.');
+                return;
+            }
+            $ips = $resolved;
+        }
+
+        $flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+
+        foreach ($ips as $ip) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
+                $fail('The URL must not resolve to an internal, loopback, or reserved IP address.');
+                return;
+            }
+        }
     }
 }


### PR DESCRIPTION
Validate that the URL provided to the file pull endpoint does not resolve to an internal, loopback, link-local, or otherwise reserved IP address, preventing Server-Side Request Forgery (SSRF) attacks.

Checks performed:
- Hostname is parsed from the URL before any resolution.
- If the host is an IP literal it is validated directly.
- If the host is a domain name, gethostbynamel() resolves all A records so DNS-rebinding tricks are also caught.
- FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE blocks: 10.x, 172.16-31.x, 192.168.x (RFC-1918) 127.x (loopback), 169.254.x (link-local / cloud metadata) and other IANA-reserved ranges.