### PR TITLE
UI Update: Made the delete files menu properly center bulletpoints.

### DIFF
--- a/resources/scripts/components/server/files/MassActionsBar.tsx
+++ b/resources/scripts/components/server/files/MassActionsBar.tsx
@@ -78,10 +78,14 @@ const MassActionsBar = () => {
                         <span className={'font-semibold text-gray-50'}>{selectedFiles.length} files</span>? This is a
                         permanent action and the files cannot be recovered.
                     </p>
+                   <ul className={'mt-2 mb-0 pl-6 list-disc list-outside'}>
                     {selectedFiles.slice(0, 15).map((file) => (
                         <li key={file}>{file}</li>
                     ))}
-                    {selectedFiles.length > 15 && <li>and {selectedFiles.length - 15} others</li>}
+                        {selectedFiles.length > 15 && (
+                        <li>and {selectedFiles.length - 15} others</li>
+                    )}
+                    </ul>
                 </Dialog.Confirm>
                 {showMove && (
                     <RenameFileModal


### PR DESCRIPTION
## Changes:
* Centered the bulletpoints for the list of selected files to delete in the "MassActionsBar" menu.

<img width="617" height="275" alt="image" src="https://github.com/user-attachments/assets/4d6f4c4d-e323-481d-99dc-5038576daa99" />
<hr>
<img width="644" height="275" alt="image" src="https://github.com/user-attachments/assets/b6f751a7-d8ea-467c-bb52-d0b462908a23" />
