### PR TITLE
Allow server transfer when overallocate < 0

### DIFF
--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -245,6 +245,6 @@ class Node extends Model implements Identifiable
         $diskLimit = $this->disk * (1 + ($this->disk_overallocate / 100));
 
         // @phpstan-ignore-next-line property.notFound, property.notFound
-        return ($this->sum_memory + $memory) <= $memoryLimit && ($this->sum_disk + $disk) <= $diskLimit;
+        return (($this->sum_memory + $memory) <= $memoryLimit || $this->memory_overallocate < 0) && (($this->sum_disk + $disk) <= $diskLimit || $this->disk_overallocate < 0);
     }
 }


### PR DESCRIPTION
This PR allows to tranfer a server from the admin panel when memory or disk overallocate is < 0
Fixes: https://github.com/pterodactyl/panel/issues/4940