### PR TITLE
Fix tooltip title to display version correctly

### DIFF
--- a/resources/views/admin/nodes/index.blade.php
+++ b/resources/views/admin/nodes/index.blade.php
@@ -87,7 +87,7 @@
                 timeout: 5000
             }).done(function (data) {
                 $(element).find('i').tooltip({
-                    title: 'v' + data.version,
+                    title: data.version,
                 });
                 $(element).removeClass('text-muted').find('i').removeClass().addClass('fa fa-fw fa-heartbeat faa-pulse animated').css('color', '#50af51');
             }).fail(function (error) {


### PR DESCRIPTION
On the admin nodes list page, hovering over a node's status/heart icon shows a tooltip with the Wings daemon version. The version is currently displayed with a duplicated `v` prefix, e.g. `vv1.13.3` instead of `v1.13.3`.