### PR TITLE
Purge dynamic database connection before setting a new one

### DIFF
--- a/app/Extensions/DynamicDatabaseConnection.php
+++ b/app/Extensions/DynamicDatabaseConnection.php
@@ -3,6 +3,7 @@
 namespace Pterodactyl\Extensions;
 
 use Pterodactyl\Models\DatabaseHost;
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Config\Repository as ConfigRepository;
 use Pterodactyl\Contracts\Repository\DatabaseHostRepositoryInterface;
@@ -18,6 +19,7 @@ class DynamicDatabaseConnection
      */
     public function __construct(
         protected ConfigRepository $config,
+        protected DatabaseManager $databaseManager,
         protected Encrypter $encrypter,
         protected DatabaseHostRepositoryInterface $repository,
     ) {
@@ -33,6 +35,10 @@ class DynamicDatabaseConnection
         if (!$host instanceof DatabaseHost) {
             $host = $this->repository->find($host);
         }
+
+        // DatabaseManager caches connections by name. Remove any previous connection so the
+        // next query uses the configuration for this host.
+        $this->databaseManager->purge($connection);
 
         $this->config->set('database.connections.' . $connection, [
             'driver' => self::DB_DRIVER,


### PR DESCRIPTION
`DynamicDatabaseConnection` currently sets the database host credentials in `ConfigRepository`, which is not used if a connection with that name is already cached in `DatabaseManager`. See the code here:
https://github.com/laravel/framework/blob/ee0296f03a02b8f890c6323f18bdf4669468c0c2/src/Illuminate/Database/DatabaseManager.php#L94-L110

This issue shows up wherever it is necessary to connect to multiple database hosts one after another (for example, `ServerDeletionService`). 

In the aforementioned `ServerDeletionService`, this means some databases are not deleted, and there is no error. Unwanted deletions are unlikely to happen because `DROP DATABASE IF EXISTS` is used, along with databases being prefixed with server ID, they will not exist on any other database hosts.

I would really suggest everyone go over the database hosts and check if there are any undeleted databases. We found around 4,000 databases that were not in the panel database table. Basically, if the server had databases from multiple hosts, only the databases from the first host would be deleted.

Credits to @barrelltitor for finding the issue.