### PR TITLE
Generate HASHIDS_SALT for existing installs

### DIFF
--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -26,18 +26,18 @@ else
     echo -e "APP_KEY=$APP_KEY" > /app/var/.env
   fi
 
-  ## generate a random salt for hashids if not provided
-  if [ -z $HASHIDS_SALT ]; then
-     echo -e "Generating hashids salt."
-     HASHIDS_SALT=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9!@#$%^&*()_+?><~' | fold -w 20 | head -n 1)
-     echo -e "Generated hashids salt: $HASHIDS_SALT"
-     echo -e "HASHIDS_SALT=$HASHIDS_SALT" >> /app/var/.env
-  else
-    echo -e "HASHIDS_SALT exists in environment, using that."
-    echo -e "HASHIDS_SALT=$HASHIDS_SALT" >> /app/var/.env
-  fi
-
   ln -s /app/var/.env /app/
+fi
+
+## generate a random salt for hashids if not provided
+if [ -z $HASHIDS_SALT ]; then
+    echo -e "Generating hashids salt."
+    HASHIDS_SALT=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9!@#$%^&*()_+?><~' | fold -w 20 | head -n 1)
+    echo -e "Generated hashids salt: $HASHIDS_SALT"
+    echo -e "HASHIDS_SALT=$HASHIDS_SALT" >> /app/var/.env
+else
+  echo -e "HASHIDS_SALT exists in environment, using that."
+  echo -e "HASHIDS_SALT=$HASHIDS_SALT" >> /app/var/.env
 fi
 
 echo "Checking if https is required."

--- a/.github/docker/entrypoint.sh
+++ b/.github/docker/entrypoint.sh
@@ -30,7 +30,9 @@ else
 fi
 
 ## generate a random salt for hashids if not provided
-if [ -z $HASHIDS_SALT ]; then
+if grep -q '^HASHIDS_SALT=' /app/var/.env; then
+    echo "HASHIDS_SALT already exists in /app/var/.env, keeping it."
+elif [ -z $HASHIDS_SALT ]; then
     echo -e "Generating hashids salt."
     HASHIDS_SALT=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9!@#$%^&*()_+?><~' | fold -w 20 | head -n 1)
     echo -e "Generated hashids salt: $HASHIDS_SALT"


### PR DESCRIPTION
Simply moves the code for HASHIDS_SALT outside of the else block guarded by clause checking for existence of .env - this breaks generation of HASHIDS_SALT for existing installs lacking the env variable causing error 500 on the user dashboard in "Database" tab.

Additionally checks for existence of HASHIDS_SALT in /app/var/.env in order to not inflate the file size by redefining the variable on every restart.

fixes #5700