### PR TITLE
Increase max characters allowed for Minecraft version

### DIFF
--- a/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.json
+++ b/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.json
@@ -54,7 +54,7 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|between:3,15",
+            "rules": "required|string|between:3,20",
             "field_type": "text"
         }
     ]


### PR DESCRIPTION
Changes the input rules for the `VANILLA_VERSION` variable to allow for 20 characters instead of 15. I was able to find a few 20 character snapshots via https://piston-meta.mojang.com/mc/game/version_manifest.json. Whitespaces within the variable do not properly download the JAR file, however that may be covered in a past or future bug report/PR.

- `1.14.1 Pre-Release 1` (valid but will not properly download)
- `1.14.1 Pre-Release 2` (valid but won't download)
- `1.14.2 Pre-Release 1` (valid but won't download)
- `1.14.2 Pre-Release 2` (valid but won't download)
- `1.14.2 Pre-Release 3` (valid but won't download)
- `1.14.2 Pre-Release 4` (valid but won't download)
- `22w13oneblockatatime`
- `26.3-snapshot-10` (this one is 16 characters but will not allow installation of the server)

This change would close #5715 