### PR TITLE
Fix backup restore activity event names

### DIFF
--- a/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupStatusController.php
@@ -102,7 +102,7 @@ class BackupStatusController extends Controller
 
         $model->server->update(['status' => null]);
 
-        Activity::event($request->boolean('successful') ? 'server:backup.restore-complete' : 'server.backup.restore-failed')
+        Activity::event($request->boolean('successful') ? 'server:backup.restore-complete' : 'server:backup.restore-failed')
             ->subject($model, $model->server)
             ->property('name', $model->name)
             ->log();

--- a/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
+++ b/app/Http/Controllers/Api/Remote/Servers/ServerDetailsController.php
@@ -99,7 +99,7 @@ class ServerDetailsController extends Controller
         $servers = Server::query()
             ->with([
                 'activity' => fn ($builder) => $builder
-                    ->where('activity_logs.event', 'server:backup.restore-started')
+                    ->where('activity_logs.event', 'server:backup.restore')
                     ->latest('timestamp'),
             ])
             ->where('node_id', $node->id)


### PR DESCRIPTION
This PR fixes activity log event names for backup restores.

Failed restore attempts were logged with an event name that used the wrong separator, while reset-state was checking for an event name that is never created anywhere. As a result, restore-related activity logs could not be matched consistently.

This change only updates activity log event naming. It does not change the restore logic itself.

Checks:

* php -l on both modified files
* git diff --check
