### PR TITLE
Fixed compress activity log showing {{file}} instead of the archive filename

### DIFF
--- a/resources/lang/en/activity.php
+++ b/resources/lang/en/activity.php
@@ -67,7 +67,7 @@ return [
             'delete' => 'Deleted database :name',
         ],
         'file' => [
-            'compress_one' => 'Compressed :directory:file',
+            'compress_one' => 'Compressed :directory:files.0',
             'compress_other' => 'Compressed :count files in :directory',
             'read' => 'Viewed the contents of :file',
             'copy' => 'Created a copy of :file',


### PR DESCRIPTION
Fix for #5630 

The compress_one string in resources/lang/en/activity.php referenced :file as the placeholder, but the backend passes the filename under a files array. This caused the activity log to render {file}} instead of the actual filename

Changed :file to :files.0 to correctly resolve the first filename from the array.

Solution was identified by the issue reporter (@marioenache).
