### PR TITLE
bugfix: user creation now properly appears in action log

### DIFF
--- a/app/Services/Users/UserCreationService.php
+++ b/app/Services/Users/UserCreationService.php
@@ -4,6 +4,7 @@ namespace Pterodactyl\Services\Users;
 
 use Ramsey\Uuid\Uuid;
 use Pterodactyl\Models\User;
+use Pterodactyl\Facades\Activity;
 use Illuminate\Contracts\Hashing\Hasher;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Contracts\Auth\PasswordBroker;
@@ -52,6 +53,15 @@ class UserCreationService
 
         $this->connection->commit();
         $user->notify(new AccountCreated($user, $token ?? null));
+
+        Activity::event('user:user.create')
+            ->subject($user)
+            ->property([
+                'email' => $user->email,
+                'username' => $user->username,
+                'admin' => $user->root_admin,
+            ])
+            ->log();
 
         return $user;
     }

--- a/resources/lang/en/activity.php
+++ b/resources/lang/en/activity.php
@@ -21,6 +21,9 @@ return [
         ],
     ],
     'user' => [
+        'user' => [
+            'create' => 'Created a new user :email',
+        ],
         'account' => [
             'email-changed' => 'Changed email from :old to :new',
             'password-changed' => 'Changed password',

--- a/tests/Integration/Api/Application/Users/UserControllerTest.php
+++ b/tests/Integration/Api/Application/Users/UserControllerTest.php
@@ -231,6 +231,8 @@ class UserControllerTest extends ApplicationApiIntegrationTestCase
                 'resource' => route('api.application.users.view', $user->id),
             ],
         ], true);
+
+        $this->assertActivityFor('user:user.create', $this->getApiUser(), $user);
     }
 
     /**

--- a/tests/Integration/Api/Client/Server/Subuser/CreateServerSubuserTest.php
+++ b/tests/Integration/Api/Client/Server/Subuser/CreateServerSubuserTest.php
@@ -48,6 +48,35 @@ class CreateServerSubuserTest extends ClientApiIntegrationTestCase
     }
 
     /**
+     * Test that inviting a brand-new email address — which transparently creates a new user
+     * account on the system — records a user:user.create activity log entry. This unprivileged
+     * path previously minted accounts with no audit trail, hiding them from forensic review.
+     */
+    public function testCreatingSubuserWithNewEmailLogsUserCreation()
+    {
+        [$user, $server] = $this->generateTestAccount();
+
+        $response = $this->actingAs($user)->postJson($this->link($server) . '/users', [
+            'email' => $email = $this->faker->email,
+            'permissions' => [
+                Permission::ACTION_USER_CREATE,
+            ],
+        ]);
+
+        $response->assertOk();
+
+        /** @var User $subuser */
+        $subuser = User::query()->where('email', $email)->firstOrFail();
+
+        $this->assertActivityLogged('user:user.create');
+        $this->assertDatabaseHas('activity_logs', [
+            'event' => 'user:user.create',
+            'actor_type' => $user->getMorphClass(),
+            'actor_id' => $user->id,
+        ]);
+    }
+
+    /**
      * Tests that an error is returned if a subuser attempts to create a new subuser and assign
      * permissions that their account does not also possess.
      */

--- a/tests/Integration/Api/Client/Server/Subuser/CreateServerSubuserTest.php
+++ b/tests/Integration/Api/Client/Server/Subuser/CreateServerSubuserTest.php
@@ -48,9 +48,8 @@ class CreateServerSubuserTest extends ClientApiIntegrationTestCase
     }
 
     /**
-     * Test that inviting a brand-new email address — which transparently creates a new user
-     * account on the system — records a user:user.create activity log entry. This unprivileged
-     * path previously minted accounts with no audit trail, hiding them from forensic review.
+     * Test that a newly created user account correctly causes the creation of a user:user.create
+     * activity log entry.
      */
     public function testCreatingSubuserWithNewEmailLogsUserCreation()
     {

--- a/tests/Integration/Http/Controllers/Admin/UserController/CreateUserTest.php
+++ b/tests/Integration/Http/Controllers/Admin/UserController/CreateUserTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pterodactyl\Tests\Integration\Http\Controllers\Admin\UserController;
+
+use Pterodactyl\Models\User;
+use Pterodactyl\Tests\Integration\Http\HttpTestCase;
+
+class CreateUserTest extends HttpTestCase
+{
+    public function testNonAdminCannotAccessEndpoint(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->post('/admin/users/new', [
+                'email' => 'test@example.com',
+                'username' => 'testuser',
+                'name_first' => 'Test',
+                'name_last' => 'User',
+            ])
+            ->assertForbidden();
+    }
+
+    public function testCreatingAdministratorAccountIsLogged(): void
+    {
+        $admin = User::factory()->admin()->create();
+
+        $this->actingAs($admin)
+            ->post('/admin/users/new', [
+                'email' => 'created.admin@example.com',
+                'username' => 'createdadmin',
+                'name_first' => 'Created',
+                'name_last' => 'Admin',
+                'root_admin' => 1,
+            ])
+            ->assertSessionHasNoErrors();
+
+        /** @var User $created */
+        $created = User::query()->where('username', 'createdadmin')->firstOrFail();
+        $this->assertTrue($created->root_admin);
+
+        $this->assertActivityFor('user:user.create', $admin, $created);
+    }
+}


### PR DESCRIPTION
### Description

User creation was not properly logged within the action log, neither from sub-user invite or manual user creation. This PR adds the relevant log and includes testing.

### Manual testing scenarios

1. Invite a user within any created server
2. Create a user in the admin
3. Verify both users appear as an action in the action log

### Questions or comments

AI was used for secondary testing, QA and code review. No code was written by AI.

### Resolved issues:
1. [x] resolves pterodactyl/panel#5631