### PR TITLE
Throttle email address changes on accounts to limit enumeration

### DIFF
--- a/app/Http/Controllers/Api/Client/AccountController.php
+++ b/app/Http/Controllers/Api/Client/AccountController.php
@@ -7,13 +7,20 @@ use Illuminate\Http\Response;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Http\JsonResponse;
 use Pterodactyl\Facades\Activity;
+use Illuminate\Support\Facades\RateLimiter;
 use Pterodactyl\Services\Users\UserUpdateService;
 use Pterodactyl\Transformers\Api\Client\AccountTransformer;
 use Pterodactyl\Http\Requests\Api\Client\Account\UpdateEmailRequest;
 use Pterodactyl\Http\Requests\Api\Client\Account\UpdatePasswordRequest;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 class AccountController extends ClientApiController
 {
+    /**
+     * The number of seconds that must elapse before the email change throttle resets.
+     */
+    private const EMAIL_UPDATE_THROTTLE = 60 * 60 * 24;
+
     /**
      * AccountController constructor.
      */
@@ -34,12 +41,22 @@ class AccountController extends ClientApiController
      */
     public function updateEmail(UpdateEmailRequest $request): JsonResponse
     {
-        $original = $request->user()->email;
-        $this->updateService->handle($request->user(), $request->validated());
+        $user = $request->user();
+        // Only allow a user to change their email three times in the span
+        // of 24 hours. This prevents malicious users from trying to find
+        // existing accounts in the system by constantly changing their email.
+        if (RateLimiter::tooManyAttempts($key = "user:update-email:{$user->uuid}", 3)) {
+            throw new TooManyRequestsHttpException(message: 'Your email address has been changed too many times today. Please try again later.');
+        }
 
-        if ($original !== $request->input('email')) {
+        $original = $user->email;
+        if (mb_strtolower($original) !== mb_strtolower($request->validated('email'))) {
+            RateLimiter::hit($key, self::EMAIL_UPDATE_THROTTLE);
+
+            $this->updateService->handle($user, $request->validated());
+
             Activity::event('user:account.email-changed')
-                ->property(['old' => $original, 'new' => $request->input('email')])
+                ->property(['old' => $original, 'new' => $request->validated('email')])
                 ->log();
         }
 

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -28,7 +28,9 @@ Route::prefix('/account')->middleware(AccountSubject::class)->group(function () 
         Route::post('/two-factor/disable', [Client\TwoFactorController::class, 'delete']);
     });
 
-    Route::put('/email', [Client\AccountController::class, 'updateEmail'])->name('api:client.account.update-email');
+    Route::put('/email', [Client\AccountController::class, 'updateEmail'])
+        ->middleware('throttle')
+        ->name('api:client.account.update-email');
     Route::put('/password', [Client\AccountController::class, 'updatePassword'])->name('api:client.account.update-password');
 
     Route::get('/activity', Client\ActivityLogController::class)->name('api:client.account.activity');

--- a/tests/Integration/Api/Client/AccountControllerTest.php
+++ b/tests/Integration/Api/Client/AccountControllerTest.php
@@ -54,6 +54,28 @@ class AccountControllerTest extends ClientApiIntegrationTestCase
         $this->assertDatabaseHas('users', ['id' => $user->id, 'email' => $email]);
     }
 
+    public function testEmailChangeIsThrottled(): void
+    {
+        $users = User::factory()->count(2)->create();
+        $endpoint = route('api:client.account.update-email');
+
+        for ($i = 0; $i < 3; ++$i) {
+            $this->actingAs($users[0])
+                ->putJson($endpoint, ['email' => "foo+{$i}@example.com", 'password' => 'password'])
+                ->assertNoContent();
+        }
+
+        $this
+            ->putJson($endpoint, ['email' => 'bar@example.com', 'password' => 'password'])
+            ->assertTooManyRequests();
+
+        // The other user should still be able to update their email because the throttle
+        // is tied to the account, not to the IP address.
+        $this->actingAs($users[1])
+            ->putJson($endpoint, ['email' => 'bar+1@example.com', 'password' => 'password'])
+            ->assertNoContent();
+    }
+
     /**
      * Tests that an email is not updated if the password provided in the request is not
      * valid for the account.


### PR DESCRIPTION
This change applies a rate limit to account email changes to prevent enumeration on the system. The throttle is applied at the account level. Administrators can still update an account's email address manually to bypass this restriction if/when necessary.