### PR TITLE
Add Java 25 docker image to default Minecraft eggs

### DIFF
--- a/database/Seeders/eggs/minecraft/egg-bungeecord.json
+++ b/database/Seeders/eggs/minecraft/egg-bungeecord.json
@@ -14,6 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
+        "Java 25": "ghcr.io\/pterodactyl\/yolks:java_25",
         "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",

--- a/database/Seeders/eggs/minecraft/egg-forge-minecraft.json
+++ b/database/Seeders/eggs/minecraft/egg-forge-minecraft.json
@@ -14,6 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
+        "Java 25": "ghcr.io\/pterodactyl\/yolks:java_25",
         "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",

--- a/database/Seeders/eggs/minecraft/egg-sponge--sponge-vanilla.json
+++ b/database/Seeders/eggs/minecraft/egg-sponge--sponge-vanilla.json
@@ -14,6 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
+        "Java 25": "ghcr.io\/pterodactyl\/yolks:java_25",
         "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",

--- a/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.json
+++ b/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.json
@@ -14,6 +14,7 @@
         "pid_limit"
     ],
     "docker_images": {
+        "Java 25": "ghcr.io\/pterodactyl\/yolks:java_25",
         "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",


### PR DESCRIPTION
This adds the existing ghcr.io\/pterodactyl\/yolks:java_25 docker image to the default Minecraft eggs where it was previously missing. Paper already supported Java 25, but the other Minecraft-related eggs only supported older Java versions. This ensures that the available Java versions remain consistent across all Minecraft eggs and allows users to select Java 25 without having to manually edit the egg.