### PR TITLE
Improve danger text readability

### DIFF
--- a/public/themes/pterodactyl/css/pterodactyl.css
+++ b/public/themes/pterodactyl/css/pterodactyl.css
@@ -561,7 +561,10 @@ body {
 }
 
 .text-danger {
-    color: #ff1c00;
+    color: #ffffff;
+    background: #dd4b39;
+    padding: 5px 10px;
+    border-radius: 3px;
 }
 
 .content-wrapper {


### PR DESCRIPTION
When you try to delete a server on the panel, you'll see warnings that say stuff like "Deleting a server is an irreversible action. All server data...". This is useful, however, the text is extremely hard to read due to the background. A user would need to highlight the text to make it readable.

I've tried changing the text color to other colors, but they didn't provide enough contrast either. I eventually decided to make the background of the text red and make the text white. I've tried to keep the design as close as possible to the Pterodactyl UI.

This change is only 4 lines in CSS. Check attached images for before & after.

Before
<img width="1123" height="277" alt="image" src="https://github.com/user-attachments/assets/ac2bb221-70f0-4c19-853c-f76aff62e71d" />

After
<img width="1123" height="277" alt="image" src="https://github.com/user-attachments/assets/e8c43871-e1b3-45b0-b729-c14c4bef70eb" />
