### PR TITLE
Fix Schedules not running via "Run Now" if schedule is marked "Only when server is online"

### DIFF
--- a/app/Jobs/Schedule/RunTaskJob.php
+++ b/app/Jobs/Schedule/RunTaskJob.php
@@ -91,6 +91,15 @@ class RunTaskJob implements ShouldQueue
         $this->markTaskNotQueued();
         $this->markScheduleComplete();
     }
+    
+    /**
+     * Skip this task without running it against the daemon, but continue to process the rest of the schedule.
+     */
+    public function skip()
+    {
+        $this->markTaskNotQueued();
+        $this->queueNextTask();
+    }
 
     /**
      * Get the next task in the schedule and queue it for running after the defined period of wait time.

--- a/app/Services/Schedules/ProcessScheduleService.php
+++ b/app/Services/Schedules/ProcessScheduleService.php
@@ -75,12 +75,16 @@ class ProcessScheduleService
             // so we need to manually trigger it and then continue with the exception throw.
             //
             // @see https://github.com/pterodactyl/panel/issues/2550
+            //
+            // When forcing a run now, if a schedule is set to only run when the server is online
+            // it will not run and will fail silently, added logic to allow force runs.
             try {
                 $details = $this->serverRepository->setServer($schedule->server)->getDetails();
                 $state = $details['state'] ?? 'offline';
-                if (in_array($state, ['offline', 'stopping']) && $task->action !== Task::ACTION_COMMAND) {
-                    $this->dispatcher->dispatchNow($job);
-                } else if (in_array($state, ['starting', 'running'])) {
+
+                if (in_array($state, ['offline', 'stopping']) && $task->action === Task::ACTION_COMMAND) {
+                    $job->skip();
+                } else {
                     $this->dispatcher->dispatchNow($job);
                 }
             } catch (\Exception $exception) {

--- a/app/Services/Schedules/ProcessScheduleService.php
+++ b/app/Services/Schedules/ProcessScheduleService.php
@@ -42,9 +42,9 @@ class ProcessScheduleService
         });
 
         $job = new RunTaskJob($task, $now);
-        if ($schedule->only_when_online) {
+        if (!$now && $schedule->only_when_online) {
             // Check that the server is currently in a starting or running state before executing
-            // this schedule if this option has been set.
+            // this schedule if this option has been set. Skipped if manually ran.
             try {
                 $details = $this->serverRepository->setServer($schedule->server)->getDetails();
                 $state = $details['state'] ?? 'offline';

--- a/app/Services/Schedules/ProcessScheduleService.php
+++ b/app/Services/Schedules/ProcessScheduleService.php
@@ -10,6 +10,7 @@ use Illuminate\Database\ConnectionInterface;
 use Pterodactyl\Exceptions\DisplayException;
 use Pterodactyl\Repositories\Wings\DaemonServerRepository;
 use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
+use Pterodactyl\Models\Task;
 
 class ProcessScheduleService
 {
@@ -75,7 +76,13 @@ class ProcessScheduleService
             //
             // @see https://github.com/pterodactyl/panel/issues/2550
             try {
-                $this->dispatcher->dispatchNow($job);
+                $details = $this->serverRepository->setServer($schedule->server)->getDetails();
+                $state = $details['state'] ?? 'offline';
+                if (in_array($state, ['offline', 'stopping']) && $task->action !== Task::ACTION_COMMAND) {
+                    $this->dispatcher->dispatchNow($job);
+                } else if (in_array($state, ['starting', 'running'])) {
+                    $this->dispatcher->dispatchNow($job);
+                }
             } catch (\Exception $exception) {
                 $job->failed($exception);
 


### PR DESCRIPTION
Small fix that fixes an issue where using the [Run Now] function within a schedule it will silently fail and refuse to run if the schedule tasks are set to run only when server is online.

If the user would like to force run a schedule via the button, the expectation would be for the schedule to run even with these settings.

This issue was originally caused by $now not getting checked as part of https://github.com/pterodactyl/panel/blob/1.0-develop/app/Services/Schedules/ProcessScheduleService.php#L45 meaning it would the resulting task would get thrown away before it could be handled. This has been fixed via adding it to the if statement

After implementing an issue was found in testing where schedules that included console command runs would cause an error message to appear, due to the console being unreachable, in technicality telling the schedules to continue on failure would fix this, but users shouldn't be expected to turn this on and since the error had no information this would of caused undue stress on the discord lol. This has been fixed as per the below

Added a helper script within the RunTaskJob.php to allow skipping of a schedule task but to continue the rest of the schedule to ensure tasks are marked off the daemon to ensure schedules don't get stuck processing.

also added use Pterodactyl\Models\Task to ProcessScheduleService as it was needed for the check.

otherwise also added an if statement to check if this condition is met [Server is offline/stopping and task is to send a command] and if so to skip the task and move to the next.

Testing for this fix involved and results
- Set Schedule to run command actions while server Online > As Expected [Ran]
- Forced Schedule to run command actions while server Online > As Expected [Ran]
- Allowed Schedule to run command actions while server Online > As Expected [Ran]
- Set Schedule to run command actions while server Offline > As Expected [Did not run]
- Forced Schedule to run command actions while server Offline > As Expected [Did not run/Skipped Task] 
- Allowed Schedule to run command actions while server Offline > As Expected [Did not run]

Below tests were added after failures caused in first commit of schedules not running after the action command due to failure as console was offline.
- Set Schedule with multiple actions in the order of [ACTION_COMMAND > ACTION_POWER] to run while Server Online > As Expected [Ran]
- Set Schedule with multiple actions in the order of [ACTION_COMMAND > ACTION_POWER] to run while server Offline > As Expected [Did not run]
- Forced Schedule with multiple actions in the order of [ACTION_COMMAND > ACTION_POWER] to run while server online > As Expected [Ran Successfully]
- Forced Schedule with multiple actions in the order of [ACTION_COMMAND > ACTION_POWER] to run while server Offline > As Expected [Ran Successfully]


Currently there's no notification sent that a task was skipped as part of this condition, please let me know if you'd like some sort of notification for the user during this edge case.

Fixes: #5258