### PR TITLE
fix: correctly persist quoted service variable defaults

### DIFF
--- a/resources/views/admin/servers/new.blade.php
+++ b/resources/views/admin/servers/new.blade.php
@@ -327,7 +327,7 @@
 
                 @if (old('environment'))
                     @foreach (old('environment') as $key => $value)
-                        $('#' + ids['{{ $key }}']).val('{{ $value }}');
+                        $('#' + ids[@json($key)]).val(@json($value));
                     @endforeach
                 @endif
             @endif


### PR DESCRIPTION
Improved default variable assignment during server creation to use `@json`, ensuring correct handling of special characters.

Fixes #5660 