### PR TITLE
removed misleading description

### DIFF
--- a/resources/scripts/components/dashboard/DashboardContainer.tsx
+++ b/resources/scripts/components/dashboard/DashboardContainer.tsx
@@ -57,7 +57,7 @@ export default () => {
             {rootAdmin && (
                 <div css={tw`mb-2 flex justify-end items-center`}>
                     <p css={tw`uppercase text-xs text-neutral-400 mr-2`}>
-                        {showOnlyAdmin ? "Showing others' servers" : 'Showing your servers'}
+                        Showing others' servers
                     </p>
                     <Switch
                         name={'show_all_servers'}


### PR DESCRIPTION
Yea, so basicly the toggle button is misleading, becaus it does TOGGLE *one* singular action, but is described with two labels.