### PR TITLE
fix(websocket): use APP_URL for socket URL instead of node FQDN

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/WebsocketController.php
+++ b/app/Http/Controllers/Api/Client/Servers/WebsocketController.php
@@ -63,7 +63,10 @@ class WebsocketController extends ClientApiController
             ->setScopes(JwtScope::Websocket)
             ->handle($node, $user->id . $server->uuid);
 
-        $socket = str_replace(['https://', 'http://'], ['wss://', 'ws://'], $node->getConnectionAddress());
+        // Use APP_URL so the WebSocket connection uses the public URL the
+        // browser can reach, not the internal Docker DNS name returned by
+        // $node->getConnectionAddress() (e.g. http://pterodactyl_wings:8080).
+        $socket = str_replace(['https://', 'http://'], ['wss://', 'ws://'], rtrim(config('app.url'), '/'));
 
         return new JsonResponse([
             'data' => [


### PR DESCRIPTION
## Summary
Fixes #5403.

`WebsocketController::index` returns the node's `getConnectionAddress()` as the WebSocket URL the browser should connect to. In containerized setups (Docker, Kubernetes, Podman) this resolves to an internal service hostname like `http://pterodactyl_wings:8080`. The browser cannot resolve that hostname, so the console WebSocket fails to connect and the live console sits in the loading donut forever.

## Fix
Use `config('app.url')` instead. The panel already requires `APP_URL` to be set to the public URL the browser uses, so it's the correct value here.

```diff
-        $socket = str_replace(['https://', 'http://'], ['wss://', 'ws://'], $node->getConnectionAddress());
+        $socket = str_replace(['https://', 'http://'], ['wss://', 'ws://'], rtrim(config('app.url'), '/'));
```

`DaemonRepository` (Panel→Wings internal calls) is untouched — those still use the internal address, which is correct because they run inside the same Docker network.

## Test plan
- [ ] Run panel behind a reverse proxy (Cloudflare Tunnel, nginx, Traefik) with `APP_URL=https://panel.example.com`
- [ ] Open a server console in the browser
- [ ] Verify the WebSocket URL in the browser dev tools is `wss://panel.example.com/api/servers/{uuid}/ws` (not `ws://pterodactyl_wings:8080/...`)
- [ ] Verify the WebSocket handshake completes (101 Switching Protocols) and live console output streams

## Related
- Issue: #5403
- This is the second of two issues that combine to make the console work behind a reverse proxy. The first is the missing WebSocket proxy location in `panel.conf` (nginx config shipped in the image), which the user is expected to configure themselves per the Pterodactyl reverse proxy docs.