### PR TITLE
fix: Removed backticks from migration script to fix issues with MariaDB connection type.

### DIFF
--- a/database/migrations/2020_04_10_141024_store_node_tokens_as_encrypted_value.php
+++ b/database/migrations/2020_04_10_141024_store_node_tokens_as_encrypted_value.php
@@ -25,7 +25,7 @@ class StoreNodeTokensAsEncryptedValue extends Migration
             $table->char('uuid', 36)->after('id');
             $table->char('daemon_token_id', 16)->after('upload_size');
 
-            $table->renameColumn('`daemonSecret`', 'daemon_token');
+            $table->renameColumn('daemonSecret', 'daemon_token');
         });
 
         Schema::table('nodes', function (Blueprint $table) {


### PR DESCRIPTION
### Summary
Quick one line fix that fixes the migration failure reported in #5683

Most installs load the database/schema/mysql-schema.sql and never have to replay these migrations, since the environment variable db_connection=mariadb was set it doesn't use the squashed schema and has to replay all migrations from 2016. This connection variable is supported though it seems as per
https://github.com/pterodactyl/panel/blob/1.0-develop/config/database.php#L63 but it also defaulted above to mysql

This field was updated to include the backticks as part of https://github.com/pterodactyl/panel/commit/8ca098940afb497b8527bc2cfe1bb2bd340ad721

but I'm unable to confirm why, if I've missed something I apologize  but other references in this file seem to also use the barename only this one was quoted.

### Testing

Built from the current v1.14.1 release branch Dockerfile. With the schema dump removed to force a full replay for testing with the mysql database connection aswell.

- MariaDB 11.8.8 - All migrations passed
- MySQL - All Migrations Passed

Installs with the dump present are also unaffected by this modification. 

[Apologies for bad formatting, i'm terrible with markdown]
