### PR TITLE
Disable reinstall action during normal server status if "skip egg install scripts" setting is enabled

### DIFF
--- a/app/Exceptions/DisplayException.php
+++ b/app/Exceptions/DisplayException.php
@@ -49,7 +49,7 @@ class DisplayException extends PterodactylException implements HttpExceptionInte
      */
     public function render(Request $request): JsonResponse|RedirectResponse
     {
-        if ($request->expectsJson()) {
+        if ($request->expectsJson() || $request->is('api/*')) {
             return response()->json(Handler::toArray($this), $this->getStatusCode(), $this->getHeaders());
         }
 

--- a/app/Http/Controllers/Api/Client/Servers/SettingsController.php
+++ b/app/Http/Controllers/Api/Client/Servers/SettingsController.php
@@ -63,6 +63,10 @@ class SettingsController extends ClientApiController
      */
     public function reinstall(ReinstallServerRequest $request, Server $server): JsonResponse
     {
+        if ($server->skip_scripts) {
+            throw new BadRequestHttpException('This server is configured to skip its egg\'s install script; reinstalling it would stop the server without running that script.');
+        }
+
         $this->reinstallServerService->handle($server);
 
         Activity::event('server:reinstall')->log();

--- a/app/Http/Controllers/Api/Client/Servers/SettingsController.php
+++ b/app/Http/Controllers/Api/Client/Servers/SettingsController.php
@@ -63,10 +63,6 @@ class SettingsController extends ClientApiController
      */
     public function reinstall(ReinstallServerRequest $request, Server $server): JsonResponse
     {
-        if ($server->skip_scripts) {
-            throw new BadRequestHttpException('This server is configured to skip its egg\'s install script; reinstalling it would stop the server without running that script.');
-        }
-
         $this->reinstallServerService->handle($server);
 
         Activity::event('server:reinstall')->log();

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -221,6 +221,19 @@ class Server extends Model implements Identifiable
     }
 
     /**
+     * A server that skips its egg's install script gains nothing from a reinstall. The one
+     * exception is a server sitting in a failed state, where that report is the way back out.
+     */
+    public function canBeReinstalled(): bool
+    {
+        return !$this->skip_scripts || in_array($this->status, [
+            self::STATUS_INSTALLING,
+            self::STATUS_INSTALL_FAILED,
+            self::STATUS_REINSTALL_FAILED,
+        ], true);
+    }
+
+    /**
      * Gets the user who owns the server.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\Pterodactyl\Models\User, $this>

--- a/app/Services/Servers/ReinstallServerService.php
+++ b/app/Services/Servers/ReinstallServerService.php
@@ -4,6 +4,7 @@ namespace Pterodactyl\Services\Servers;
 
 use Pterodactyl\Models\Server;
 use Illuminate\Database\ConnectionInterface;
+use Pterodactyl\Exceptions\DisplayException;
 use Pterodactyl\Repositories\Wings\DaemonServerRepository;
 
 class ReinstallServerService
@@ -21,9 +22,14 @@ class ReinstallServerService
      * Reinstall a server on the remote daemon.
      *
      * @throws \Throwable
+     * @throws DisplayException
      */
     public function handle(Server $server): Server
     {
+        if (!$server->canBeReinstalled()) {
+            throw new DisplayException(trans('admin/server.exceptions.skipping_install_script'));
+        }
+
         return $this->connection->transaction(function () use ($server) {
             $server->fill(['status' => Server::STATUS_INSTALLING])->save();
 

--- a/app/Transformers/Api/Application/ServerTransformer.php
+++ b/app/Transformers/Api/Application/ServerTransformer.php
@@ -85,6 +85,7 @@ class ServerTransformer extends BaseTransformer
                 // This field is deprecated, please use "status".
                 'installed' => $server->isInstalled() ? 1 : 0,
                 'environment' => $this->environmentService->handle($server),
+                'skip_scripts' => $server->skip_scripts,
             ],
             $server->getUpdatedAtColumn() => $this->formatTimestamp($server->updated_at),
             $server->getCreatedAtColumn() => $this->formatTimestamp($server->created_at),

--- a/app/Transformers/Api/Client/ServerTransformer.php
+++ b/app/Transformers/Api/Client/ServerTransformer.php
@@ -79,6 +79,7 @@ class ServerTransformer extends BaseClientTransformer
             // This field is deprecated, please use "status".
             'is_installing' => !$server->isInstalled(),
             'is_transferring' => !is_null($server->transfer),
+            'skip_scripts' => $server->skip_scripts,
         ];
     }
 

--- a/resources/lang/en/admin/server.php
+++ b/resources/lang/en/admin/server.php
@@ -4,6 +4,7 @@ return [
     'exceptions' => [
         'no_new_default_allocation' => 'You are attempting to delete the default allocation for this server but there is no fallback allocation to use.',
         'marked_as_failed' => 'This server was marked as having failed a previous installation. Current status cannot be toggled in this state.',
+        'skipping_install_script' => 'This server is configured to skip its egg\'s install script. Reinstalling is not available until that setting is disabled.',
         'bad_variable' => 'There was a validation error with the :name variable.',
         'daemon_exception' => 'There was an exception while attempting to communicate with the daemon resulting in a HTTP/:code response code. This exception has been logged. (request id: :request_id)',
         'default_allocation_not_found' => 'The requested default allocation was not found in this server\'s allocations.',

--- a/resources/scripts/api/server/getServer.ts
+++ b/resources/scripts/api/server/getServer.ts
@@ -58,6 +58,7 @@ export interface Server {
         backups: number;
     };
     isTransferring: boolean;
+    skipScripts: boolean;
     variables: ServerEggVariable[];
     allocations: Allocation[];
 }
@@ -83,6 +84,7 @@ export const rawDataToServerObject = ({ attributes: data }: FractalResponseData)
     eggFeatures: data.egg_features || [],
     featureLimits: { ...data.feature_limits },
     isTransferring: data.is_transferring,
+    skipScripts: data.skip_scripts,
     variables: ((data.relationships?.variables as FractalResponseList | undefined)?.data || []).map(
         rawDataToServerEggVariable
     ),

--- a/resources/scripts/components/server/settings/ReinstallServerBox.tsx
+++ b/resources/scripts/components/server/settings/ReinstallServerBox.tsx
@@ -11,6 +11,7 @@ import { Dialog } from '@/components/elements/dialog';
 
 export default () => {
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
+    const skipScripts = ServerContext.useStoreState((state) => state.server.data!.skipScripts);
     const [modalVisible, setModalVisible] = useState(false);
     const { addFlash, clearFlashes } = useStoreActions((actions: Actions<ApplicationStore>) => actions.flashes);
 
@@ -35,6 +36,18 @@ export default () => {
     useEffect(() => {
         clearFlashes();
     }, []);
+
+    if (skipScripts) {
+        return (
+            <TitledGreyBox title={'Reinstall Server'}>
+                <p css={tw`text-sm`}>
+                    This server has been configured by an administrator to skip its egg&apos;s installation script.
+                    Reinstalling it would stop the server without running that script, so this option is not available
+                    here. An administrator can still reinstall this server from the admin area.
+                </p>
+            </TitledGreyBox>
+        );
+    }
 
     return (
         <TitledGreyBox title={'Reinstall Server'} css={tw`relative`}>

--- a/resources/scripts/components/server/settings/ReinstallServerBox.tsx
+++ b/resources/scripts/components/server/settings/ReinstallServerBox.tsx
@@ -41,9 +41,8 @@ export default () => {
         return (
             <TitledGreyBox title={'Reinstall Server'}>
                 <p css={tw`text-sm`}>
-                    This server has been configured by an administrator to skip its egg&apos;s installation script.
-                    Reinstalling it would stop the server without running that script, so this option is not available
-                    here. An administrator can still reinstall this server from the admin area.
+                    This server has been configured to skip its egg&apos;s installation script.
+                    An administrator can still reinstall this server from the admin area.
                 </p>
             </TitledGreyBox>
         );

--- a/resources/scripts/components/server/settings/ReinstallServerBox.tsx
+++ b/resources/scripts/components/server/settings/ReinstallServerBox.tsx
@@ -41,8 +41,8 @@ export default () => {
         return (
             <TitledGreyBox title={'Reinstall Server'}>
                 <p css={tw`text-sm`}>
-                    This server has been configured to skip its egg&apos;s installation script.
-                    An administrator can still reinstall this server from the admin area.
+                    Reinstalling this server has been disabled because it is configured to skip its egg&apos;s install
+                    script. If you would like to reinstall this server, contact a server administrator.
                 </p>
             </TitledGreyBox>
         );

--- a/resources/views/admin/servers/view/manage.blade.php
+++ b/resources/views/admin/servers/view/manage.blade.php
@@ -27,8 +27,8 @@
                 </div>
                 <div class="box-footer">
                     @if(! $server->canBeReinstalled())
-                        <button class="btn btn-danger disabled">Server Is Set to Skip Its Install Script</button>
-                        <p style="padding-top: 1rem;">Disable "Skip Egg Install Script" on the startup page to reinstall it.</p>
+                        <button class="btn btn-danger disabled">Reinstall Server</button>
+                        <p style="padding-top: 1rem;">This server is set to skip its install script. Disable "Skip Egg Install Script" on the startup page to reinstall it.</p>
                     @elseif($server->isInstalled())
                         <form action="{{ route('admin.servers.view.manage.reinstall', $server->id) }}" method="POST">
                             {!! csrf_field() !!}

--- a/resources/views/admin/servers/view/manage.blade.php
+++ b/resources/views/admin/servers/view/manage.blade.php
@@ -26,7 +26,10 @@
                     <p>This will reinstall the server with the assigned service scripts. <strong>Danger!</strong> This could overwrite server data.</p>
                 </div>
                 <div class="box-footer">
-                    @if($server->isInstalled())
+                    @if(! $server->canBeReinstalled())
+                        <button class="btn btn-danger disabled">Server Is Set to Skip Its Install Script</button>
+                        <p style="padding-top: 1rem;">Disable "Skip Egg Install Script" on the startup page to reinstall it.</p>
+                    @elseif($server->isInstalled())
                         <form action="{{ route('admin.servers.view.manage.reinstall', $server->id) }}" method="POST">
                             {!! csrf_field() !!}
                             <button type="submit" class="btn btn-danger">Reinstall Server</button>

--- a/tests/Integration/Api/Application/Servers/ServerControllerTest.php
+++ b/tests/Integration/Api/Application/Servers/ServerControllerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Pterodactyl\Tests\Integration\Api\Application\Servers;
+
+use Pterodactyl\Tests\Integration\Api\Application\ApplicationApiIntegrationTestCase;
+
+class ServerControllerTest extends ApplicationApiIntegrationTestCase
+{
+    /**
+     * Test that the "skip scripts" state is returned for a server.
+     */
+    public function testSkipScriptsStateIsReturned()
+    {
+        $server = $this->createServerModel(['skip_scripts' => true]);
+
+        $this->getJson('/api/application/servers/' . $server->id)
+            ->assertOk()
+            ->assertJsonPath('attributes.container.skip_scripts', true);
+
+        $server->update(['skip_scripts' => false]);
+
+        $this->getJson('/api/application/servers/' . $server->id)
+            ->assertOk()
+            ->assertJsonPath('attributes.container.skip_scripts', false);
+    }
+}

--- a/tests/Integration/Api/Application/Servers/ServerManagementControllerTest.php
+++ b/tests/Integration/Api/Application/Servers/ServerManagementControllerTest.php
@@ -10,12 +10,11 @@ use Pterodactyl\Tests\Integration\Api\Application\ApplicationApiIntegrationTestC
 class ServerManagementControllerTest extends ApplicationApiIntegrationTestCase
 {
     /**
-     * Test that a server can still be reinstalled via the admin
-     * even if it is configured to skip its egg's install script.
+     * Test that a server can be reinstalled.
      */
-    public function testServerConfiguredToSkipScriptsCanStillBeReinstalled()
+    public function testServerCanBeReinstalled()
     {
-        $server = $this->createServerModel(['skip_scripts' => true]);
+        $server = $this->createServerModel();
 
         $service = \Mockery::mock(DaemonServerRepository::class);
         $this->app->instance(DaemonServerRepository::class, $service);
@@ -30,8 +29,75 @@ class ServerManagementControllerTest extends ApplicationApiIntegrationTestCase
         $this->postJson('/api/application/servers/' . $server->id . '/reinstall')
             ->assertStatus(Response::HTTP_NO_CONTENT);
 
-        $server = $server->refresh();
-        $this->assertSame(Server::STATUS_INSTALLING, $server->status);
-        $this->assertTrue($server->skip_scripts);
+        $this->assertSame(Server::STATUS_INSTALLING, $server->refresh()->status);
+    }
+
+    /**
+     * Test that a server configured to skip its egg's install script cannot be reinstalled.
+     */
+    public function testServerConfiguredToSkipScriptsCannotBeReinstalled()
+    {
+        $server = $this->createServerModel(['skip_scripts' => true]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')->never();
+
+        $this->postJson('/api/application/servers/' . $server->id . '/reinstall')
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJsonPath('errors.0.detail', trans('admin/server.exceptions.skipping_install_script'));
+    }
+
+    /**
+     * Test that a client which does not explicitly ask for JSON still receives the error status
+     * rather than being redirected away from the API.
+     */
+    public function testBlockedReinstallReturnsAnErrorToClientsNotRequestingJson()
+    {
+        $server = $this->createServerModel(['skip_scripts' => true]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')->never();
+
+        $this->post('/api/application/servers/' . $server->id . '/reinstall', [], ['Accept' => '*/*'])
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJsonPath('errors.0.detail', trans('admin/server.exceptions.skipping_install_script'));
+    }
+
+    /**
+     * Test that a server configured to skip its egg's install script can still be reinstalled
+     * while it is in a failed state, since that is the only way to pull it back out of one.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('recoverableStatusesDataProvider')]
+    public function testServerConfiguredToSkipScriptsCanBeReinstalledFromAFailedState(string $status)
+    {
+        $server = $this->createServerModel(['skip_scripts' => true, 'status' => $status]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')
+            ->with(\Mockery::on(fn ($value) => $value->uuid === $server->uuid))
+            ->andReturnSelf()
+            ->getMock()
+            ->expects('reinstall')
+            ->andReturnUndefined();
+
+        $this->postJson('/api/application/servers/' . $server->id . '/reinstall')
+            ->assertStatus(Response::HTTP_NO_CONTENT);
+
+        $this->assertSame(Server::STATUS_INSTALLING, $server->refresh()->status);
+    }
+
+    public static function recoverableStatusesDataProvider(): array
+    {
+        return [
+            [Server::STATUS_INSTALLING],
+            [Server::STATUS_INSTALL_FAILED],
+            [Server::STATUS_REINSTALL_FAILED],
+        ];
     }
 }

--- a/tests/Integration/Api/Application/Servers/ServerManagementControllerTest.php
+++ b/tests/Integration/Api/Application/Servers/ServerManagementControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Pterodactyl\Tests\Integration\Api\Application\Servers;
+
+use Illuminate\Http\Response;
+use Pterodactyl\Models\Server;
+use Pterodactyl\Repositories\Wings\DaemonServerRepository;
+use Pterodactyl\Tests\Integration\Api\Application\ApplicationApiIntegrationTestCase;
+
+class ServerManagementControllerTest extends ApplicationApiIntegrationTestCase
+{
+    /**
+     * Test that a server can still be reinstalled via the admin
+     * even if it is configured to skip its egg's install script.
+     */
+    public function testServerConfiguredToSkipScriptsCanStillBeReinstalled()
+    {
+        $server = $this->createServerModel(['skip_scripts' => true]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')
+            ->with(\Mockery::on(fn ($value) => $value->uuid === $server->uuid))
+            ->andReturnSelf()
+            ->getMock()
+            ->expects('reinstall')
+            ->andReturnUndefined();
+
+        $this->postJson('/api/application/servers/' . $server->id . '/reinstall')
+            ->assertStatus(Response::HTTP_NO_CONTENT);
+
+        $server = $server->refresh();
+        $this->assertSame(Server::STATUS_INSTALLING, $server->status);
+        $this->assertTrue($server->skip_scripts);
+    }
+}

--- a/tests/Integration/Api/Client/Server/SettingsControllerTest.php
+++ b/tests/Integration/Api/Client/Server/SettingsControllerTest.php
@@ -110,6 +110,51 @@ class SettingsControllerTest extends ClientApiIntegrationTestCase
         $this->assertTrue($server->isInstalled());
     }
 
+    /**
+     * Test that a server configured to skip its egg's install script cannot be reinstalled.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('reinstallPermissionsDataProvider')]
+    public function testServerCannotBeReinstalledIfConfiguredToSkipScripts(array $permissions)
+    {
+        [$user, $server] = $this->generateTestAccount($permissions);
+        $server->update(['skip_scripts' => true]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')->never();
+
+        $this->actingAs($user)
+            ->postJson("/api/client/servers/$server->uuid/settings/reinstall")
+            ->assertStatus(Response::HTTP_BAD_REQUEST)
+            ->assertJsonPath(
+                'errors.0.detail',
+                'This server is configured to skip its egg\'s install script; reinstalling it would stop the server without running that script.'
+            );
+
+        $this->assertNull($server->refresh()->status);
+    }
+
+    /**
+     * Test that the "skip scripts" state is exposed to the client API.
+     */
+    public function testSkipScriptsStateIsExposedToClient()
+    {
+        [$user, $server] = $this->generateTestAccount([Permission::ACTION_SETTINGS_REINSTALL]);
+
+        $this->actingAs($user)
+            ->getJson("/api/client/servers/$server->uuid")
+            ->assertOk()
+            ->assertJsonPath('attributes.skip_scripts', false);
+
+        $server->update(['skip_scripts' => true]);
+
+        $this->actingAs($user)
+            ->getJson("/api/client/servers/$server->uuid")
+            ->assertOk()
+            ->assertJsonPath('attributes.skip_scripts', true);
+    }
+
     public static function renamePermissionsDataProvider(): array
     {
         return [[[]], [[Permission::ACTION_SETTINGS_RENAME]]];

--- a/tests/Integration/Api/Client/Server/SettingsControllerTest.php
+++ b/tests/Integration/Api/Client/Server/SettingsControllerTest.php
@@ -127,10 +127,7 @@ class SettingsControllerTest extends ClientApiIntegrationTestCase
         $this->actingAs($user)
             ->postJson("/api/client/servers/$server->uuid/settings/reinstall")
             ->assertStatus(Response::HTTP_BAD_REQUEST)
-            ->assertJsonPath(
-                'errors.0.detail',
-                'This server is configured to skip its egg\'s install script; reinstalling it would stop the server without running that script.'
-            );
+            ->assertJsonPath('errors.0.detail', trans('admin/server.exceptions.skipping_install_script'));
 
         $this->assertNull($server->refresh()->status);
     }

--- a/tests/Integration/Http/Controllers/Admin/ServersController/ReinstallServerTest.php
+++ b/tests/Integration/Http/Controllers/Admin/ServersController/ReinstallServerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Pterodactyl\Tests\Integration\Http\Controllers\Admin\ServersController;
+
+use Pterodactyl\Models\User;
+use Pterodactyl\Models\Server;
+use Pterodactyl\Tests\Integration\Http\HttpTestCase;
+use Pterodactyl\Repositories\Wings\DaemonServerRepository;
+
+class ReinstallServerTest extends HttpTestCase
+{
+    /**
+     * Test that a server can be reinstalled from the admin area.
+     */
+    public function testServerCanBeReinstalled(): void
+    {
+        $server = $this->createServerModel();
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')
+            ->with(\Mockery::on(fn ($value) => $value->uuid === $server->uuid))
+            ->andReturnSelf()
+            ->getMock()
+            ->expects('reinstall')
+            ->andReturnUndefined();
+
+        $this->actingAs(User::factory()->admin()->create())
+            ->withHeaders(['Accept' => 'text/html'])
+            ->post(route('admin.servers.view.manage.reinstall', ['server' => $server]))
+            ->assertRedirect();
+
+        $this->assertSame(Server::STATUS_INSTALLING, $server->refresh()->status);
+    }
+
+    /**
+     * Test that a server configured to skip its egg's install script cannot be reinstalled from
+     * the admin area.
+     */
+    public function testServerConfiguredToSkipScriptsCannotBeReinstalled(): void
+    {
+        $server = $this->createServerModel(['skip_scripts' => true]);
+
+        $service = \Mockery::mock(DaemonServerRepository::class);
+        $this->app->instance(DaemonServerRepository::class, $service);
+
+        $service->expects('setServer')->never();
+
+        $this->actingAs(User::factory()->admin()->create())
+            ->withHeaders(['Accept' => 'text/html'])
+            ->post(route('admin.servers.view.manage.reinstall', ['server' => $server]))
+            ->assertRedirect();
+
+        $this->assertNull($server->refresh()->status);
+    }
+}


### PR DESCRIPTION
### Description

You're able to enable a "skip egg install scripts" per server, while still being able to reinstall a server. With this setting enabled, reinstalling a server has no functional use, the server is locked and shutdown, then simply unlocked immediately afterwards after a success signal from wings. This PR disables the reinstall button when skip install scripts is enabled for both the user and admin, with a little component telling you why you cannot reinstall. The reinstall button is not disabled if the server is in a status that reinstall could resolve (eg. failed install).

### Resolved issues:
1. [x] resolves pterodactyl/panel#5306